### PR TITLE
WIP / RFC: commands for setting led segments

### DIFF
--- a/right/src/led_display.c
+++ b/right/src/led_display.c
@@ -116,16 +116,22 @@ static const uint8_t segmentLedIds[maxSegmentChars][ledCountPerChar] = {
     {105, 121, 124, 136, 137, 106, 122, 123, 120, 138, 139, 140, 107, 108},
 };
 
+void LedDisplay_SetRawSegment(uint8_t charId, uint16_t charBits) {
+    if (charId > 2) return;
+
+    for (uint8_t ledId=0; ledId<ledCountPerChar; ledId++) {
+        uint8_t ledIdx = segmentLedIds[charId][ledId];
+        bool isLedOn = charBits & (1 << ledId);
+        LedDriverValues[LedDriverId_Left][ledIdx] = isLedOn ? AlphanumericSegmentsBrightness : 0;
+    }
+}
+
 void LedDisplay_SetText(uint8_t length, const char* text)
 {
     for (uint8_t charId=0; charId<LED_DISPLAY_KEYMAP_NAME_LENGTH; charId++) {
         char keymapChar = charId < length ? text[charId] : ' ';
         uint16_t charBits = letterToSegmentMap[keymapChar - ' '];
-        for (uint8_t ledId=0; ledId<ledCountPerChar; ledId++) {
-            uint8_t ledIdx = segmentLedIds[charId][ledId];
-            bool isLedOn = charBits & (1 << ledId);
-            LedDriverValues[LedDriverId_Left][ledIdx] = isLedOn ? AlphanumericSegmentsBrightness : 0;
-        }
+        LedDisplay_SetRawSegment(charId, charBits);
     }
 }
 

--- a/right/src/led_display.h
+++ b/right/src/led_display.h
@@ -30,6 +30,7 @@
 
 // Functions:
 
+    void LedDisplay_SetRawSegment(uint8_t charId, uint16_t charBits);
     void LedDisplay_SetText(uint8_t length, const char* text);
     void LedDisplay_SetLayer(layer_id_t layerId);
     bool LedDisplay_GetIcon(led_display_icon_t icon);

--- a/right/src/usb_commands/usb_command_set_led_segments.c
+++ b/right/src/usb_commands/usb_command_set_led_segments.c
@@ -1,0 +1,17 @@
+#include "usb_protocol_handler.h"
+#include "usb_commands/usb_command_set_led_segments.h"
+#include "led_display.h"
+
+void UsbCommand_SetLedSegments_Raw() {
+    LedDisplay_SetRawSegment(0, GetUsbRxBufferUint16(1));
+    LedDisplay_SetRawSegment(1, GetUsbRxBufferUint16(3));
+    LedDisplay_SetRawSegment(2, GetUsbRxBufferUint16(5));
+}
+
+void UsbCommand_SetLedSegments_Text() {
+    char text[3];
+    text[0] = GetUsbRxBufferUint8(1);
+    text[1] = GetUsbRxBufferUint8(2);
+    text[2] = GetUsbRxBufferUint8(3);
+    LedDisplay_SetText(3, text);
+}

--- a/right/src/usb_commands/usb_command_set_led_segments.h
+++ b/right/src/usb_commands/usb_command_set_led_segments.h
@@ -1,0 +1,9 @@
+#ifndef __USB_COMMAND_SET_LED_SEGMENTS_H__
+#define __USB_COMMAND_SET_LED_SEGMENTS_H__
+
+// Functions:
+
+    void UsbCommand_SetLedSegments_Raw(void);
+    void UsbCommand_SetLedSegments_Text(void);
+
+#endif

--- a/right/src/usb_protocol_handler.c
+++ b/right/src/usb_protocol_handler.c
@@ -85,6 +85,12 @@ void UsbProtocolHandler(void)
         case UsbCommandId_SetVariable:
             UsbCommand_SetVariable();
             break;
+        case UsbCommandId_SetLedSegments_Text:
+            UsbCommand_SetLedSegments_Text();
+            break;
+        case UsbCommandId_SetLedSegments_Raw:
+            UsbCommand_SetLedSegments_Raw();
+            break;
         default:
             SetUsbTxBufferUint8(0, UsbStatusCode_InvalidCommand);
             break;

--- a/right/src/usb_protocol_handler.h
+++ b/right/src/usb_protocol_handler.h
@@ -36,6 +36,9 @@
         UsbCommandId_SwitchKeymap             = 0x11,
         UsbCommandId_GetVariable              = 0x12,
         UsbCommandId_SetVariable              = 0x13,
+
+        UsbCommandId_SetLedSegments_Text      = 0x21,
+        UsbCommandId_SetLedSegments_Raw       = 0x22,
     } usb_command_id_t;
 
     typedef enum {


### PR DESCRIPTION
So, here's some code. Thanks for the hint about using the same command system as for everything else. I was planning to fully model the display as a HID feature with usage pages, reports and all, but that's probably overkill. The only slight downside of this much simpler approach is that it's vendor specific. But there probably are no generic HID segment display drivers anyway.

For this firmware patch there's proof-of-concept userspace code for writing to the display at https://github.com/dancek/uhk-leds/blob/master/src/main.rs .

I arbitrarily chose the command ids 0x21 and 0x22 but expect them to change. Please recommend whatever suits your plans.

Any code review is welcome, as are comments regarding what should be done so this can be included in the official firmware (as opposed to a fork).