### PR TITLE
Light up LEDs on the display when switching layers

### DIFF
--- a/right/src/keyboard_layout.c
+++ b/right/src/keyboard_layout.c
@@ -1,5 +1,5 @@
 #include "keyboard_layout.h"
-#include "led_driver.h"
+#include "led_display.h"
 #include "layer.h"
 
 static uint8_t keyMasks[SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE];
@@ -82,6 +82,7 @@ bool handleKey(uhk_key_t key, int scancodeIdx, usb_keyboard_report_t *report, co
         if (key_toggled_off(prevKeyStates, currKeyStates, keyId)) {
             ActiveLayer = LAYER_ID_BASE;
         }
+        LedDisplay_SetLayerLed(ActiveLayer, 0xff);
         return false;
         break;
     default:

--- a/right/src/keyboard_layout.c
+++ b/right/src/keyboard_layout.c
@@ -82,7 +82,7 @@ bool handleKey(uhk_key_t key, int scancodeIdx, usb_keyboard_report_t *report, co
         if (key_toggled_off(prevKeyStates, currKeyStates, keyId)) {
             ActiveLayer = LAYER_ID_BASE;
         }
-        LedDisplay_SetLayerLed(ActiveLayer, 0xff);
+        LedDisplay_SetLayerLed(ActiveLayer);
         return false;
         break;
     default:

--- a/right/src/led_display.c
+++ b/right/src/led_display.c
@@ -4,8 +4,10 @@
 #define LAYER_LED_FIRST    FRAME_REGISTER_PWM_FIRST + 13
 #define LAYER_LED_DISTANCE 16
 
-void LedDisplay_SetLayerLed(uint8_t layerId, uint8_t brightness) {
+uint8_t LedDisplayBrightness = 0xff;
+
+void LedDisplay_SetLayerLed(uint8_t layerId) {
     for (uint8_t i = 0; i < LAYER_COUNT; i++) {
-        LedDriver_WriteRegister(I2C_ADDRESS_LED_DRIVER_LEFT, LAYER_LED_FIRST + (i * LAYER_LED_DISTANCE), brightness * (layerId == i + 1));
+        LedDriver_WriteRegister(I2C_ADDRESS_LED_DRIVER_LEFT, LAYER_LED_FIRST + (i * LAYER_LED_DISTANCE), LedDisplayBrightness * (layerId == i + 1));
     }
 }

--- a/right/src/led_display.c
+++ b/right/src/led_display.c
@@ -1,0 +1,11 @@
+#include "led_display.h"
+#include "layer.h"
+
+#define LAYER_LED_FIRST    FRAME_REGISTER_PWM_FIRST + 13
+#define LAYER_LED_DISTANCE 16
+
+void LedDisplay_SetLayerLed(uint8_t layerId, uint8_t brightness) {
+    for (uint8_t i = 0; i < LAYER_COUNT; i++) {
+        LedDriver_WriteRegister(I2C_ADDRESS_LED_DRIVER_LEFT, LAYER_LED_FIRST + (i * LAYER_LED_DISTANCE), brightness * (layerId == i + 1));
+    }
+}

--- a/right/src/led_display.h
+++ b/right/src/led_display.h
@@ -1,0 +1,8 @@
+#ifndef __LED_DISPLAY_H__
+#define __LED_DISPLAY_H__
+
+    #include "led_driver.h"
+
+    void LedDisplay_SetLayerLed(uint8_t layerId, uint8_t brightness);
+
+#endif

--- a/right/src/led_display.h
+++ b/right/src/led_display.h
@@ -3,6 +3,8 @@
 
     #include "led_driver.h"
 
-    void LedDisplay_SetLayerLed(uint8_t layerId, uint8_t brightness);
+    extern uint8_t LedDisplayBrightness;
+
+    void LedDisplay_SetLayerLed(uint8_t layerId);
 
 #endif


### PR DESCRIPTION
When switching layers, light up the appropriate LED on the display. For this purpose, start `led_display.[ch]`, which as a start, has a function to set the brightness of a layer led.

The function will also turn all other LEDs off, and turn all of them off when on the base layer.
