### PR TITLE
Fix memory corruption in led_display driver

### DIFF
--- a/right/src/led_display.c
+++ b/right/src/led_display.c
@@ -5,7 +5,7 @@
 
 uint8_t IconsAndLayerTextsBrightness = 0xff;
 uint8_t AlphanumericSegmentsBrightness = 0xff;
-bool ledIconStates[LedDisplayIcon_Last];
+bool ledIconStates[LedDisplayIcon_Count];
 char LedDisplay_DebugString[] = "   ";
 
 static const uint16_t letterToSegmentMap[] = {


### PR DESCRIPTION
What happened here (in case it is not obvious):
`LedDisplayIcon_Last` allocated array of 2 states instead of 3. As a result, writing adaptive mode led resulted into rewriting someone else's piece of memory - whatever the linker placed right after the `ledIconStates` array. In this case it blew up macro recorder on my fork. 

Please, lets be careful about memory corruptions (allocations, indices, etc.). These bugs can be pretty nasty, and today I was very lucky to be able to hunt it down so easily.