### PR TITLE
Fix held layer flag.

### DIFF
--- a/right/src/layer_switcher.c
+++ b/right/src/layer_switcher.c
@@ -53,7 +53,7 @@ void updateActiveLayer() {
     }
     //(write actual ActiveLayer atomically, so that random observer is not confused)
     ActiveLayer = activeLayer;
-    ActiveLayerHeld = heldLayer == ActiveLayer;
+    ActiveLayerHeld = heldLayer == ActiveLayer && ActiveLayer != LayerId_Base;
 
 }
 


### PR DESCRIPTION
The refactor accidentally made base layer clasify as "held layer", which made sticky mods stick on base layer (which is wrong).