### PR TITLE
fix: change device ids

### DIFF
--- a/shared/device.h
+++ b/shared/device.h
@@ -3,8 +3,8 @@
 
 // Macros:
 
-    #define DEVICE_ID_UHK60V1 0
-    #define DEVICE_ID_UHK60V2 1
+    #define DEVICE_ID_UHK60V1 1
+    #define DEVICE_ID_UHK60V2 2
 
 #ifndef DEVICE_ID
     #error "DEVICE_ID is undefined!"


### PR DESCRIPTION
When implemented the UltimateHackingKeyboard/agent#1483 identified the current v1 device uses `1` deviceId.