### PR TITLE
Big Keymap Restructure

### DIFF
--- a/right/src/default_layout.c
+++ b/right/src/default_layout.c
@@ -1,77 +1,56 @@
 #include "default_layout.h"
 
-KEYBOARD_LAYOUT(defaultKeyboardLayout)={
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_7_AND_AMPERSAND } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F7 } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_8_AND_ASTERISK } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F8 } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_9_AND_OPENING_PARENTHESIS } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F9 } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_0_AND_CLOSING_PARENTHESIS } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F10 } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MINUS_AND_UNDERSCORE } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F11 } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_EQUAL_AND_PLUS } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F12 } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_BACKSPACE } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_DELETE } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_U } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_I } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_UP_ARROW } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_O } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_P } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_PRINT_SCREEN } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_OPENING_BRACKET_AND_OPENING_BRACE } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_SCROLL_LOCK } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_CLOSING_BRACKET_AND_CLOSING_BRACE } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_PAUSE } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_BACKSLASH_AND_PIPE } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_Y } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_PAGE_UP } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_J } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_ARROW } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_K } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_DOWN_ARROW } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_L } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_ARROW } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_SEMICOLON_AND_COLON } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_APOSTROPHE_AND_QUOTE } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_ENTER } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_H } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_PAGE_DOWN } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_N } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_MUTE } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_M } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_COMMA_AND_LESS_THAN_SIGN } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_DOT_AND_GREATER_THAN_SIGN } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_SLASH_AND_QUESTION_MARK } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_SHIFT } }},
-        {Key_NoKey}, //??
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_SPACE } }},
-        {Key_NoKey}, //??
-        {{.type = UHK_KEY_LAYER, .layer = { .target = LAYER_FN }}}, //Fn
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_ALT } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_GUI } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_CONTROL } }},
+#define S(k) {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_ ## k }}
+#define L(l) {.type = UHK_KEY_LAYER, .layer = { .target = LAYER_ID_ ## l }}
+#define TRNS {.type = UHK_KEY_TRANSPARENT}
 
-        //Left half
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_GRAVE_ACCENT_AND_TILDE } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_ESCAPE } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_1_AND_EXCLAMATION } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F1 } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_2_AND_AT } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F2 } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_3_AND_HASHMARK } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F3 } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_4_AND_DOLLAR } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F4 } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_5_AND_PERCENTAGE } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F5 } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_6_AND_CARET } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F6 } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_TAB } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_Q } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_W } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_UP_ARROW } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_E } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_R } }},
-        {Key_NoKey}, //??
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_T } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_HOME } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_CAPS_LOCK } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_A } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_ARROW } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_S } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_DOWN_ARROW } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_D } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_ARROW } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_DELETE } }},
-        {Key_NoKey}, //??
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_G } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_END } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_SHIFT } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_NON_US_BACKSLASH_AND_PIPE } }}, //no idea if this is the right one},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_Z } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_BACKWARD } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_X } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_PLAY } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_C } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_FORWARD } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_V } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_VOLUME_DOWN } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_B } }, {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_VOLUME_UP } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_CONTROL } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_GUI } }},
-        {{.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_ALT } }},
-        {{.type = UHK_KEY_LAYER, .layer = { .target = LAYER_FN }}}, //Fn
-        {Key_NoKey}, //??
-        {{.type = UHK_KEY_LAYER, .layer = { .target = LAYER_MOD }}}, //Mod
-        {Key_NoKey} //??
+#define Key_NoKey { .raw = 0 }
+
+KEYBOARD_LAYOUT(defaultKeyboardLayout)= {
+    // Layer 0
+    {
+        // Right
+        {
+            S(7_AND_AMPERSAND), S(8_AND_ASTERISK), S(9_AND_OPENING_PARENTHESIS), S(0_AND_CLOSING_PARENTHESIS), S(MINUS_AND_UNDERSCORE), S(EQUAL_AND_PLUS), S(BACKSPACE),
+            S(U), S(I), S(O), S(P), S(OPENING_BRACKET_AND_OPENING_BRACE), S(CLOSING_BRACKET_AND_CLOSING_BRACE), S(BACKSLASH_AND_PIPE), S(Y),
+            S(J), S(K), S(L), S(SEMICOLON_AND_COLON), S(APOSTROPHE_AND_QUOTE), S(ENTER), S(H),
+            S(N), S(M), S(COMMA_AND_LESS_THAN_SIGN), S(DOT_AND_GREATER_THAN_SIGN), S(SLASH_AND_QUESTION_MARK), S(RIGHT_SHIFT), Key_NoKey,
+            S(SPACE), L(MOD), L(FN), S(RIGHT_ALT), S(RIGHT_GUI), S(RIGHT_CONTROL),
+        },
+
+        // Left
+        {
+            S(GRAVE_ACCENT_AND_TILDE), S(1_AND_EXCLAMATION), S(2_AND_AT), S(3_AND_HASHMARK), S(4_AND_DOLLAR), S(5_AND_PERCENTAGE), S(6_AND_CARET),
+            S(TAB), S(Q), S(W), S(E), S(R), Key_NoKey, S(T),
+            S(CAPS_LOCK), S(A), S(S), S(D), S(F), Key_NoKey, S(G),
+            S(LEFT_SHIFT), S(NON_US_BACKSLASH_AND_PIPE), S(Z), S(X), S(C), S(V), S(B),
+            S(LEFT_CONTROL), S(LEFT_GUI), S(LEFT_ALT), L(FN), S(SPACE), L(MOD), Key_NoKey,
+        }
+    },
+
+    // Layer 1: MOD
+    {
+        // Right
+        {
+            S(F7), S(F8), S(F9), S(F10), S(F11), S(F12), S(DELETE),
+            Key_NoKey, S(UP_ARROW), Key_NoKey, S(PRINT_SCREEN), S(SCROLL_LOCK), S(PAUSE), Key_NoKey, S(PAGE_UP),
+            S(LEFT_ARROW), S(DOWN_ARROW), S(RIGHT_ARROW), Key_NoKey, Key_NoKey, Key_NoKey, S(PAGE_DOWN),
+            S(MEDIA_MUTE), Key_NoKey, Key_NoKey, Key_NoKey, Key_NoKey, Key_NoKey, Key_NoKey,
+            Key_NoKey, TRNS, Key_NoKey, Key_NoKey, Key_NoKey,
+        },
+
+        // Left
+        {
+            S(ESCAPE), S(F1), S(F2), S(F3), S(F4), S(F5), S(F6),
+            Key_NoKey, Key_NoKey, S(UP_ARROW), Key_NoKey, Key_NoKey, Key_NoKey, S(HOME),
+            Key_NoKey, S(LEFT_ARROW), S(DOWN_ARROW), S(RIGHT_ARROW), S(DELETE), Key_NoKey, S(END),
+            Key_NoKey, Key_NoKey, S(MEDIA_BACKWARD), S(MEDIA_PLAY), S(MEDIA_FORWARD), S(MEDIA_VOLUME_DOWN), S(MEDIA_VOLUME_UP),
+            Key_NoKey, Key_NoKey, Key_NoKey, Key_NoKey, Key_NoKey, TRNS, Key_NoKey,
+        }
+    },
+
+    // Layer 2: FN
+    // Layer 3: Mouse
+
 };
 

--- a/right/src/default_layout.c
+++ b/right/src/default_layout.c
@@ -1,30 +1,102 @@
-#include "default_layout.h"
+#include "keyboard_layout.h"
 
-#define S(k) {.type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_ ## k }}
-#define L(l) {.type = UHK_KEY_LAYER, .layer = { .target = LAYER_ID_ ## l }}
-#define TRNS {.type = UHK_KEY_TRANSPARENT}
-
-#define Key_NoKey { .raw = 0 }
-
-KEYBOARD_LAYOUT(defaultKeyboardLayout)= {
+uhk_key_t CurrentKeymap[LAYER_COUNT][SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE] = {
     // Layer 0
     {
         // Right
         {
-            S(7_AND_AMPERSAND), S(8_AND_ASTERISK), S(9_AND_OPENING_PARENTHESIS), S(0_AND_CLOSING_PARENTHESIS), S(MINUS_AND_UNDERSCORE), S(EQUAL_AND_PLUS), S(BACKSPACE),
-            S(U), S(I), S(O), S(P), S(OPENING_BRACKET_AND_OPENING_BRACE), S(CLOSING_BRACKET_AND_CLOSING_BRACE), S(BACKSLASH_AND_PIPE), S(Y),
-            S(J), S(K), S(L), S(SEMICOLON_AND_COLON), S(APOSTROPHE_AND_QUOTE), S(ENTER), S(H),
-            S(N), S(M), S(COMMA_AND_LESS_THAN_SIGN), S(DOT_AND_GREATER_THAN_SIGN), S(SLASH_AND_QUESTION_MARK), S(RIGHT_SHIFT), Key_NoKey,
-            S(SPACE), L(MOD), L(FN), S(RIGHT_ALT), S(RIGHT_GUI), S(RIGHT_CONTROL),
+            // Row 1
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_7_AND_AMPERSAND }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_8_AND_ASTERISK }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_9_AND_OPENING_PARENTHESIS }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_0_AND_CLOSING_PARENTHESIS }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MINUS_AND_UNDERSCORE }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_EQUAL_AND_PLUS }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_BACKSPACE }},
+
+            // Row 2
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_U }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_I }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_O }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_P }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_OPENING_BRACKET_AND_OPENING_BRACE }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_CLOSING_BRACKET_AND_CLOSING_BRACE }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_BACKSLASH_AND_PIPE }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_Y }},
+
+            // Row 3
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_J }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_K }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_L }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_SEMICOLON_AND_COLON }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_APOSTROPHE_AND_QUOTE }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_ENTER }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_H }},
+
+            // Row 4
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_N }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_M }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_COMMA_AND_LESS_THAN_SIGN }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_DOT_AND_GREATER_THAN_SIGN }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_SLASH_AND_QUESTION_MARK }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_SHIFT }},
+            { .type = UHK_KEY_NONE },
+
+            // Row 5
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_SPACE }},
+            { .type = UHK_KEY_LAYER, .layer = { .target = LAYER_ID_MOD }},
+            { .type = UHK_KEY_LAYER, .layer = { .target = LAYER_ID_FN }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_ALT }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_GUI }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_CONTROL }},
         },
 
         // Left
         {
-            S(GRAVE_ACCENT_AND_TILDE), S(1_AND_EXCLAMATION), S(2_AND_AT), S(3_AND_HASHMARK), S(4_AND_DOLLAR), S(5_AND_PERCENTAGE), S(6_AND_CARET),
-            S(TAB), S(Q), S(W), S(E), S(R), Key_NoKey, S(T),
-            S(CAPS_LOCK), S(A), S(S), S(D), S(F), Key_NoKey, S(G),
-            S(LEFT_SHIFT), S(NON_US_BACKSLASH_AND_PIPE), S(Z), S(X), S(C), S(V), S(B),
-            S(LEFT_CONTROL), S(LEFT_GUI), S(LEFT_ALT), L(FN), S(SPACE), L(MOD), Key_NoKey,
+            // Row 1
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_GRAVE_ACCENT_AND_TILDE }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_1_AND_EXCLAMATION }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_2_AND_AT }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_3_AND_HASHMARK }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_4_AND_DOLLAR }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_5_AND_PERCENTAGE }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_6_AND_CARET }},
+
+            // Row 2
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_TAB }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_Q }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_W }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_E }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_R }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_T }},
+
+            // Row 3
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_CAPS_LOCK }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_A }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_S }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_D }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_G }},
+
+            // Row 4
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_SHIFT }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_NON_US_BACKSLASH_AND_PIPE }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_Z }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_X }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_C }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_V }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_B }},
+
+            // Row 5
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_CONTROL }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_GUI }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_ALT }},
+            { .type = UHK_KEY_LAYER, .layer = { .target = LAYER_ID_FN }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_SPACE }},
+            { .type = UHK_KEY_LAYER, .layer = { .target = LAYER_ID_MOD }},
+            { .type = UHK_KEY_NONE },
         }
     },
 
@@ -32,20 +104,97 @@ KEYBOARD_LAYOUT(defaultKeyboardLayout)= {
     {
         // Right
         {
-            S(F7), S(F8), S(F9), S(F10), S(F11), S(F12), S(DELETE),
-            Key_NoKey, S(UP_ARROW), Key_NoKey, S(PRINT_SCREEN), S(SCROLL_LOCK), S(PAUSE), Key_NoKey, S(PAGE_UP),
-            S(LEFT_ARROW), S(DOWN_ARROW), S(RIGHT_ARROW), Key_NoKey, Key_NoKey, Key_NoKey, S(PAGE_DOWN),
-            S(MEDIA_MUTE), Key_NoKey, Key_NoKey, Key_NoKey, Key_NoKey, Key_NoKey, Key_NoKey,
-            Key_NoKey, TRNS, Key_NoKey, Key_NoKey, Key_NoKey,
+            // Row 1
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F7 }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F8 }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F9 }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F10 }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F11 }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F12 }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_DELETE }},
+
+            // Row 2
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_UP_ARROW }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_PRINT_SCREEN }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_SCROLL_LOCK }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_PAUSE }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_PAGE_UP }},
+
+            // Row 3
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_ARROW }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_DOWN_ARROW }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_ARROW }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_PAGE_DOWN }},
+
+            // Row 4
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_MUTE }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+
+            // Row 5
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_LAYER, .layer = { .target = LAYER_ID_MOD }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
         },
 
         // Left
         {
-            S(ESCAPE), S(F1), S(F2), S(F3), S(F4), S(F5), S(F6),
-            Key_NoKey, Key_NoKey, S(UP_ARROW), Key_NoKey, Key_NoKey, Key_NoKey, S(HOME),
-            Key_NoKey, S(LEFT_ARROW), S(DOWN_ARROW), S(RIGHT_ARROW), S(DELETE), Key_NoKey, S(END),
-            Key_NoKey, Key_NoKey, S(MEDIA_BACKWARD), S(MEDIA_PLAY), S(MEDIA_FORWARD), S(MEDIA_VOLUME_DOWN), S(MEDIA_VOLUME_UP),
-            Key_NoKey, Key_NoKey, Key_NoKey, Key_NoKey, Key_NoKey, TRNS, Key_NoKey,
+            // Row 1
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_ESCAPE }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F1 }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F2 }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F3 }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F4 }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F5 }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_F6 }},
+
+            // Row 2
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_UP_ARROW }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_HOME }},
+
+            // Row 3
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_ARROW }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_DOWN_ARROW }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_ARROW }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_DELETE }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_END }},
+
+            // Row 4
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_BACKWARD }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_PLAY }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_FORWARD }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_VOLUME_DOWN }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_VOLUME_UP }},
+
+            // Row 5
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_LAYER, .layer = { .target = LAYER_ID_MOD }},
+            { .type = UHK_KEY_NONE },
         }
     },
 

--- a/right/src/default_layout.h
+++ b/right/src/default_layout.h
@@ -1,9 +1,0 @@
-#ifndef SRC_DEFAULT_LAYOUT_H_
-#define SRC_DEFAULT_LAYOUT_H_
-
-#include <stdint.h>
-#include "keyboard_layout.h"
-
-extern KEYBOARD_LAYOUT(defaultKeyboardLayout);
-
-#endif

--- a/right/src/keyboard_layout.c
+++ b/right/src/keyboard_layout.c
@@ -65,31 +65,31 @@ bool layerOff(uhk_key_t key) {
     return false;
 }
 
-bool key_toggled_on (const uint8_t *prevKeyStates, const uint8_t *currKeyStates, uint8_t keyId) {
+bool key_toggled_on(const uint8_t *prevKeyStates, const uint8_t *currKeyStates, uint8_t keyId) {
     return (!prevKeyStates[keyId]) && currKeyStates[keyId];
 }
 
-bool key_is_pressed (const uint8_t *prevKeyStates, const uint8_t *currKeyStates, uint8_t keyId) {
+bool key_is_pressed(const uint8_t *prevKeyStates, const uint8_t *currKeyStates, uint8_t keyId) {
     return currKeyStates[keyId];
 }
 
-bool key_toggled_off (const uint8_t *prevKeyStates, const uint8_t *currKeyStates, uint8_t keyId) {
+bool key_toggled_off(const uint8_t *prevKeyStates, const uint8_t *currKeyStates, uint8_t keyId) {
     return (!currKeyStates[keyId]) && prevKeyStates[keyId];
 }
 
 bool handleKey(uhk_key_t key, int scancodeIdx, usb_keyboard_report_t *report, const uint8_t *prevKeyStates, const uint8_t *currKeyStates, uint8_t keyId) {
     switch (key.type) {
     case UHK_KEY_SIMPLE:
-        if (key_is_pressed (prevKeyStates, currKeyStates, keyId)) {
-            return pressKey (key, scancodeIdx, report);
+        if (key_is_pressed(prevKeyStates, currKeyStates, keyId)) {
+            return pressKey(key, scancodeIdx, report);
         }
         break;
     case UHK_KEY_LAYER:
-        if (key_toggled_on (prevKeyStates, currKeyStates, keyId)) {
-            return layerOn (key);
+        if (key_toggled_on(prevKeyStates, currKeyStates, keyId)) {
+            return layerOn(key);
         }
-        if (key_toggled_off (prevKeyStates, currKeyStates, keyId)) {
-            return layerOff (key);
+        if (key_toggled_off(prevKeyStates, currKeyStates, keyId)) {
+            return layerOff(key);
         }
         break;
     default:
@@ -127,6 +127,6 @@ void fillKeyboardReport(usb_keyboard_report_t *report, const uint8_t *leftKeySta
         }
     }
 
-    memcpy (prevKeyStates[SLOT_ID_RIGHT_KEYBOARD_HALF], rightKeyStates, KEY_STATE_COUNT);
-    memcpy (prevKeyStates[SLOT_ID_LEFT_KEYBOARD_HALF], leftKeyStates, KEY_STATE_COUNT);
+    memcpy(prevKeyStates[SLOT_ID_RIGHT_KEYBOARD_HALF], rightKeyStates, KEY_STATE_COUNT);
+    memcpy(prevKeyStates[SLOT_ID_LEFT_KEYBOARD_HALF], leftKeyStates, KEY_STATE_COUNT);
 }

--- a/right/src/keyboard_layout.h
+++ b/right/src/keyboard_layout.h
@@ -21,11 +21,6 @@
 
 #define KEY_STATE_COUNT (5*7)
 
-#define LAYOUT_KEY_COUNT 70
-#define LAYOUT_MOD_COUNT 4
-
-#define LAYOUT_LEFT_OFFSET KEY_STATE_COUNT
-
 typedef enum {
     UHK_KEY_SIMPLE,
     UHK_KEY_MOUSE,

--- a/right/src/keyboard_layout.h
+++ b/right/src/keyboard_layout.h
@@ -5,6 +5,8 @@
 #include "lufa/HIDClassCommon.h"
 #include "usb_composite_device.h"
 
+#include "module.h"
+
 // Keyboard layout is a 2D array of scan codes.
 //
 // First dimension is the Key ID of a given key. Key IDs are the indices of the
@@ -33,6 +35,8 @@ typedef enum {
     UHK_KEY_MACRO,
     UHK_KEY_LPRESSMOD,
     UHK_KEY_LPRESSLAYER,
+
+    UHK_KEY_TRANSPARENT = 0xff,
 } uhk_key_type_t;
 
 typedef union {
@@ -76,11 +80,7 @@ typedef union {
     uint32_t raw;
 } __attribute__ ((packed)) uhk_key_t;
 
-#define Key_NoKey {.raw = 0}
-#define KEYBOARD_LAYOUT(name) const uhk_key_t name[LAYOUT_KEY_COUNT][LAYOUT_MOD_COUNT]
-
-#define LAYER_MOD 1
-#define LAYER_FN 2
+#define KEYBOARD_LAYOUT(name) uhk_key_t name[LAYER_COUNT][SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE]
 
 void fillKeyboardReport(usb_keyboard_report_t *report, const uint8_t *leftKeyStates, const uint8_t *rightKeyStates, KEYBOARD_LAYOUT(layout));
 

--- a/right/src/keyboard_layout.h
+++ b/right/src/keyboard_layout.h
@@ -22,6 +22,7 @@
 #define KEY_STATE_COUNT (5*7)
 
 typedef enum {
+    UHK_KEY_NONE,
     UHK_KEY_SIMPLE,
     UHK_KEY_MOUSE,
     UHK_KEY_LAYER,
@@ -30,53 +31,49 @@ typedef enum {
     UHK_KEY_MACRO,
     UHK_KEY_LPRESSMOD,
     UHK_KEY_LPRESSLAYER,
-
-    UHK_KEY_TRANSPARENT = 0xff,
 } uhk_key_type_t;
 
-typedef union {
-    struct {
+typedef struct {
     uint8_t type;
-        union {
-            struct {
-                uint8_t __unused_bits;
-                uint8_t mods;
-                uint8_t key;
-            } __attribute__ ((packed)) simple;
-            struct {
-                uint8_t __unused_bits;
-                uint8_t scrollActions; // bitfield
-                uint8_t moveActions; // bitfield
-            } __attribute__ ((packed)) mouse;
-            struct {
-                uint16_t __unused_bits;
-                uint8_t target;
-            } __attribute__ ((packed)) layer;
-            struct {
-                uint16_t __unused_bits;
-                uint8_t target;
-            } __attribute__ ((packed)) keymap;
-            struct {
-                uint8_t __unused_bits;
-                uint16_t index;
-            } __attribute__ ((packed)) macro;
-            struct {
-                uint8_t longPressMod; // single mod, or bitfield?
-                uint8_t mods; // for the alternate action
-                uint8_t key;
-            } __attribute__ ((packed)) longpressMod;
-            struct {
-                uint8_t longPressLayer;
-                uint8_t mods;
-                uint8_t key;
-            } __attribute__ ((packed)) longpressLayer;
-        };
-    } __attribute__ ((packed));
-    uint32_t raw;
+    union {
+        struct {
+            uint8_t __unused_bits;
+            uint8_t mods;
+            uint8_t key;
+        } __attribute__ ((packed)) simple;
+        struct {
+            uint8_t __unused_bits;
+            uint8_t scrollActions; // bitfield
+            uint8_t moveActions; // bitfield
+        } __attribute__ ((packed)) mouse;
+        struct {
+            uint16_t __unused_bits;
+            uint8_t target;
+        } __attribute__ ((packed)) layer;
+        struct {
+            uint16_t __unused_bits;
+            uint8_t target;
+        } __attribute__ ((packed)) keymap;
+        struct {
+            uint8_t __unused_bits;
+            uint16_t index;
+        } __attribute__ ((packed)) macro;
+        struct {
+            uint8_t longPressMod; // single mod, or bitfield?
+            uint8_t mods; // for the alternate action
+            uint8_t key;
+        } __attribute__ ((packed)) longpressMod;
+        struct {
+            uint8_t longPressLayer;
+            uint8_t mods;
+            uint8_t key;
+        } __attribute__ ((packed)) longpressLayer;
+    };
 } __attribute__ ((packed)) uhk_key_t;
 
-#define KEYBOARD_LAYOUT(name) uhk_key_t name[LAYER_COUNT][SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE]
+extern uint8_t prevKeyStates[SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE];
+extern uhk_key_t CurrentKeymap[LAYER_COUNT][SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE];
 
-void fillKeyboardReport(usb_keyboard_report_t *report, const uint8_t *leftKeyStates, const uint8_t *rightKeyStates, KEYBOARD_LAYOUT(layout));
+void fillKeyboardReport(usb_keyboard_report_t *report, const uint8_t *leftKeyStates, const uint8_t *rightKeyStates);
 
 #endif

--- a/right/src/usb_interface_keyboard.c
+++ b/right/src/usb_interface_keyboard.c
@@ -6,7 +6,7 @@
 #include "fsl_i2c.h"
 #include "i2c.h"
 #include "i2c_addresses.h"
-#include "default_layout.h"
+#include "keyboard_layout.h"
 
 static usb_device_endpoint_struct_t UsbKeyboardEndpoints[USB_KEYBOARD_ENDPOINT_COUNT] = {{
     USB_KEYBOARD_ENDPOINT_INDEX | (USB_IN << USB_DESCRIPTOR_ENDPOINT_ADDRESS_DIRECTION_SHIFT),
@@ -100,7 +100,7 @@ void UsbKeyboadTask(){
 
     readLeftKeys(leftKeyStates);
 
-    fillKeyboardReport(&UsbKeyboardReport[newLayout], leftKeyStates, keyMatrix.keyStates, defaultKeyboardLayout);
+    fillKeyboardReport(&UsbKeyboardReport[newLayout], leftKeyStates, keyMatrix.keyStates);
 
     // Change to the new layout in atomic operation (int copy). Even if
     // the copy is not atomic itself, only single bit changes. So it can


### PR DESCRIPTION
This changes the keymap layout to be as described in #17, and updates the default layout to follow. (Also adds the missing Space and Mod keys on the two keys below the bottom row)

The layout itself was considerably simplified by introducing a few local macros to hide some of the uglier details.

Also includes #16, rebased and slightly redone, on top of the restructuring.

Quick tests show that at least the `MOD` layer is working, as does the base.