### PR TITLE
Fix first tick of scroll timer

### DIFF
--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -127,7 +127,7 @@ static void processMouseKineticState(mouse_kinetic_state_t *kineticState)
         kineticState->xOut = xSumInt;
 
         if (kineticState->isScroll && !kineticState->wasMoveAction && kineticState->xOut == 0 && horizontalMovement) {
-            kineticState->xOut = kineticState->xSum ? copysignf(1.0, kineticState->xSum) : 0;
+            kineticState->xOut = activeMouseStates[kineticState->leftState] ? -1 : 1;
             kineticState->xSum = 0;
         }
 
@@ -148,7 +148,7 @@ static void processMouseKineticState(mouse_kinetic_state_t *kineticState)
         kineticState->yOut = ySumInt;
 
         if (kineticState->isScroll && !kineticState->wasMoveAction && kineticState->yOut == 0 && verticalMovement) {
-            kineticState->yOut = kineticState->ySum ? copysignf(1.0, kineticState->ySum) : 0;
+            kineticState->yOut = activeMouseStates[kineticState->upState] ? -1 : 1;
             kineticState->ySum = 0;
         }
     } else {


### PR DESCRIPTION
Should solve #209.

Conditions at 130 && 150 apparently handle the first update cycle tick of scroll event. Clauses at 130 & 151 defaulted to 0, due to zeroing at 108. (Distance is always zero in the first tick since elapsed time is also zero.) I believe that `copysignf(1.0, kineticState->ySum)` was unreachable.