### PR TITLE
add https://github.com/p4elkin/firmware to the list of featured forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ The following list contains unofficial forks of the firmware. These forks provid
 
 - [https://github.com/kareltucek/firmware](https://github.com/kareltucek/firmware) - firmware featuring macro engine extended by a set of custom commands, allowing more advanced configurations including custom layer switching logic, doubletap bindings, alternative secondary roles etc.
 
+- [https://github.com/p4elkin/firmware](https://github.com/p4elkin/firmware) - firmware fork which comes with an alternative implementation of the secondary key role mechanism making it possible to use the feature for keys actively involved in typing (e.g. alphanumeric ones).
+


### PR DESCRIPTION
this changeset proposes to add https://github.com/p4elkin/firmware to the list of the custom firmware forks.