### PR TITLE
Minor key_action_t updates

### DIFF
--- a/right/src/action.h
+++ b/right/src/action.h
@@ -81,7 +81,7 @@ typedef struct {
         } __attribute__ ((packed)) switchLayer;
         struct {
             uint16_t __unused_bits;
-            uint8_t layer;
+            uint8_t keymap;
         } __attribute__ ((packed)) switchKeymap;
         struct {
             uint8_t __unused_bits;

--- a/right/src/action.h
+++ b/right/src/action.h
@@ -65,7 +65,7 @@ typedef struct {
     uint8_t type;
     union {
         struct {
-            uint8_t __unused_bits;
+            uint8_t longPress;
             uint8_t mods;
             uint8_t key;
         } __attribute__ ((packed)) keystroke;
@@ -75,7 +75,8 @@ typedef struct {
             uint8_t moveActions; // bitfield
         } __attribute__ ((packed)) mouse;
         struct {
-            uint16_t __unused_bits;
+            uint16_t __unused_bits:15;
+            bool isToggle:1;
             uint8_t layer;
         } __attribute__ ((packed)) switchLayer;
         struct {


### PR DESCRIPTION
This adds `keystroke.longPress` and `switchLayer.isToggle` to `key_action_t`, and renames `switchKeymap.layer` to `switchKeymap.keymap`.

These will be used by the deserialization, and are stuff the Agent already supports. There is no code yet to handle these, but at least with these changes, they can be represented.