### PR TITLE
Simplify building firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ If you want to use the latest firmware version for your UHK, then instead of goi
 
 If you're one of the brave few who wants to hack the firmware then read on.
 
+## Building
+
+1. Make sure to clone this repo with:
+
+`git clone --recursive git@github.com:UltimateHackingKeyboard/firmware.git`
+
+2. Install `arm-none-eabi-binutils`, `arm-none-eabi-gcc`, `arm-none-eabi-newlib` and Node.js v12.
+
+3. `cd scripts && npm install && ./make-release.js --skip-agent`
+
+## Full development setup
+
 1. Make sure to clone this repo with:
 
 `git clone --recursive git@github.com:UltimateHackingKeyboard/firmware.git`

--- a/scripts/make-release.js
+++ b/scripts/make-release.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 const fs = require('fs');
 const path = require('path');
 require('shelljs/global');
@@ -29,7 +30,12 @@ for (sourcePath of sourcePaths) {
     exec(`cd ${buildDir}/..; make clean; make -j8`);
 }
 
-exec(`git pull origin master; git checkout master; npm ci; npm run build`, { cwd: agentDir });
+// --skip-agent: don't build Agent, just get minimal dependencies
+if (process.argv.slice(2).includes("--skip-agent")) {
+    exec('npm ci', { cwd: agentDir });
+} else {
+    exec(`git pull origin master; git checkout master; npm ci; npm run build`, { cwd: agentDir });
+}
 
 for (const device of package.devices) {
     const deviceDir = `${releaseDir}/devices/${device.name}`;


### PR DESCRIPTION
- add make-release.js option --skip-agent to avoid building the agent
- add instructions for the simplest way of building the firmware