### PR TITLE
Fix toggle key

### DIFF
--- a/right/src/layer.c
+++ b/right/src/layer.c
@@ -15,12 +15,13 @@ void updateLayerStates(void)
     for (uint8_t slotId=0; slotId<SLOT_COUNT; slotId++) {
         for (uint8_t keyId=0; keyId<MAX_KEY_COUNT_PER_MODULE; keyId++) {
             key_state_t *keyState = &KeyStates[slotId][keyId];
-            if (keyState->current) {
+            if (KeyState_Active(keyState)) {
                 key_action_t action = CurrentKeymap[LayerId_Base][slotId][keyId];
                 if (action.type == KeyActionType_SwitchLayer) {
                     if (action.switchLayer.mode != SwitchLayerMode_Toggle) {
                         heldLayers[action.switchLayer.layer] = true;
-                    } else if (!keyState->previous) {
+                    }
+                    if (action.switchLayer.mode == SwitchLayerMode_Toggle && KeyState_ActivatedNow(keyState)) {
                         toggledLayers[action.switchLayer.layer] = true;
                     }
                 }
@@ -39,10 +40,13 @@ layer_id_t GetActiveLayer()
     // Handle toggled layers
 
     for (layer_id_t layerId=LayerId_Mod; layerId<=LayerId_Mouse; layerId++) {
+        // Toggle for the layer is in ActivatedNow state
         if (toggledLayers[layerId]) {
+            // if toggled, untoggle
             if (ToggledLayer == layerId) {
                 ToggledLayer = LayerId_Base;
                 break;
+            // if not toggled, toggle it            // this part of condition is already implied by updateLayerStates
             } else if (ToggledLayer == LayerId_Base && toggledLayers[layerId] == SwitchLayerMode_Toggle) {
                 ToggledLayer = layerId;
                 break;

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -525,10 +525,6 @@ static void updateActiveUsbReports(void)
         return;
     }
 
-    if ( PostponerCore_IsActive() ) {
-        PostponerCore_RunPostponedEvents();
-    }
-
     memset(activeMouseStates, 0, ACTIVE_MOUSE_STATES_COUNT);
 
     basicScancodeIndex = 0;
@@ -571,6 +567,20 @@ static void updateActiveUsbReports(void)
         }
     }
 
+    // This has to happen:
+    // - after GetActiveLayer()
+    // - before new key activations via Postponer
+    for (uint8_t slotId=0; slotId<SLOT_COUNT; slotId++) {
+        for (uint8_t keyId=0; keyId<MAX_KEY_COUNT_PER_MODULE; keyId++) {
+            key_state_t *keyState = &KeyStates[slotId][keyId];
+            keyState->previous = keyState->current;
+        }
+    }
+
+    if ( PostponerCore_IsActive() ) {
+        PostponerCore_RunPostponedEvents();
+    }
+
     for (uint8_t slotId=0; slotId<SLOT_COUNT; slotId++) {
         for (uint8_t keyId=0; keyId<MAX_KEY_COUNT_PER_MODULE; keyId++) {
             key_state_t *keyState = &KeyStates[slotId][keyId];
@@ -595,8 +605,6 @@ static void updateActiveUsbReports(void)
             if (KeyState_NonZero(keyState)) {
                 applyKeyAction(keyState, action, slotId, keyId);
             }
-
-            keyState->previous = keyState->current;
         }
     }
 


### PR DESCRIPTION
Broken by postponer-related changes in the keystate flow and the fact that the layer activations are done "outside" of the flow.

The layer switching code is in a pretty bad shape, unfortunatelly, for some hold layer scenarios, it is quite hard to decide what is actually a feature and what is a bug.

Closes #291 .