### PR TITLE
Ensure LEDs are updated on the key cluster when it is initialized.

### DIFF
--- a/right/src/slave_drivers/is31fl3xxx_driver.c
+++ b/right/src/slave_drivers/is31fl3xxx_driver.c
@@ -208,7 +208,7 @@ void LedSlaveDriver_Init(uint8_t ledDriverId)
     currentLedDriverState->ledIndex = 0;
     memset(LedDriverValues[ledDriverId], KeyBacklightBrightness, currentLedDriverState->ledCount);
 
-    if (ledDriverId == LedDriverId_Left) {
+    if (ledDriverId == LedDriverId_Left || ledDriverId == LedDriverId_ModuleLeft) {
         UpdateLayerLeds();
         LedDisplay_UpdateAll();
     }

--- a/right/src/slave_scheduler.c
+++ b/right/src/slave_scheduler.c
@@ -83,12 +83,11 @@ static void slaveSchedulerCallback(I2C_Type *base, i2c_master_handle_t *handle, 
             if (wasPreviousSlaveConnected && !previousSlave->isConnected && previousSlave->disconnect) {
                 previousSlave->disconnect(previousSlaveId);
             }
+            else if (! wasPreviousSlaveConnected && previousSlave->isConnected) {
+                previousSlave->init(previousSlave->perDriverId);
+            }
 
             isFirstCycle = false;
-        }
-
-        if (!currentSlave->isConnected) {
-            currentSlave->init(currentSlave->perDriverId);
         }
 
         status_t currentStatus = currentSlave->update(currentSlave->perDriverId);
@@ -115,6 +114,7 @@ void InitSlaveScheduler(void)
     for (uint8_t i=0; i<SLAVE_COUNT; i++) {
         uhk_slave_t *currentSlave = Slaves + i;
         currentSlave->isConnected = false;
+        currentSlave->init(currentSlave->perDriverId);
     }
 
     I2C_MasterTransferCreateHandle(I2C_MAIN_BUS_BASEADDR, &I2cMasterHandle, slaveSchedulerCallback, NULL);


### PR DESCRIPTION
Fixes #366.

When the key cluster is hot-swapped in, the LED driver wasn't pushing the initial LED driver states over correctly. This fixes that (although it's not immediately obvious to me why the module ID checks are needed at all) and updates the slave scheduler logic to initialize the modules when the firmware boots, and once when a module is connected (rather than continuously when disconnected).

I've tested by setting the cluster keys to various special modifiers, then hot-swapping it in and out. Without this patch the cluster LEDs are all a off-shade white (not the same as regular key white) and with the patch all the initial colours are set correctly.