### PR TITLE
Improve the configuration parser

### DIFF
--- a/right/src/config/parse_keymap.c
+++ b/right/src/config/parse_keymap.c
@@ -169,7 +169,7 @@ static void clearModule(uint8_t layer, uint8_t moduleId) {
     memset(&CurrentKeymap[layer][moduleId], 0, MAX_KEY_COUNT_PER_MODULE * sizeof(key_action_t));
 }
 
-void parseLayer(serialized_buffer_t *buffer, uint8_t layer) {
+static void parseLayer(serialized_buffer_t *buffer, uint8_t layer) {
     uint8_t moduleCount = readCompactLength(buffer);
 
     for (uint8_t moduleIdx = 0; moduleIdx < moduleCount; moduleIdx++) {

--- a/right/src/config/parse_keymap.c
+++ b/right/src/config/parse_keymap.c
@@ -90,11 +90,11 @@ static uint8_t parseSwitchLayerAction(key_action_t *KeyAction, serialized_buffer
 }
 
 static uint8_t parseSwitchKeymapAction(key_action_t *keyAction, serialized_buffer_t *buffer) {
-//    uint16_t len;
-//    const char *keymap = readString(buffer, &len);
+    uint16_t keymapAbbreviationLen;
+    const char *keymapAbbreviation = readString(buffer, &keymapAbbreviationLen);
 
+    (void)keymapAbbreviation;
     keyAction->type = KeyActionType_SwitchKeymap;
-
     // TODO: Implement this
     return ParserError_Success;
 }

--- a/right/src/config/parse_keymap.c
+++ b/right/src/config/parse_keymap.c
@@ -25,7 +25,6 @@ static uint16_t readCompactLength(serialized_buffer_t *buffer) {
     return length;
 }
 
-/*
 static const char *readString(serialized_buffer_t *buffer, uint16_t *len) {
     const char *str = (const char *)&(buffer->buffer[buffer->offset]);
 
@@ -34,7 +33,6 @@ static const char *readString(serialized_buffer_t *buffer, uint16_t *len) {
 
     return str;
 }
-*/
 
 static void parseNoneAction(key_action_t *keyAction, serialized_buffer_t *buffer) {
     keyAction->type = KeyActionType_None;
@@ -171,15 +169,32 @@ static void clearModule(uint8_t layer, uint8_t moduleId) {
     memset(&CurrentKeymap[layer][moduleId], 0, MAX_KEY_COUNT_PER_MODULE * sizeof(key_action_t));
 }
 
-void ParseLayer(uint8_t *data, uint8_t layer) {
-    serialized_buffer_t buffer;
-    buffer.buffer = data;
-    buffer.offset = 0;
-
-    uint8_t moduleCount = readCompactLength(&buffer);
+void parseLayer(serialized_buffer_t *buffer, uint8_t layer) {
+    uint8_t moduleCount = readCompactLength(buffer);
 
     for (uint8_t moduleIdx = 0; moduleIdx < moduleCount; moduleIdx++) {
         clearModule(layer, moduleIdx);
-        parseModule(&buffer, layer);
+        parseModule(buffer, layer);
     }
 }
+
+void ParseKeymap(uint8_t *data) {
+    serialized_buffer_t *buffer = &(serialized_buffer_t){ data, 0 };
+    uint16_t abbreviationLen;
+    uint16_t nameLen;
+    uint16_t descriptionLen;
+    const char *abbreviation = readString(buffer, &abbreviationLen);
+    bool isDefault = readBool(buffer);
+    const char *name = readString(buffer, &nameLen);
+    const char *description = readString(buffer, &descriptionLen);
+    uint8_t layerCount = readCompactLength(buffer);
+
+    (void)abbreviation;
+    (void)isDefault;
+    (void)name;
+    (void)description;
+    for (uint8_t layerIdx = 0; layerIdx < layerCount; layerIdx++) {
+        parseLayer(buffer, layerIdx);
+    }
+}
+

--- a/right/src/config/parse_keymap.c
+++ b/right/src/config/parse_keymap.c
@@ -193,8 +193,7 @@ static bool parseLayer(serialized_buffer_t *buffer, uint8_t layer) {
     return false;
 }
 
-bool ParseKeymap(uint8_t *data) {
-    serialized_buffer_t *buffer = &(serialized_buffer_t){ data, 0 };
+bool ParseKeymap(serialized_buffer_t *buffer) {;
     uint16_t abbreviationLen;
     uint16_t nameLen;
     uint16_t descriptionLen;

--- a/right/src/config/parse_keymap.h
+++ b/right/src/config/parse_keymap.h
@@ -56,6 +56,6 @@
 
 // Functions:
 
-    bool ParseKeymap(serialized_buffer_t *buffer);
+    uint8_t ParseKeymap(serialized_buffer_t *buffer);
 
 #endif

--- a/right/src/config/parse_keymap.h
+++ b/right/src/config/parse_keymap.h
@@ -54,8 +54,18 @@
         uint16_t offset;
     } serialized_buffer_t;
 
+    typedef enum {
+        ParserError_Success,
+        ParserError_InvalidSerializedKeystrokeType,
+        ParserError_InvalidSerializedMouseAction,
+        ParserError_InvalidSerializedKeyActionType,
+        ParserError_InvalidLayerCount,
+        ParserError_InvalidModuleCount,
+        ParserError_InvalidActionCount,
+    } parser_error_t;
+
 // Functions:
 
-    uint8_t ParseKeymap(serialized_buffer_t *buffer);
+    parser_error_t ParseKeymap(serialized_buffer_t *buffer);
 
 #endif

--- a/right/src/config/parse_keymap.h
+++ b/right/src/config/parse_keymap.h
@@ -4,6 +4,7 @@
 // Includes:
 
     #include <stdint.h>
+    #include <stdbool.h>
 
 // Macros:
 
@@ -55,6 +56,6 @@
 
 // Functions:
 
-    void ParseKeymap(uint8_t *data);
+    bool ParseKeymap(uint8_t *data);
 
 #endif

--- a/right/src/config/parse_keymap.h
+++ b/right/src/config/parse_keymap.h
@@ -56,6 +56,6 @@
 
 // Functions:
 
-    bool ParseKeymap(uint8_t *data);
+    bool ParseKeymap(serialized_buffer_t *buffer);
 
 #endif

--- a/right/src/config/parse_keymap.h
+++ b/right/src/config/parse_keymap.h
@@ -55,6 +55,6 @@
 
 // Functions:
 
-    void ParseLayer(uint8_t *data, uint8_t layer);
+    void ParseKeymap(uint8_t *data);
 
 #endif

--- a/right/src/usb_protocol_handler.c
+++ b/right/src/usb_protocol_handler.c
@@ -193,7 +193,7 @@ void uploadConfig()
 
 void applyConfig()
 {
-    ParseKeymap(ConfigBuffer);
+    setError(ParseKeymap(ConfigBuffer));
 }
 
 void setLedPwm()

--- a/right/src/usb_protocol_handler.c
+++ b/right/src/usb_protocol_handler.c
@@ -193,7 +193,11 @@ void uploadConfig()
 
 void applyConfig()
 {
-    setError(ParseKeymap(ConfigBuffer));
+    serialized_buffer_t buffer = { ConfigBuffer, 0 };
+
+    GenericHidOutBuffer[0] = ParseKeymap(&buffer);
+    GenericHidOutBuffer[1] = buffer.offset;
+    GenericHidOutBuffer[2] = buffer.offset >> 8;
 }
 
 void setLedPwm()

--- a/right/src/usb_protocol_handler.c
+++ b/right/src/usb_protocol_handler.c
@@ -193,7 +193,7 @@ void uploadConfig()
 
 void applyConfig()
 {
-    ParseLayer(ConfigBuffer, 0);
+    ParseKeymap(ConfigBuffer);
 }
 
 void setLedPwm()


### PR DESCRIPTION
This allows the configuration parser to parse keymap configurations and resolves #42. In addition, it introduces a bit of error checking to so that unexpected data is less likely to cause problems.