### PR TITLE
Adjust the behavior of sticky modifiers

### DIFF
--- a/right/src/key_states.h
+++ b/right/src/key_states.h
@@ -13,7 +13,6 @@
         uint8_t timestamp;
         bool previous : 1;
         bool current : 1;
-        bool suppressed : 1;
         bool debouncing : 1;
     } key_state_t;
 

--- a/right/src/layer.c
+++ b/right/src/layer.c
@@ -15,7 +15,7 @@ void updateLayerStates(void)
     for (uint8_t slotId=0; slotId<SLOT_COUNT; slotId++) {
         for (uint8_t keyId=0; keyId<MAX_KEY_COUNT_PER_MODULE; keyId++) {
             key_state_t *keyState = &KeyStates[slotId][keyId];
-            if (keyState->current && !keyState->suppressed) {
+            if (keyState->current) {
                 key_action_t action = CurrentKeymap[LayerId_Base][slotId][keyId];
                 if (action.type == KeyActionType_SwitchLayer) {
                     if (action.switchLayer.mode != SwitchLayerMode_Toggle) {
@@ -69,4 +69,15 @@ layer_id_t GetActiveLayer()
     PreviousHeldLayer = heldLayer;
 
     return heldLayer;
+}
+
+bool IsLayerHeld(void)
+{
+    for (layer_id_t layerId = LayerId_Mod; layerId <= LayerId_Mouse; layerId++) {
+        if (heldLayers[layerId]) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/right/src/layer.h
+++ b/right/src/layer.h
@@ -25,6 +25,7 @@
 
 // Functions:
 
-    layer_id_t GetActiveLayer();
+    layer_id_t GetActiveLayer(void);
+    bool IsLayerHeld(void);
 
 #endif


### PR DESCRIPTION
This closes #169 and makes sticky modifiers play nice with secondary role keys. This also removes key suppression, which no longer serves a purpose.