### PR TITLE
Enable the link-time optimizer for the left side, as this was also us…

### DIFF
--- a/left/Makefile
+++ b/left/Makefile
@@ -34,6 +34,9 @@ FLASH_CMD = node ../lib/agent/packages/usb/update-module-firmware.js leftHalf $(
 # Path to the JLink script used for the left half.
 JLINK_SCRIPT = ../scripts/flash-left.jlink
 
+# Enable the link-time optimizer.
+BUILD_FLAGS = -flto
+
 # Source files.
 SOURCE = $(wildcard src/*.c) \
          ../lib/KSDK_2.0_MKL03Z8xxx4/devices/MKL03Z4/system_MKL03Z4.c \


### PR DESCRIPTION
…ed before the Makefile were added

I also checked the effect of adding it to the right side, but in this case it actually makes the binary size larger since we using ```-O3```: <https://stackoverflow.com/questions/24718652/why-does-link-time-optimization-results-in-larger-binaries>.

With lto:
```bash
Memory region         Used Size  Region Size  %age Used
    m_interrupts:          1 KB         1 KB    100.00%
          m_text:       37280 B       463 KB      7.86%
          m_data:       49728 B        64 KB     75.88%
        m_data_2:       41920 B      65280 B     64.22%
        m_noinit:          16 B        255 B      6.27%
```

Without:
```bash
Memory region         Used Size  Region Size  %age Used
    m_interrupts:          1 KB         1 KB    100.00%
          m_text:       37152 B       463 KB      7.84%
          m_data:       49912 B        64 KB     76.16%
        m_data_2:       41920 B      65280 B     64.22%
        m_noinit:          16 B        255 B      6.27%
```