### PR TITLE
Enable and fix additional warnings, switch to -O3 and LTO.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,30 @@
+kind: pipeline
+name: Build (Arch)
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: Fetch Submodules
+  image: alpine/git
+  commands:
+  - git submodule init
+  - git submodule update --recursive
+
+- name: Build (Ubuntu Linux)
+  image: abcminiuser/docker-ci-arm-toolchain:latest
+  pull: always
+  commands:
+  - make -j -C left DEBUG=1
+  - make -j -C left DEBUG=0
+  - make -j -C right/uhk60v1 DEBUG=1
+  - make -j -C right/uhk60v1 DEBUG=0
+  - make -j -C right/uhk60v2 DEBUG=1
+  - make -j -C right/uhk60v2 DEBUG=0
+  - make -j -C keycluster DEBUG=1
+  - make -j -C keycluster DEBUG=0
+  - make -j -C trackball DEBUG=1
+  - make -j -C trackball DEBUG=0
+  - make -j -C trackpoint DEBUG=1
+  - make -j -C trackpoint DEBUG=0

--- a/keycluster/src/module.c
+++ b/keycluster/src/module.c
@@ -38,6 +38,7 @@ key_vector_t keyVector = {
         {PORTB, GPIOB, kCLOCK_PortB,  7}, // trackball microswitch
         {PORTA, GPIOA, kCLOCK_PortA,  8}, // right microswitch
     },
+    .keyStates = {0}
 };
 
 void BlackberryTrackball_Init(void)

--- a/left/src/module.c
+++ b/left/src/module.c
@@ -20,7 +20,8 @@ key_matrix_t keyMatrix = {
         {PORTA, GPIOA, kCLOCK_PortA,  5},
         {PORTA, GPIOA, kCLOCK_PortA,  7},
         {PORTA, GPIOA, kCLOCK_PortA,  4}
-    }
+    },
+    .keyStates = {0}
 };
 
 void Module_Init(void)

--- a/right/src/buspal/bm_usb/usb_descriptor.c
+++ b/right/src/buspal/bm_usb/usb_descriptor.c
@@ -48,6 +48,7 @@ usb_device_interface_struct_t g_hid_generic_interface[] = { {
         USB_HID_GENERIC_ENDPOINT_COUNT, /* Endpoint count */
         g_hid_generic_endpoints,        /* Endpoints handle */
     },
+    NULL
 } };
 
 usb_device_interfaces_struct_t g_hid_generic_interfaces[USB_HID_GENERIC_INTERFACE_COUNT] = { {

--- a/right/src/config_parser/config_globals.c
+++ b/right/src/config_parser/config_globals.c
@@ -7,9 +7,9 @@ static uint8_t ATTR_DATA2 stagingUserConfig[USER_CONFIG_SIZE];
 static uint8_t validatedUserConfig[USER_CONFIG_SIZE];
 
 uint16_t ValidatedUserConfigLength;
-config_buffer_t HardwareConfigBuffer = { hardwareConfig };
-config_buffer_t StagingUserConfigBuffer = { stagingUserConfig };
-config_buffer_t ValidatedUserConfigBuffer = { validatedUserConfig };
+config_buffer_t HardwareConfigBuffer = { .buffer = hardwareConfig, .offset = 0 };
+config_buffer_t StagingUserConfigBuffer = { .buffer = stagingUserConfig, .offset = 0 };
+config_buffer_t ValidatedUserConfigBuffer = { .buffer = validatedUserConfig, .offset = 0 };
 
 hardware_config_t *HardwareConfig = (hardware_config_t*)hardwareConfig;
 

--- a/right/src/macros.c
+++ b/right/src/macros.c
@@ -271,6 +271,7 @@ bool processKeyAction(void)
                     pressPhase = 0;
                     return false;
             }
+            break;
         case MacroSubAction_Release:
             switch (pressPhase) {
                 case 1:
@@ -281,6 +282,7 @@ bool processKeyAction(void)
                     pressPhase = 0;
                     return false;
             }
+            break;
         case MacroSubAction_Press:
             switch (pressPhase) {
                 case 1:
@@ -291,6 +293,7 @@ bool processKeyAction(void)
                     pressPhase = 0;
                     return false;
             }
+            break;
     }
     return false;
 }

--- a/right/src/right_key_matrix.c
+++ b/right/src/right_key_matrix.c
@@ -20,5 +20,6 @@ key_matrix_t RightKeyMatrix = {
         {PORTC, GPIOC, kCLOCK_PortC, 1},
         {PORTC, GPIOC, kCLOCK_PortC, 0},
         {PORTD, GPIOD, kCLOCK_PortD, 5}
-    }
+    },
+    .keyStates = {0}
 };

--- a/scripts/Makedefs.mk
+++ b/scripts/Makedefs.mk
@@ -87,6 +87,9 @@ CFLAGS = -mthumb                    \
          -Wdouble-promotion         \
          -Woverflow                 \
          -Wall                      \
+         -Wextra                    \
+         -Wno-unused-parameter      \
+         -Wno-type-limits           \
          -Wshadow                   \
          -flto                      \
          $(BUILD_FLAGS)

--- a/scripts/Makedefs.mk
+++ b/scripts/Makedefs.mk
@@ -91,7 +91,6 @@ CFLAGS = -mthumb                    \
          -Wno-unused-parameter      \
          -Wno-type-limits           \
          -Wshadow                   \
-         -flto                      \
          $(BUILD_FLAGS)
 
 # Compiler options for C++ only.

--- a/scripts/Makedefs.mk
+++ b/scripts/Makedefs.mk
@@ -88,6 +88,7 @@ CFLAGS = -mthumb                    \
          -Woverflow                 \
          -Wall                      \
          -Wshadow                   \
+         -flto                      \
          $(BUILD_FLAGS)
 
 # Compiler options for C++ only.
@@ -123,9 +124,9 @@ endif
 # Check if the DEBUG environment variable is set.
 DEBUG ?= 0
 ifeq ($(DEBUG),1)
-    CFLAGS += -O3 -g3 -DDEBUG
+    CFLAGS += -Os -g3 -DDEBUG
 else
-    CFLAGS += -O3 -DNDEBUG
+    CFLAGS += -Os -DNDEBUG
 endif
 
 # Add the include file paths to AFLAGS and CFLAGS.

--- a/shared/bool_array_converter.c
+++ b/shared/bool_array_converter.c
@@ -1,7 +1,7 @@
 #include <string.h>
 #include "bool_array_converter.h"
 
-void BoolBytesToBits(uint8_t *srcBytes, uint8_t *dstBits, uint8_t byteCount)
+void BoolBytesToBits(const uint8_t *srcBytes, uint8_t *dstBits, uint8_t byteCount)
 {
     memset(dstBits, 0, byteCount/8 + (byteCount % 8 ? 1 : 0));
     for (uint8_t i=0; i<byteCount; i++) {

--- a/shared/bool_array_converter.h
+++ b/shared/bool_array_converter.h
@@ -11,7 +11,7 @@
 
 // Functions:
 
-    void BoolBytesToBits(uint8_t *srcBytes, uint8_t *dstBits, uint8_t byteCount);
+    void BoolBytesToBits(const uint8_t *srcBytes, uint8_t *dstBits, uint8_t byteCount);
     void BoolBitsToBytes(uint8_t *srcBits, uint8_t *dstBytes, uint8_t byteCount);
 
 #endif

--- a/shared/buffer.c
+++ b/shared/buffer.c
@@ -1,31 +1,31 @@
 #include "buffer.h"
 
-uint8_t GetBufferUint8(uint8_t *buffer, uint32_t offset)
+uint8_t GetBufferUint8(const uint8_t *buffer, uint32_t offset)
 {
-    return *(uint8_t*)(buffer + offset);
+    return *(const uint8_t*)(buffer + offset);
 }
 
-uint16_t GetBufferUint16(uint8_t *buffer, uint32_t offset)
+uint16_t GetBufferUint16(const uint8_t *buffer, uint32_t offset)
 {
-    return *(uint16_t*)(buffer+ offset);
+    return *(const uint16_t*)(buffer+ offset);
 }
 
-uint32_t GetBufferUint32(uint8_t *buffer, uint32_t offset)
+uint32_t GetBufferUint32(const uint8_t *buffer, uint32_t offset)
 {
-    return *(uint32_t*)(buffer + offset);
+    return *(const uint32_t*)(buffer + offset);
 }
 
-uint8_t  GetBufferUint8Be(uint8_t *buffer, uint32_t offset)
+uint8_t  GetBufferUint8Be(const uint8_t *buffer, uint32_t offset)
 {
     return buffer[offset];
 }
 
-uint16_t GetBufferUint16Be(uint8_t *buffer, uint32_t offset)
+uint16_t GetBufferUint16Be(const uint8_t *buffer, uint32_t offset)
 {
     return (buffer[offset] << 8) + (buffer[offset+1] << 0);
 }
 
-uint32_t GetBufferUint32Be(uint8_t *buffer, uint32_t offset)
+uint32_t GetBufferUint32Be(const uint8_t *buffer, uint32_t offset)
 {
     return (buffer[offset] << 24) + (buffer[offset+1] << 16) + (buffer[offset+2] << 8) + (buffer[offset+3] << 0);
 }

--- a/shared/buffer.h
+++ b/shared/buffer.h
@@ -7,13 +7,13 @@
 
 // Functions:
 
-    uint8_t  GetBufferUint8(uint8_t *buffer, uint32_t offset);
-    uint16_t GetBufferUint16(uint8_t *buffer, uint32_t offset);
-    uint32_t GetBufferUint32(uint8_t *buffer, uint32_t offset);
+    uint8_t  GetBufferUint8(const uint8_t *buffer, uint32_t offset);
+    uint16_t GetBufferUint16(const uint8_t *buffer, uint32_t offset);
+    uint32_t GetBufferUint32(const uint8_t *buffer, uint32_t offset);
 
-    uint8_t  GetBufferUint8Be(uint8_t *buffer, uint32_t offset);
-    uint16_t GetBufferUint16Be(uint8_t *buffer, uint32_t offset);
-    uint32_t GetBufferUint32Be(uint8_t *buffer, uint32_t offset);
+    uint8_t  GetBufferUint8Be(const uint8_t *buffer, uint32_t offset);
+    uint16_t GetBufferUint16Be(const uint8_t *buffer, uint32_t offset);
+    uint32_t GetBufferUint32Be(const uint8_t *buffer, uint32_t offset);
 
     void SetBufferUint8(uint8_t *buffer, uint32_t offset, uint8_t value);
     void SetBufferUint16(uint8_t *buffer, uint32_t offset, uint16_t value);
@@ -23,7 +23,7 @@
     void SetBufferInt16(uint8_t *buffer, uint32_t offset, int16_t value);
     void SetBufferInt32(uint8_t *buffer, uint32_t offset, int32_t value);
 
-    void  SetBufferUint8Be(uint8_t *buffer, uint32_t offset, uint8_t value);
+    void SetBufferUint8Be(uint8_t *buffer, uint32_t offset, uint8_t value);
     void SetBufferUint16Be(uint8_t *buffer, uint32_t offset, uint16_t value);
     void SetBufferUint32Be(uint8_t *buffer, uint32_t offset, uint32_t value);
 

--- a/trackball/src/module.c
+++ b/trackball/src/module.c
@@ -44,6 +44,7 @@ key_vector_t keyVector = {
         {PORTA, GPIOA, kCLOCK_PortA, 3}, // left button
         {PORTA, GPIOA, kCLOCK_PortA, 12}, // right button
     },
+    .keyStates = {0}
 };
 
 #define BUFFER_SIZE 2

--- a/trackpoint/src/module.c
+++ b/trackpoint/src/module.c
@@ -9,6 +9,7 @@ key_vector_t keyVector = {
         {PORTB, GPIOB, kCLOCK_PortB,  5}, // left microswitch
         {PORTA, GPIOA, kCLOCK_PortA,  12}, // right microswitch
     },
+    .keyStates = {0}
 };
 
 void Module_Init(void)
@@ -18,7 +19,7 @@ void Module_Init(void)
     CLOCK_EnableClock(PS2_CLOCK_CLOCK);
     PORT_SetPinConfig(PS2_CLOCK_PORT, PS2_CLOCK_PIN,
                       &(port_pin_config_t){/*.pullSelect=kPORT_PullDown,*/ .mux=kPORT_MuxAsGpio});
-    GPIO_PinInit(PS2_CLOCK_GPIO, PS2_CLOCK_PIN, &(gpio_pin_config_t){kGPIO_DigitalInput});
+    GPIO_PinInit(PS2_CLOCK_GPIO, PS2_CLOCK_PIN, &(gpio_pin_config_t){.pinDirection=kGPIO_DigitalInput, .outputLogic=0});
 
     PORT_SetPinInterruptConfig(PS2_CLOCK_PORT, PS2_CLOCK_PIN, kPORT_InterruptEitherEdge);
     EnableIRQ(PS2_CLOCK_IRQ);
@@ -27,7 +28,7 @@ void Module_Init(void)
     CLOCK_EnableClock(PS2_DATA_CLOCK);
     PORT_SetPinConfig(PS2_DATA_PORT, PS2_DATA_PIN,
                       &(port_pin_config_t){/*.pullSelect=kPORT_PullDown,*/ .mux=kPORT_MuxAsGpio});
-    GPIO_PinInit(PS2_DATA_GPIO, PS2_DATA_PIN, &(gpio_pin_config_t){kGPIO_DigitalInput});
+    GPIO_PinInit(PS2_DATA_GPIO, PS2_DATA_PIN, &(gpio_pin_config_t){.pinDirection=kGPIO_DigitalInput, .outputLogic=0});
 
 }
 
@@ -40,14 +41,14 @@ uint32_t downTransitionCount = 0;
 void requestToSend()
 {
     for (volatile uint32_t i=0; i<150; i++);
-    GPIO_PinInit(PS2_CLOCK_GPIO, PS2_CLOCK_PIN, &(gpio_pin_config_t){kGPIO_DigitalOutput});
+    GPIO_PinInit(PS2_CLOCK_GPIO, PS2_CLOCK_PIN, &(gpio_pin_config_t){.pinDirection=kGPIO_DigitalOutput, .outputLogic=0});
     GPIO_WritePinOutput(PS2_CLOCK_GPIO, PS2_CLOCK_PIN, 0);
     for (volatile uint32_t i=0; i<150; i++);
-    GPIO_PinInit(PS2_DATA_GPIO, PS2_DATA_PIN, &(gpio_pin_config_t){kGPIO_DigitalOutput});
+    GPIO_PinInit(PS2_DATA_GPIO, PS2_DATA_PIN, &(gpio_pin_config_t){.pinDirection=kGPIO_DigitalOutput, .outputLogic=0});
     GPIO_WritePinOutput(PS2_DATA_GPIO, PS2_DATA_PIN, 0);
     for (volatile uint32_t i=0; i<150; i++);
     GPIO_WritePinOutput(PS2_CLOCK_GPIO, PS2_CLOCK_PIN, 1);
-    GPIO_PinInit(PS2_CLOCK_GPIO, PS2_CLOCK_PIN, &(gpio_pin_config_t){kGPIO_DigitalInput});
+    GPIO_PinInit(PS2_CLOCK_GPIO, PS2_CLOCK_PIN, &(gpio_pin_config_t){.pinDirection=kGPIO_DigitalInput, .outputLogic=0});
 }
 
 uint8_t bitId = 0;
@@ -59,7 +60,7 @@ bool writeByte()
     static bool parityBit;
 
     if (bitId == 10 && clockState == 0) {
-        GPIO_PinInit(PS2_DATA_GPIO, PS2_DATA_PIN, &(gpio_pin_config_t){kGPIO_DigitalInput});
+        GPIO_PinInit(PS2_DATA_GPIO, PS2_DATA_PIN, &(gpio_pin_config_t){.pinDirection=kGPIO_DigitalInput, .outputLogic=0});
         return true;
     }
 
@@ -71,7 +72,7 @@ bool writeByte()
         case 0 ... 7: {
             if (bitId == 0) {
                 parityBit = 1;
-                GPIO_PinInit(PS2_DATA_GPIO, PS2_DATA_PIN, &(gpio_pin_config_t){kGPIO_DigitalOutput});
+                GPIO_PinInit(PS2_DATA_GPIO, PS2_DATA_PIN, &(gpio_pin_config_t){.pinDirection=kGPIO_DigitalOutput, .outputLogic=0});
             }
             bool dataBit = buffer & (1 << bitId);
             if (dataBit) {

--- a/trackpoint/src/module.c
+++ b/trackpoint/src/module.c
@@ -170,6 +170,7 @@ void PS2_CLOCK_IRQ_HANDLER(void) {
             bitId = 0;
             buffer = 0xf4;
             phase = 5;
+            break;
         }
         case 5: {
             if (writeByte()) {


### PR DESCRIPTION
This is more of a RFC than an actual request to pull as-is. I'm just getting acquainted with the project and code.

This is a roll-up of several minor changes:

1) *Switching from -O3 to -Os*. Most ARM embedded platforms don't really gain a whole lot from -O3 other than code bloat, and generally any hot loops can be marked as such with attributes, or compiled with alternative settings.

2) *Enabling Link Time Optimization*. As long as we're OK targeting modern GCC installations, i.e. GCC 8+, LTO is quite stable for ARM Cortex M. This greatly reduces the code size and helps inlining across translation units, leading to smaller and faster code.

Right V2 firmware with -O3:
```
Memory region         Used Size  Region Size  %age Used
    m_interrupts:          1 KB         1 KB    100.00%
          m_text:         52 KB       463 KB     11.23%
          m_data:       53496 B        64 KB     81.63%
        m_data_2:       41920 B      65280 B     64.22%
        m_noinit:          16 B        255 B      6.27%
```

Right V2 firmware with LTO and -Os:
```
Memory region         Used Size  Region Size  %age Used
    m_interrupts:          1 KB         1 KB    100.00%
          m_text:       39384 B       463 KB      8.31%
          m_data:       52288 B        64 KB     79.79%
        m_data_2:       41920 B      65280 B     64.22%
        m_noinit:          16 B        255 B      6.27%
```

3) *Enabling additional warnings*. Fairly self-explanatory. I've disabled some of the nosier ones that are enabled with `-Wextra` and patched the code to fix the new warnings that were generated.

4) *Add missing `const` to pointer params`. Just a few instances I noticed where functions that were not expected to alter their pointer arguments pass into them, which I've now altered to be passed as `const T*`.



I've built and tested the repo on my local Drone CI, and built/flashed my new V2 unit with it without any apparent issues.