### PR TITLE
Rearrange the layout to follow the factory layout more closely

### DIFF
--- a/right/src/default_layout.c
+++ b/right/src/default_layout.c
@@ -72,7 +72,7 @@ uhk_key_t CurrentKeymap[LAYER_COUNT][SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE] = {
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_T }},
 
             // Row 3
-            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_CAPS_LOCK }},
+            { .type = UHK_KEY_LAYER, .layer = { .target = LAYER_ID_MOUSE }},
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_A }},
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_S }},
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_D }},
@@ -114,39 +114,40 @@ uhk_key_t CurrentKeymap[LAYER_COUNT][SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE] = {
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_DELETE }},
 
             // Row 2
-            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_HOME }},
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_UP_ARROW }},
-            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_END }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_DELETE }},
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_PRINT_SCREEN }},
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_SCROLL_LOCK }},
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_PAUSE }},
-            { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_PAGE_UP }},
 
             // Row 3
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_ARROW }},
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_DOWN_ARROW }},
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_ARROW }},
-            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_INSERT }},
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_PAGE_DOWN }},
 
             // Row 4
-            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_MUTE }},
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_SHIFT }},
             { .type = UHK_KEY_NONE },
 
             // Row 5
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_LAYER, .layer = { .target = LAYER_ID_MOD }},
             { .type = UHK_KEY_NONE },
-            { .type = UHK_KEY_NONE },
-            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_ALT }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_GUI }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_CONTROL }},
         },
 
         // Left
@@ -163,34 +164,34 @@ uhk_key_t CurrentKeymap[LAYER_COUNT][SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE] = {
             // Row 2
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_NONE },
-            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_UP_ARROW }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_PAGE_UP, .mods = HID_KEYBOARD_MODIFIER_LEFTCTRL }}, // [<] tab prev
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_T, .mods = HID_KEYBOARD_MODIFIER_LEFTCTRL }}, // [+] tab new
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_PAGE_DOWN, .mods = HID_KEYBOARD_MODIFIER_LEFTCTRL }}, // [>] tab next
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_NONE },
-            { .type = UHK_KEY_NONE },
-            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_HOME }},
 
             // Row 3
             { .type = UHK_KEY_NONE },
-            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_ARROW }},
-            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_DOWN_ARROW }},
-            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_ARROW }},
-            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_DELETE }},
             { .type = UHK_KEY_NONE },
-            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_END }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_ARROW, .mods = HID_KEYBOARD_MODIFIER_LEFTCTRL | HID_KEYBOARD_MODIFIER_LEFTALT }}, // workspace prev
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_TAB, .mods = HID_KEYBOARD_MODIFIER_LEFTSHIFT }}, // Window switch?
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_ARROW, .mods = HID_KEYBOARD_MODIFIER_LEFTCTRL | HID_KEYBOARD_MODIFIER_LEFTALT }}, // workspace next
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
 
             // Row 4
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_SHIFT }},
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_NONE },
-            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_BACKWARD }},
-            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_PLAY }},
-            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_FORWARD }},
-            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_VOLUME_DOWN }},
-            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_VOLUME_UP }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_W, .mods = HID_KEYBOARD_MODIFIER_LEFTCTRL }}, // [x] tab close
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
 
             // Row 5
-            { .type = UHK_KEY_NONE },
-            { .type = UHK_KEY_NONE },
-            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_CONTROL }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_GUI }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_ALT }},
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_LAYER, .layer = { .target = LAYER_ID_MOD }},
@@ -199,7 +200,201 @@ uhk_key_t CurrentKeymap[LAYER_COUNT][SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE] = {
     },
 
     // Layer 2: FN
+    {
+        // Right
+        {
+            // Row 1
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+
+            // Row 2
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_PLAY }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_VOLUME_UP }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_STOP }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_SLEEP }},
+            { .type = UHK_KEY_NONE },
+
+            // Row 3
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_PREVIOUS_TRACK }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_VOLUME_DOWN }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_NEXT_TRACK }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+
+            // Row 4
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_MUTE }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_SHIFT }},
+            { .type = UHK_KEY_NONE },
+
+            // Row 5
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_LAYER, .layer = { .target = LAYER_ID_FN }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_ALT }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_GUI }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_CONTROL }},
+        },
+
+        // Left
+        {
+            // Row 1
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+
+            // Row 2
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_STOP }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_RELOAD }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+
+            // Row 3
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE }, // TODO: hist-
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_WWW }},
+            { .type = UHK_KEY_NONE }, // TODO: hist+
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+
+            // Row 4
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_SHIFT }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_LOCK }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_SEARCH }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_CALCULATOR }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_MEDIA_EJECT }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+
+            // Row 5
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_CONTROL }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_GUI }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_ALT }},
+            { .type = UHK_KEY_LAYER, .layer = { .target = LAYER_ID_FN }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+        }
+    },
+
     // Layer 3: Mouse
+    {
+        // Right
+        {
+            // Row 1
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+
+            // Row 2
+            { .type = UHK_KEY_NONE }, // TODO: Mouse button 4
+            { .type = UHK_KEY_NONE }, // TODO: Mouse up
+            { .type = UHK_KEY_NONE }, // TODO: Mouse button 5
+            { .type = UHK_KEY_NONE }, // TODO: Mouse button 6
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE }, // TODO: Mouse Wheel Up
+
+            // Row 3
+            { .type = UHK_KEY_NONE }, // TODO: Mouse left
+            { .type = UHK_KEY_NONE }, // TODO: Mouse down
+            { .type = UHK_KEY_NONE }, // TODO: Mouse right
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE }, // TODO: Mouse Wheel down
+
+            // Row 4
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_SHIFT }},
+            { .type = UHK_KEY_NONE },
+
+            // Row 5
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_ALT }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_GUI }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_RIGHT_CONTROL }},
+        },
+
+        // Left
+        {
+            // Row 1
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+
+            // Row 2
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+
+            // Row 3
+            { .type = UHK_KEY_LAYER, .layer = { .target = LAYER_ID_MOUSE }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE }, // TODO: Mouse left click
+            { .type = UHK_KEY_NONE }, // TODO: Mouse middle click
+            { .type = UHK_KEY_NONE }, // TODO: Mouse right click
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+
+            // Row 4
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_SHIFT }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE },
+
+            // Row 5
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_CONTROL }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_GUI }},
+            { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_ALT }},
+            { .type = UHK_KEY_NONE },
+            { .type = UHK_KEY_NONE }, // TODO: mouse decelerate
+            { .type = UHK_KEY_NONE }, // TODO: mouse accelerate
+            { .type = UHK_KEY_NONE },
+        }
+    },
 
 };
-

--- a/right/src/default_layout.c
+++ b/right/src/default_layout.c
@@ -312,23 +312,23 @@ uhk_key_t CurrentKeymap[LAYER_COUNT][SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE] = {
             { .type = UHK_KEY_NONE },
 
             // Row 2
-            { .type = UHK_KEY_NONE }, // TODO: Mouse button 4
-            { .type = UHK_KEY_NONE }, // TODO: Mouse up
-            { .type = UHK_KEY_NONE }, // TODO: Mouse button 5
-            { .type = UHK_KEY_NONE }, // TODO: Mouse button 6
+            { .type = UHK_KEY_MOUSE, .mouse = { .buttonActions = UHK_MOUSE_BUTTON_4 }},
+            { .type = UHK_KEY_MOUSE, .mouse = { .moveActions = UHK_MOUSE_MOVE_UP }},
+            { .type = UHK_KEY_MOUSE, .mouse = { .buttonActions = UHK_MOUSE_BUTTON_5 }},
+            { .type = UHK_KEY_MOUSE, .mouse = { .buttonActions = UHK_MOUSE_BUTTON_6 }},
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_NONE },
-            { .type = UHK_KEY_NONE }, // TODO: Mouse Wheel Up
+            { .type = UHK_KEY_MOUSE, .mouse = { .scrollActions = UHK_MOUSE_SCROLL_UP }},
 
             // Row 3
-            { .type = UHK_KEY_NONE }, // TODO: Mouse left
-            { .type = UHK_KEY_NONE }, // TODO: Mouse down
-            { .type = UHK_KEY_NONE }, // TODO: Mouse right
+            { .type = UHK_KEY_MOUSE, .mouse = { .moveActions = UHK_MOUSE_MOVE_LEFT }},
+            { .type = UHK_KEY_MOUSE, .mouse = { .moveActions = UHK_MOUSE_MOVE_DOWN }},
+            { .type = UHK_KEY_MOUSE, .mouse = { .moveActions = UHK_MOUSE_MOVE_RIGHT }},
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_NONE },
-            { .type = UHK_KEY_NONE }, // TODO: Mouse Wheel down
+            { .type = UHK_KEY_MOUSE, .mouse = { .scrollActions = UHK_MOUSE_SCROLL_DOWN }},
 
             // Row 4
             { .type = UHK_KEY_NONE },
@@ -371,9 +371,9 @@ uhk_key_t CurrentKeymap[LAYER_COUNT][SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE] = {
             // Row 3
             { .type = UHK_KEY_LAYER, .layer = { .target = LAYER_ID_MOUSE }},
             { .type = UHK_KEY_NONE },
-            { .type = UHK_KEY_NONE }, // TODO: Mouse left click
-            { .type = UHK_KEY_NONE }, // TODO: Mouse middle click
-            { .type = UHK_KEY_NONE }, // TODO: Mouse right click
+            { .type = UHK_KEY_MOUSE, .mouse = { .buttonActions = UHK_MOUSE_BUTTON_LEFT }},
+            { .type = UHK_KEY_MOUSE, .mouse = { .buttonActions = UHK_MOUSE_BUTTON_MIDDLE }},
+            { .type = UHK_KEY_MOUSE, .mouse = { .buttonActions = UHK_MOUSE_BUTTON_RIGHT }},
             { .type = UHK_KEY_NONE },
             { .type = UHK_KEY_NONE },
 
@@ -391,8 +391,8 @@ uhk_key_t CurrentKeymap[LAYER_COUNT][SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE] = {
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_GUI }},
             { .type = UHK_KEY_SIMPLE, .simple = { .key = HID_KEYBOARD_SC_LEFT_ALT }},
             { .type = UHK_KEY_NONE },
-            { .type = UHK_KEY_NONE }, // TODO: mouse decelerate
-            { .type = UHK_KEY_NONE }, // TODO: mouse accelerate
+            { .type = UHK_KEY_MOUSE, .mouse = { .moveActions = UHK_MOUSE_DECELERATE }},
+            { .type = UHK_KEY_MOUSE, .mouse = { .moveActions = UHK_MOUSE_ACCELERATE }},
             { .type = UHK_KEY_NONE },
         }
     },

--- a/right/src/keyboard_layout.h
+++ b/right/src/keyboard_layout.h
@@ -33,6 +33,32 @@ typedef enum {
     UHK_KEY_LPRESSLAYER,
 } uhk_key_type_t;
 
+enum {
+    UHK_MOUSE_BUTTON_LEFT   = (1 << 0),
+    UHK_MOUSE_BUTTON_RIGHT  = (1 << 1),
+    UHK_MOUSE_BUTTON_MIDDLE = (1 << 2),
+    UHK_MOUSE_BUTTON_4      = (1 << 3),
+    UHK_MOUSE_BUTTON_5      = (1 << 4),
+    UHK_MOUSE_BUTTON_6      = (1 << 5),
+};
+
+enum {
+    UHK_MOUSE_MOVE_UP    = (1 << 0),
+    UHK_MOUSE_MOVE_DOWN  = (1 << 1),
+    UHK_MOUSE_MOVE_LEFT  = (1 << 2),
+    UHK_MOUSE_MOVE_RIGHT = (1 << 3),
+
+    UHK_MOUSE_ACCELERATE = (1 << 4),
+    UHK_MOUSE_DECELERATE = (1 << 5),
+};
+
+enum {
+    UHK_MOUSE_SCROLL_UP    = (1 << 0),
+    UHK_MOUSE_SCROLL_DOWN  = (1 << 1),
+    UHK_MOUSE_SCROLL_LEFT  = (1 << 2),
+    UHK_MOUSE_SCROLL_RIGHT = (1 << 3),
+};
+
 typedef struct {
     uint8_t type;
     union {
@@ -42,7 +68,7 @@ typedef struct {
             uint8_t key;
         } __attribute__ ((packed)) simple;
         struct {
-            uint8_t __unused_bits;
+            uint8_t buttonActions; // bitfield
             uint8_t scrollActions; // bitfield
             uint8_t moveActions; // bitfield
         } __attribute__ ((packed)) mouse;


### PR DESCRIPTION
Rearranges the `Base` and `Mod` layers to follow the factory layout more closely, and also adds the `Fn` and `Mouse` layers. Apart from the `Mouse` layer, and two small TODO items in the `Fn` layer, it should all be functional.

There is a minor deviation from the factory layout: modifiers are all present on every layer, in the same position. This is so that one can do `Shift + Mouse + J` to augment a  `Mouse Left` action with `Shift`, among other things.

The mouse layer has all its actions filled in, for which I created a number of enums, to make them clearer. There are no actions implemented yet, though. One thing to note here, is that all actions are bitfields, so we can have a `Mouse Up + Mouse Right` action, or a `Mouse Button Left + Mouse Button Right` action, and so on. Once I get to implementing mouse actions, the handler will do the right thing in all these cases.