### PR TITLE
Fix symmetry of mouse movement behaviour

### DIFF
--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -35,6 +35,8 @@ mouse_kinetic_state_t MouseMoveState = {
     .downState = SerializedMouseAction_MoveDown,
     .leftState = SerializedMouseAction_MoveLeft,
     .rightState = SerializedMouseAction_MoveRight,
+    .verticalStateSign = 0,
+    .horizontalStateSign = 0,
     .intMultiplier = 25,
     .initialSpeed = 5,
     .acceleration = 35,
@@ -49,6 +51,8 @@ mouse_kinetic_state_t MouseScrollState = {
     .downState = SerializedMouseAction_ScrollUp,
     .leftState = SerializedMouseAction_ScrollLeft,
     .rightState = SerializedMouseAction_ScrollRight,
+    .verticalStateSign = 0,
+    .horizontalStateSign = 0,
     .intMultiplier = 1,
     .initialSpeed = 20,
     .acceleration = 20,
@@ -56,6 +60,56 @@ mouse_kinetic_state_t MouseScrollState = {
     .baseSpeed = 20,
     .acceleratedSpeed = 50,
 };
+
+static void updateOneDirectionSign(int8_t* sign, int8_t expectedSign, uint8_t expectedState, uint8_t otherState) {
+    if (*sign == expectedSign && !activeMouseStates[expectedState]) {
+        *sign = activeMouseStates[otherState] ? -expectedSign : 0;
+    }
+}
+
+/*
+ * Assume that mouse movement key has been just released. In that case check if there is another key which keeps the state active.
+ * If not, check whether the other direction state is active and either flip movement direction or zero the state.
+ */
+static void updateDirectionSigns(mouse_kinetic_state_t *kineticState) {
+    updateOneDirectionSign(&kineticState->horizontalStateSign, -1, kineticState->leftState, kineticState->rightState);
+    updateOneDirectionSign(&kineticState->horizontalStateSign,  1, kineticState->rightState, kineticState->leftState);
+    updateOneDirectionSign(&kineticState->verticalStateSign, -1, kineticState->upState, kineticState->downState);
+    updateOneDirectionSign(&kineticState->verticalStateSign,  1, kineticState->downState, kineticState->upState);
+}
+
+/*
+ * Called on keydown of mouse action. Direction signs ensure that the last pressed action always takes precedence, and therefore
+ * have to be updated statefully.
+ */
+static void activateDirectionSigns(uint8_t state) {
+    switch (state) {
+    case SerializedMouseAction_MoveUp:
+        MouseMoveState.verticalStateSign = -1;
+        break;
+    case SerializedMouseAction_MoveDown:
+        MouseMoveState.verticalStateSign = 1;
+        break;
+    case SerializedMouseAction_MoveLeft:
+        MouseMoveState.horizontalStateSign = -1;
+        break;
+    case SerializedMouseAction_MoveRight:
+        MouseMoveState.horizontalStateSign = 1;
+        break;
+    case SerializedMouseAction_ScrollUp:
+        MouseScrollState.verticalStateSign = 1;
+        break;
+    case SerializedMouseAction_ScrollDown:
+        MouseScrollState.verticalStateSign = -1;
+        break;
+    case SerializedMouseAction_ScrollLeft:
+        MouseScrollState.horizontalStateSign = -1;
+        break;
+    case SerializedMouseAction_ScrollRight:
+        MouseScrollState.horizontalStateSign = 1;
+        break;
+    }
+}
 
 static void processMouseKineticState(mouse_kinetic_state_t *kineticState)
 {
@@ -110,22 +164,22 @@ static void processMouseKineticState(mouse_kinetic_state_t *kineticState)
             kineticState->ySum = 0;
         }
 
+        // Update travelled distances
+        updateDirectionSigns(kineticState);
+
+        kineticState->xSum += distance * kineticState->horizontalStateSign;
+        kineticState->ySum += distance * kineticState->verticalStateSign;
+
         // Update horizontal state
 
-        bool horizontalMovement = true;
-        if (activeMouseStates[kineticState->leftState]) {
-            kineticState->xSum -= distance;
-        } else if (activeMouseStates[kineticState->rightState]) {
-            kineticState->xSum += distance;
-        } else {
-            horizontalMovement = false;
-        }
+        bool horizontalMovement = kineticState->horizontalStateSign != 0;
 
         float xSumInt;
         float xSumFrac = modff(kineticState->xSum, &xSumInt);
         kineticState->xSum = xSumFrac;
         kineticState->xOut = xSumInt;
 
+        /* Handle the first scroll tick. */
         if (kineticState->isScroll && !kineticState->wasMoveAction && kineticState->xOut == 0 && horizontalMovement) {
             kineticState->xOut = activeMouseStates[kineticState->leftState] ? -1 : 1;
             kineticState->xSum = 0;
@@ -133,20 +187,14 @@ static void processMouseKineticState(mouse_kinetic_state_t *kineticState)
 
         // Update vertical state
 
-        bool verticalMovement = true;
-        if (activeMouseStates[kineticState->upState]) {
-            kineticState->ySum -= distance;
-        } else if (activeMouseStates[kineticState->downState]) {
-            kineticState->ySum += distance;
-        } else {
-            verticalMovement = false;
-        }
+        bool verticalMovement = kineticState->verticalStateSign != 0;
 
         float ySumInt;
         float ySumFrac = modff(kineticState->ySum, &ySumInt);
         kineticState->ySum = ySumFrac;
         kineticState->yOut = ySumInt;
 
+        /* Handle the first scroll tick. */
         if (kineticState->isScroll && !kineticState->wasMoveAction && kineticState->yOut == 0 && verticalMovement) {
             kineticState->yOut = activeMouseStates[kineticState->upState] ? -1 : 1;
             kineticState->ySum = 0;
@@ -298,6 +346,7 @@ static void applyKeyAction(key_state_t *keyState, key_action_t *action, uint8_t 
             case KeyActionType_Mouse:
                 if (KeyState_ActivatedNow(keyState)) {
                     stickyModifiers = 0;
+                    activateDirectionSigns(action->mouseAction);
                 }
                 activeMouseStates[action->mouseAction] = true;
                 break;

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -67,10 +67,8 @@ static void updateOneDirectionSign(int8_t* sign, int8_t expectedSign, uint8_t ex
     }
 }
 
-/*
- * Assume that mouse movement key has been just released. In that case check if there is another key which keeps the state active.
- * If not, check whether the other direction state is active and either flip movement direction or zero the state.
- */
+// Assume that mouse movement key has been just released. In that case check if there is another key which keeps the state active.
+// If not, check whether the other direction state is active and either flip movement direction or zero the state.
 static void updateDirectionSigns(mouse_kinetic_state_t *kineticState) {
     updateOneDirectionSign(&kineticState->horizontalStateSign, -1, kineticState->leftState, kineticState->rightState);
     updateOneDirectionSign(&kineticState->horizontalStateSign,  1, kineticState->rightState, kineticState->leftState);
@@ -78,10 +76,8 @@ static void updateDirectionSigns(mouse_kinetic_state_t *kineticState) {
     updateOneDirectionSign(&kineticState->verticalStateSign,  1, kineticState->downState, kineticState->upState);
 }
 
-/*
- * Called on keydown of mouse action. Direction signs ensure that the last pressed action always takes precedence, and therefore
- * have to be updated statefully.
- */
+// Called on keydown of mouse action. Direction signs ensure that the last pressed action always takes precedence, and therefore
+// have to be updated statefully.
 static void activateDirectionSigns(uint8_t state) {
     switch (state) {
     case SerializedMouseAction_MoveUp:
@@ -165,6 +161,7 @@ static void processMouseKineticState(mouse_kinetic_state_t *kineticState)
         }
 
         // Update travelled distances
+
         updateDirectionSigns(kineticState);
 
         kineticState->xSum += distance * kineticState->horizontalStateSign;
@@ -179,7 +176,7 @@ static void processMouseKineticState(mouse_kinetic_state_t *kineticState)
         kineticState->xSum = xSumFrac;
         kineticState->xOut = xSumInt;
 
-        /* Handle the first scroll tick. */
+        // Handle the first scroll tick.
         if (kineticState->isScroll && !kineticState->wasMoveAction && kineticState->xOut == 0 && horizontalMovement) {
             kineticState->xOut = activeMouseStates[kineticState->leftState] ? -1 : 1;
             kineticState->xSum = 0;
@@ -194,7 +191,7 @@ static void processMouseKineticState(mouse_kinetic_state_t *kineticState)
         kineticState->ySum = ySumFrac;
         kineticState->yOut = ySumInt;
 
-        /* Handle the first scroll tick. */
+        // Handle the first scroll tick.
         if (kineticState->isScroll && !kineticState->wasMoveAction && kineticState->yOut == 0 && verticalMovement) {
             kineticState->yOut = activeMouseStates[kineticState->upState] ? -1 : 1;
             kineticState->ySum = 0;

--- a/right/src/usb_report_updater.h
+++ b/right/src/usb_report_updater.h
@@ -65,6 +65,8 @@
         float ySum;
         int16_t xOut;
         int16_t yOut;
+        int8_t verticalStateSign;
+        int8_t horizontalStateSign;
     } mouse_kinetic_state_t;
 
 // Variables:


### PR DESCRIPTION
Solves symmetry problem mentioned in #256 .

I am afraid that this adds a bit of complexity into the code, unfortunately I don't see any way around.

Basically, I am extracting "sign" related switches from 115 and 136 into their own functions, and adding them into the kinetic state.

Please test that up&down scrolling works as expected on Mac. 