### PR TITLE
Enable more warnings, generate assembly listing files.

### DIFF
--- a/scripts/Makedefs.mk
+++ b/scripts/Makedefs.mk
@@ -60,6 +60,9 @@ LD = $(PREFIX)-g++$(SUFFIX)
 # The command for extracting images from the linked executables.
 OBJCOPY = $(PREFIX)-objcopy$(SUFFIX)
 
+# The command to dump information from a linked executable.
+OBJDUMP = $(PREFIX)-objdump$(SUFFIX)
+
 # The command for the size tool.
 SIZE = $(PREFIX)-size$(SUFFIX)
 
@@ -90,6 +93,9 @@ CFLAGS = -mthumb                    \
          -Wextra                    \
          -Wno-unused-parameter      \
          -Wno-type-limits           \
+         -Wlogical-op               \
+         -Wrestrict                 \
+         -Wnull-dereference         \
          -Wshadow                   \
          $(BUILD_FLAGS)
 
@@ -197,6 +203,7 @@ $(PROJECT_OBJ): $(OBJS) $(LDSCRIPT)
 	@echo
 	@if [ '$(VERBOSE)' = 1 ]; then                               \
 	     $(SIZE) -Ax $(@);                                       \
+	     $(OBJDUMP) -h -d -S -z $(@) > $(@:.axf=.lss);           \
 	 fi
 	@$(OBJCOPY) -O binary $(@) $(@:.axf=.bin)
 	@$(OBJCOPY) -O ihex $(@) $(@:.axf=.hex)


### PR DESCRIPTION
There's a few more useful GCC warnings that aren't covered by -Wall -Wextra, enabled here.

When building in `VERBOSE=1` mode, firmware builds will now generate assembly listing files (LSS) which can be inspected. These take a few seconds to generate, hence the current restriction to verbose builds.