### PR TITLE
Improved key state tracking

### DIFF
--- a/right/src/default_layout.c
+++ b/right/src/default_layout.c
@@ -31,7 +31,7 @@ KEYBOARD_LAYOUT(defaultKeyboardLayout)={
 		{{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_SHIFT } }},
 		{Key_NoKey}, //??
 		{{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_SPACE } }},
-		{Key_NoKey}, //??
+		{{.type = UHK_KEY_LAYER, .layer = { .target = LAYER_MOD }}}, // Mod
 		{{.type = UHK_KEY_LAYER, .layer = { .target = LAYER_FN }}}, //Fn
 		{{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_ALT } }},
 		{{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_GUI } }},
@@ -70,7 +70,7 @@ KEYBOARD_LAYOUT(defaultKeyboardLayout)={
 		{{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_GUI } }},
 		{{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_ALT } }},
 		{{.type = UHK_KEY_LAYER, .layer = { .target = LAYER_FN }}}, //Fn
-		{Key_NoKey}, //??
+		{{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_SPACE } }}, // Space-under-mod
 		{{.type = UHK_KEY_LAYER, .layer = { .target = LAYER_MOD }}}, //Mod
 		{Key_NoKey} //??
 };

--- a/right/src/keyboard_layout.c
+++ b/right/src/keyboard_layout.c
@@ -5,6 +5,9 @@ static uint8_t keyMasks[LAYOUT_KEY_COUNT];
 
 static uint8_t modifierState = 0;
 
+static uint8_t prevLeftKeyStates[KEY_STATE_COUNT];
+static uint8_t prevRightKeyStates[KEY_STATE_COUNT];
+
 static inline __attribute__((always_inline)) uhk_key_t getKeycode(KEYBOARD_LAYOUT(layout), uint8_t keyId)
 {
 	if (keyId<LAYOUT_KEY_COUNT) {
@@ -39,9 +42,6 @@ static void clearKeymasks(const uint8_t *leftKeyStates, const uint8_t *rightKeyS
 	}
 }
 
-static uint8_t LEDVal = 0;
-static int8_t LEDstep = 10;
-
 bool pressKey(uhk_key_t key, int scancodeIdx, usb_keyboard_report_t *report) {
   if (key.type != UHK_KEY_SIMPLE)
     return false;
@@ -69,16 +69,29 @@ bool layerOff(uhk_key_t key) {
   return false;
 }
 
-bool handleKey(uhk_key_t key, int scancodeIdx, usb_keyboard_report_t *report, uint8_t keyState) {
+bool key_toggled_on (const uint8_t *prevKeyStates, const uint8_t *currKeyStates, uint8_t keyId) {
+  return (!prevKeyStates[keyId]) && currKeyStates[keyId];
+}
+
+bool key_is_pressed (const uint8_t *prevKeyStates, const uint8_t *currKeyStates, uint8_t keyId) {
+  return currKeyStates[keyId];
+}
+
+bool key_toggled_off (const uint8_t *prevKeyStates, const uint8_t *currKeyStates, uint8_t keyId) {
+  return (!currKeyStates[keyId]) && prevKeyStates[keyId];
+}
+
+bool handleKey(uhk_key_t key, int scancodeIdx, usb_keyboard_report_t *report, const uint8_t *prevKeyStates, const uint8_t *currKeyStates, uint8_t keyId) {
   switch (key.type) {
   case UHK_KEY_SIMPLE:
-    if (keyState)
+    if (key_is_pressed (prevKeyStates, currKeyStates, keyId))
       return pressKey (key, scancodeIdx, report);
     break;
   case UHK_KEY_LAYER:
-    if (keyState)
+    if (key_toggled_on (prevKeyStates, currKeyStates, keyId))
       return layerOn (key);
-    return layerOff (key);
+    if (key_toggled_off (prevKeyStates, currKeyStates, keyId))
+      return layerOff (key);
     break;
   default:
     break;
@@ -98,7 +111,7 @@ void fillKeyboardReport(usb_keyboard_report_t *report, const uint8_t *leftKeySta
 
     uhk_key_t code=getKeycode(layout, keyId);
 
-    if (handleKey(code, scancodeIdx, report, rightKeyStates[keyId])) {
+    if (handleKey(code, scancodeIdx, report, prevRightKeyStates, rightKeyStates, keyId)) {
       scancodeIdx++;
     }
 	}
@@ -110,8 +123,11 @@ void fillKeyboardReport(usb_keyboard_report_t *report, const uint8_t *leftKeySta
 
     uhk_key_t code=getKeycode(layout, LAYOUT_LEFT_OFFSET+keyId);
 
-    if (handleKey(code, scancodeIdx, report, leftKeyStates[keyId])) {
+    if (handleKey(code, scancodeIdx, report, prevLeftKeyStates, leftKeyStates, keyId)) {
       scancodeIdx++;
     }
 	}
+
+  memcpy (prevLeftKeyStates, leftKeyStates, KEY_STATE_COUNT);
+  memcpy (prevRightKeyStates, rightKeyStates, KEY_STATE_COUNT);
 }


### PR DESCRIPTION
This adds the `prevLeftKeyStates` and `prevRightKeyStates` arrays, which are used to store the previous state of the matrix. These are then used to determine when a key is released, as opposed to when it is just not pressed. Without these, if we had two or more layer keys, only the last one would work, because the rest would keep getting handled as releases (since we can't make a difference between release and noop, unless we know the previous state).

We could just track layer keys, but there could be any number of them, so it is easier to just save the full matrix state. It's a memcpy of 70 bytes, fairly light.

(As an added bonus, the first commit adds the Mod & Space keys below the bottom row, as they appear on the default layout.)