### PR TITLE
Refactor keyState queries to be more descriptive

### DIFF
--- a/right/src/key_states.h
+++ b/right/src/key_states.h
@@ -14,8 +14,6 @@
     #define KEYSTATE_INACTIVE(KEY) (!((KEY)->current))
     #define KEYSTATE_ACTIVATED_NOW(KEY) (!(KEY)->previous && (KEY)->current)
     #define KEYSTATE_DEACTIVATED_NOW(KEY) ((KEY)->previous && !(KEY)->current)
-    #define KEYSTATE_ACTIVATED_EARLIER(KEY) ((KEY)->previous && (KEY)->current)
-    #define KEYSTATE_DEACTIVATED_EARLIER(KEY) (!(KEY)->previous && !(KEY)->current)
 
 // Typedefs:
 

--- a/right/src/key_states.h
+++ b/right/src/key_states.h
@@ -9,12 +9,13 @@
 
 // Macros:
 
-    #define ACTIVE(KEY) (((KEY)->current))
-    #define INACTIVE(KEY) (!((KEY)->current))
-    #define ACTIVATED_NOW(KEY) (!(KEY)->previous && (KEY)->current)
-    #define DEACTIVATED_NOW(KEY) ((KEY)->previous && !(KEY)->current)
-    #define ACTIVATED_EARLIER(KEY) ((KEY)->previous && (KEY)->current)
-    #define DEACTIVATED_EARLIER(KEY) (!(KEY)->previous && !(KEY)->current)
+
+    #define KEYSTATE_ACTIVE(KEY) (((KEY)->current))
+    #define KEYSTATE_INACTIVE(KEY) (!((KEY)->current))
+    #define KEYSTATE_ACTIVATED_NOW(KEY) (!(KEY)->previous && (KEY)->current)
+    #define KEYSTATE_DEACTIVATED_NOW(KEY) ((KEY)->previous && !(KEY)->current)
+    #define KEYSTATE_ACTIVATED_EARLIER(KEY) ((KEY)->previous && (KEY)->current)
+    #define KEYSTATE_DEACTIVATED_EARLIER(KEY) (!(KEY)->previous && !(KEY)->current)
 
 // Typedefs:
 
@@ -40,5 +41,8 @@
 // Variables:
 
     extern key_state_t KeyStates[SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE];
+
+
+    static inline bool Keystate_Active(key_state_t* s) { return s->current; };
 
 #endif

--- a/right/src/key_states.h
+++ b/right/src/key_states.h
@@ -7,6 +7,15 @@
     #include "slot.h"
     #include "module.h"
 
+// Macros:
+
+    #define ACTIVE(KEY) (((KEY)->current))
+    #define INACTIVE(KEY) (!((KEY)->current))
+    #define ACTIVATED_NOW(KEY) (!(KEY)->previous && (KEY)->current)
+    #define DEACTIVATED_NOW(KEY) ((KEY)->previous && !(KEY)->current)
+    #define ACTIVATED_EARLIER(KEY) ((KEY)->previous && (KEY)->current)
+    #define DEACTIVATED_EARLIER(KEY) (!(KEY)->previous && !(KEY)->current)
+
 // Typedefs:
 
     // Next is used as an accumulator of the state - asynchronous state updates

--- a/right/src/key_states.h
+++ b/right/src/key_states.h
@@ -7,14 +7,6 @@
     #include "slot.h"
     #include "module.h"
 
-// Macros:
-
-
-    #define KEYSTATE_ACTIVE(KEY) (((KEY)->current))
-    #define KEYSTATE_INACTIVE(KEY) (!((KEY)->current))
-    #define KEYSTATE_ACTIVATED_NOW(KEY) (!(KEY)->previous && (KEY)->current)
-    #define KEYSTATE_DEACTIVATED_NOW(KEY) ((KEY)->previous && !(KEY)->current)
-
 // Typedefs:
 
     // Next is used as an accumulator of the state - asynchronous state updates
@@ -40,7 +32,11 @@
 
     extern key_state_t KeyStates[SLOT_COUNT][MAX_KEY_COUNT_PER_MODULE];
 
+// Inline functions
 
-    static inline bool Keystate_Active(key_state_t* s) { return s->current; };
+    static inline bool KeyState_Active(key_state_t* s) { return s->current; };
+    static inline bool KeyState_Inactive(key_state_t* s) { return !s->current; };
+    static inline bool KeyState_ActivatedNow(key_state_t* s) { return !s->previous && s->current; };
+    static inline bool KeyState_DeactivatedNow(key_state_t* s) { return s->previous && !s->current; };
 
 #endif

--- a/right/src/key_states.h
+++ b/right/src/key_states.h
@@ -38,5 +38,7 @@
     static inline bool KeyState_Inactive(key_state_t* s) { return !s->current; };
     static inline bool KeyState_ActivatedNow(key_state_t* s) { return !s->previous && s->current; };
     static inline bool KeyState_DeactivatedNow(key_state_t* s) { return s->previous && !s->current; };
+    static inline bool KeyState_ActivatedEarlier(key_state_t* s) { return s->previous && s->current; };
+    static inline bool KeyState_DeactivatedEarlier(key_state_t* s) { return !s->previous && !s->current; };
 
 #endif

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -260,7 +260,7 @@ static secondary_role_t secondaryRole;
 
 static void applyKeyAction(key_state_t *keyState, key_action_t *action, uint8_t slotId, uint8_t keyId)
 {
-    if (Keystate_Active(keyState)) {
+    if (KeyState_Active(keyState)) {
         handleSwitchLayerAction(keyState, action);
 
         switch (action->type) {

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -321,7 +321,7 @@ static void applyKeyAction(key_state_t *keyState, key_action_t *action, uint8_t 
     } else {
         switch (action->type) {
             case KeyActionType_Keystroke:
-                if (KEYSTATE_DEACTIVATED_EARLIER(keyState)) {
+                if (KEYSTATE_DEACTIVATED_NOW(keyState)) {
                     if (slotId == stickySlotId && keyId == stickyKeyId) {
                         if (!IsLayerHeld() && !(secondaryRoleState == SecondaryRoleState_Triggered && IS_SECONDARY_ROLE_LAYER_SWITCHER(secondaryRole))) {
                             stickyModifiers = 0;

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -260,13 +260,13 @@ static secondary_role_t secondaryRole;
 
 static void applyKeyAction(key_state_t *keyState, key_action_t *action, uint8_t slotId, uint8_t keyId)
 {
-    if (keyState->current) {
+    if (ACTIVE(keyState)) {
         handleSwitchLayerAction(keyState, action);
 
         switch (action->type) {
             case KeyActionType_Keystroke:
                 if (action->keystroke.scancode) {
-                    if (!keyState->previous) {
+                    if (ACTIVATED_NOW(keyState)) {
                         stickyModifiers = action->keystroke.modifiers;
                         stickySlotId = slotId;
                         stickyKeyId = keyId;
@@ -296,7 +296,7 @@ static void applyKeyAction(key_state_t *keyState, key_action_t *action, uint8_t 
                 }
                 break;
             case KeyActionType_Mouse:
-                if (!keyState->previous) {
+                if (ACTIVATED_NOW(keyState)) {
                     stickyModifiers = 0;
                 }
                 activeMouseStates[action->mouseAction] = true;
@@ -305,14 +305,14 @@ static void applyKeyAction(key_state_t *keyState, key_action_t *action, uint8_t 
                 // Handled by handleSwitchLayerAction()
                 break;
             case KeyActionType_SwitchKeymap:
-                if (!keyState->previous) {
+                if (ACTIVATED_NOW(keyState)) {
                     stickyModifiers = 0;
                     secondaryRoleState = SecondaryRoleState_Released;
                     SwitchKeymapById(action->switchKeymap.keymapId);
                 }
                 break;
             case KeyActionType_PlayMacro:
-                if (!keyState->previous) {
+                if (ACTIVATED_NOW(keyState)) {
                     stickyModifiers = 0;
                     Macros_StartMacro(action->playMacro.macroId);
                 }
@@ -321,7 +321,7 @@ static void applyKeyAction(key_state_t *keyState, key_action_t *action, uint8_t 
     } else {
         switch (action->type) {
             case KeyActionType_Keystroke:
-                if (keyState->previous) {
+                if (DEACTIVATED_EARLIER(keyState)) {
                     if (slotId == stickySlotId && keyId == stickyKeyId) {
                         if (!IsLayerHeld() && !(secondaryRoleState == SecondaryRoleState_Triggered && IS_SECONDARY_ROLE_LAYER_SWITCHER(secondaryRole))) {
                             stickyModifiers = 0;
@@ -408,7 +408,7 @@ static void updateActiveUsbReports(void)
 
             preprocessKeyState(keyState);
 
-            if (keyState->current && !keyState->previous) {
+            if (ACTIVATED_NOW(keyState)) {
                 if (SleepModeActive) {
                     WakeUpHost();
                 }
@@ -424,10 +424,10 @@ static void updateActiveUsbReports(void)
 
             action = &actionCache[slotId][keyId];
 
-            if (keyState->current) {
+            if (ACTIVE(keyState)) {
                 if (action->type == KeyActionType_Keystroke && action->keystroke.secondaryRole) {
                     // Press released secondary role key.
-                    if (!keyState->previous && secondaryRoleState == SecondaryRoleState_Released) {
+                    if (ACTIVATED_NOW(keyState) && secondaryRoleState == SecondaryRoleState_Released) {
                         secondaryRoleState = SecondaryRoleState_Pressed;
                         secondaryRoleSlotId = slotId;
                         secondaryRoleKeyId = keyId;
@@ -438,7 +438,7 @@ static void updateActiveUsbReports(void)
                 }
             } else {
                 // Release secondary role key.
-                if (keyState->previous && secondaryRoleSlotId == slotId && secondaryRoleKeyId == keyId && secondaryRoleState != SecondaryRoleState_Released) {
+                if (DEACTIVATED_NOW(keyState) && secondaryRoleSlotId == slotId && secondaryRoleKeyId == keyId && secondaryRoleState != SecondaryRoleState_Released) {
                     // Trigger primary role.
                     if (secondaryRoleState == SecondaryRoleState_Pressed) {
                         keyState->previous = false;

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -260,13 +260,13 @@ static secondary_role_t secondaryRole;
 
 static void applyKeyAction(key_state_t *keyState, key_action_t *action, uint8_t slotId, uint8_t keyId)
 {
-    if (KEYSTATE_ACTIVE(keyState)) {
+    if (Keystate_Active(keyState)) {
         handleSwitchLayerAction(keyState, action);
 
         switch (action->type) {
             case KeyActionType_Keystroke:
                 if (action->keystroke.scancode) {
-                    if (KEYSTATE_ACTIVATED_NOW(keyState)) {
+                    if (KeyState_ActivatedNow(keyState)) {
                         stickyModifiers = action->keystroke.modifiers;
                         stickySlotId = slotId;
                         stickyKeyId = keyId;
@@ -296,7 +296,7 @@ static void applyKeyAction(key_state_t *keyState, key_action_t *action, uint8_t 
                 }
                 break;
             case KeyActionType_Mouse:
-                if (KEYSTATE_ACTIVATED_NOW(keyState)) {
+                if (KeyState_ActivatedNow(keyState)) {
                     stickyModifiers = 0;
                 }
                 activeMouseStates[action->mouseAction] = true;
@@ -305,14 +305,14 @@ static void applyKeyAction(key_state_t *keyState, key_action_t *action, uint8_t 
                 // Handled by handleSwitchLayerAction()
                 break;
             case KeyActionType_SwitchKeymap:
-                if (KEYSTATE_ACTIVATED_NOW(keyState)) {
+                if (KeyState_ActivatedNow(keyState)) {
                     stickyModifiers = 0;
                     secondaryRoleState = SecondaryRoleState_Released;
                     SwitchKeymapById(action->switchKeymap.keymapId);
                 }
                 break;
             case KeyActionType_PlayMacro:
-                if (KEYSTATE_ACTIVATED_NOW(keyState)) {
+                if (KeyState_ActivatedNow(keyState)) {
                     stickyModifiers = 0;
                     Macros_StartMacro(action->playMacro.macroId);
                 }
@@ -321,7 +321,7 @@ static void applyKeyAction(key_state_t *keyState, key_action_t *action, uint8_t 
     } else {
         switch (action->type) {
             case KeyActionType_Keystroke:
-                if (KEYSTATE_DEACTIVATED_NOW(keyState)) {
+                if (KeyState_DeactivatedNow(keyState)) {
                     if (slotId == stickySlotId && keyId == stickyKeyId) {
                         if (!IsLayerHeld() && !(secondaryRoleState == SecondaryRoleState_Triggered && IS_SECONDARY_ROLE_LAYER_SWITCHER(secondaryRole))) {
                             stickyModifiers = 0;
@@ -408,7 +408,7 @@ static void updateActiveUsbReports(void)
 
             preprocessKeyState(keyState);
 
-            if (KEYSTATE_ACTIVATED_NOW(keyState)) {
+            if (KeyState_ActivatedNow(keyState)) {
                 if (SleepModeActive) {
                     WakeUpHost();
                 }
@@ -424,10 +424,10 @@ static void updateActiveUsbReports(void)
 
             action = &actionCache[slotId][keyId];
 
-            if (KEYSTATE_ACTIVE(keyState)) {
+            if (KeyState_Active(keyState)) {
                 if (action->type == KeyActionType_Keystroke && action->keystroke.secondaryRole) {
                     // Press released secondary role key.
-                    if (KEYSTATE_ACTIVATED_NOW(keyState) && secondaryRoleState == SecondaryRoleState_Released) {
+                    if (KeyState_ActivatedNow(keyState) && secondaryRoleState == SecondaryRoleState_Released) {
                         secondaryRoleState = SecondaryRoleState_Pressed;
                         secondaryRoleSlotId = slotId;
                         secondaryRoleKeyId = keyId;
@@ -438,7 +438,7 @@ static void updateActiveUsbReports(void)
                 }
             } else {
                 // Release secondary role key.
-                if (KEYSTATE_DEACTIVATED_NOW(keyState) && secondaryRoleSlotId == slotId && secondaryRoleKeyId == keyId && secondaryRoleState != SecondaryRoleState_Released) {
+                if (KeyState_DeactivatedNow(keyState) && secondaryRoleSlotId == slotId && secondaryRoleKeyId == keyId && secondaryRoleState != SecondaryRoleState_Released) {
                     // Trigger primary role.
                     if (secondaryRoleState == SecondaryRoleState_Pressed) {
                         keyState->previous = false;

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -260,13 +260,13 @@ static secondary_role_t secondaryRole;
 
 static void applyKeyAction(key_state_t *keyState, key_action_t *action, uint8_t slotId, uint8_t keyId)
 {
-    if (ACTIVE(keyState)) {
+    if (KEYSTATE_ACTIVE(keyState)) {
         handleSwitchLayerAction(keyState, action);
 
         switch (action->type) {
             case KeyActionType_Keystroke:
                 if (action->keystroke.scancode) {
-                    if (ACTIVATED_NOW(keyState)) {
+                    if (KEYSTATE_ACTIVATED_NOW(keyState)) {
                         stickyModifiers = action->keystroke.modifiers;
                         stickySlotId = slotId;
                         stickyKeyId = keyId;
@@ -296,7 +296,7 @@ static void applyKeyAction(key_state_t *keyState, key_action_t *action, uint8_t 
                 }
                 break;
             case KeyActionType_Mouse:
-                if (ACTIVATED_NOW(keyState)) {
+                if (KEYSTATE_ACTIVATED_NOW(keyState)) {
                     stickyModifiers = 0;
                 }
                 activeMouseStates[action->mouseAction] = true;
@@ -305,14 +305,14 @@ static void applyKeyAction(key_state_t *keyState, key_action_t *action, uint8_t 
                 // Handled by handleSwitchLayerAction()
                 break;
             case KeyActionType_SwitchKeymap:
-                if (ACTIVATED_NOW(keyState)) {
+                if (KEYSTATE_ACTIVATED_NOW(keyState)) {
                     stickyModifiers = 0;
                     secondaryRoleState = SecondaryRoleState_Released;
                     SwitchKeymapById(action->switchKeymap.keymapId);
                 }
                 break;
             case KeyActionType_PlayMacro:
-                if (ACTIVATED_NOW(keyState)) {
+                if (KEYSTATE_ACTIVATED_NOW(keyState)) {
                     stickyModifiers = 0;
                     Macros_StartMacro(action->playMacro.macroId);
                 }
@@ -321,7 +321,7 @@ static void applyKeyAction(key_state_t *keyState, key_action_t *action, uint8_t 
     } else {
         switch (action->type) {
             case KeyActionType_Keystroke:
-                if (DEACTIVATED_EARLIER(keyState)) {
+                if (KEYSTATE_DEACTIVATED_EARLIER(keyState)) {
                     if (slotId == stickySlotId && keyId == stickyKeyId) {
                         if (!IsLayerHeld() && !(secondaryRoleState == SecondaryRoleState_Triggered && IS_SECONDARY_ROLE_LAYER_SWITCHER(secondaryRole))) {
                             stickyModifiers = 0;
@@ -408,7 +408,7 @@ static void updateActiveUsbReports(void)
 
             preprocessKeyState(keyState);
 
-            if (ACTIVATED_NOW(keyState)) {
+            if (KEYSTATE_ACTIVATED_NOW(keyState)) {
                 if (SleepModeActive) {
                     WakeUpHost();
                 }
@@ -424,10 +424,10 @@ static void updateActiveUsbReports(void)
 
             action = &actionCache[slotId][keyId];
 
-            if (ACTIVE(keyState)) {
+            if (KEYSTATE_ACTIVE(keyState)) {
                 if (action->type == KeyActionType_Keystroke && action->keystroke.secondaryRole) {
                     // Press released secondary role key.
-                    if (ACTIVATED_NOW(keyState) && secondaryRoleState == SecondaryRoleState_Released) {
+                    if (KEYSTATE_ACTIVATED_NOW(keyState) && secondaryRoleState == SecondaryRoleState_Released) {
                         secondaryRoleState = SecondaryRoleState_Pressed;
                         secondaryRoleSlotId = slotId;
                         secondaryRoleKeyId = keyId;
@@ -438,7 +438,7 @@ static void updateActiveUsbReports(void)
                 }
             } else {
                 // Release secondary role key.
-                if (DEACTIVATED_NOW(keyState) && secondaryRoleSlotId == slotId && secondaryRoleKeyId == keyId && secondaryRoleState != SecondaryRoleState_Released) {
+                if (KEYSTATE_DEACTIVATED_NOW(keyState) && secondaryRoleSlotId == slotId && secondaryRoleKeyId == keyId && secondaryRoleState != SecondaryRoleState_Released) {
                     // Trigger primary role.
                     if (secondaryRoleState == SecondaryRoleState_Pressed) {
                         keyState->previous = false;


### PR DESCRIPTION
Should increase readability of the code, since this way it should always be clear *when* the condition is actually met.