### PR TITLE
fix make-release script

### DIFF
--- a/scripts/make-release.js
+++ b/scripts/make-release.js
@@ -25,6 +25,7 @@ const sourcePaths = [
 ];
 for (sourcePath of sourcePaths) {
     const buildDir = path.dirname(`${__dirname}/../${sourcePath}`);
+    exec(`mkdir -p ${buildDir}`);
     exec(`cd ${buildDir}/..; make clean; make -j8`);
 }
 


### PR DESCRIPTION
If the user has not ran all makes manually first, the `build_make` directory (which is part of `${buildDir}` does not exist and therefore the cd on line 29 fails. 

