### PR TITLE
Improve OSX dependency management through brew bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
   directories:
     - $HOME/Library/Caches/Homebrew/Cask
 install:
-  - brew cask install eclipse-cpp gcc-arm-embedded
+  - brew tap Homebrew/bundle && brew bundle
   - /Applications/Eclipse.app/Contents/MacOS/eclipse -noSplash 
     -application org.eclipse.equinox.p2.director 
     -repository http://gnuarmeclipse.sourceforge.net/updates 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,3 @@ script:
     -import $TRAVIS_BUILD_DIR/left/build/kds
     -import $TRAVIS_BUILD_DIR/right/build/kds
     -build all
-

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+cask "eclipse-cpp"
+cask "gcc-arm-embedded"


### PR DESCRIPTION
a new and improved osx dependency management system, takes the dependencies out of `.travis.yml` and moves them into a more track-able file