### PR TITLE
Swap naming of generic hid IN/OUT buffers.

### DIFF
--- a/right/src/usb_commands/usb_command_get_debug_buffer.c
+++ b/right/src/usb_commands/usb_command_get_debug_buffer.c
@@ -12,7 +12,7 @@
 #include "usb_interfaces/usb_interface_system_keyboard.h"
 #include "usb_interfaces/usb_interface_mouse.h"
 
-uint8_t DebugBuffer[USB_GENERIC_HID_OUT_BUFFER_LENGTH];
+uint8_t DebugBuffer[USB_GENERIC_HID_IN_BUFFER_LENGTH];
 
 void UsbCommand_GetDebugBuffer(void)
 {
@@ -29,7 +29,7 @@ void UsbCommand_GetDebugBuffer(void)
     SetDebugBufferUint32(41, UsbSystemKeyboardActionCounter);
     SetDebugBufferUint32(45, UsbMouseActionCounter);
 
-    memcpy(GenericHidOutBuffer, DebugBuffer, USB_GENERIC_HID_OUT_BUFFER_LENGTH);
+    memcpy(GenericHidInBuffer, DebugBuffer, USB_GENERIC_HID_IN_BUFFER_LENGTH);
 }
 
 void SetDebugBufferUint8(uint32_t offset, uint8_t value)

--- a/right/src/usb_commands/usb_command_get_debug_buffer.h
+++ b/right/src/usb_commands/usb_command_get_debug_buffer.h
@@ -7,7 +7,7 @@
 
 // Variables:
 
-    extern uint8_t DebugBuffer[USB_GENERIC_HID_OUT_BUFFER_LENGTH];
+    extern uint8_t DebugBuffer[USB_GENERIC_HID_IN_BUFFER_LENGTH];
 
 // Functions:
 

--- a/right/src/usb_commands/usb_command_get_device_property.c
+++ b/right/src/usb_commands/usb_command_get_device_property.c
@@ -52,19 +52,19 @@ void UsbCommand_GetDeviceProperty(void)
 
     switch (propertyId) {
         case DevicePropertyId_DeviceProtocolVersion:
-            memcpy(GenericHidOutBuffer+1, (uint8_t*)&deviceProtocolVersion, sizeof(deviceProtocolVersion));
+            memcpy(GenericHidInBuffer+1, (uint8_t*)&deviceProtocolVersion, sizeof(deviceProtocolVersion));
             break;
         case DevicePropertyId_ProtocolVersions:
-            memcpy(GenericHidOutBuffer+1, (uint8_t*)&protocolVersions, sizeof(protocolVersions));
+            memcpy(GenericHidInBuffer+1, (uint8_t*)&protocolVersions, sizeof(protocolVersions));
             break;
         case DevicePropertyId_ConfigSizes:
-            memcpy(GenericHidOutBuffer+1, (uint8_t*)&configSizes, sizeof(configSizes));
+            memcpy(GenericHidInBuffer+1, (uint8_t*)&configSizes, sizeof(configSizes));
             break;
         case DevicePropertyId_CurrentKbootCommand:
-            GenericHidOutBuffer[1] = KbootDriverState.command;
+            GenericHidInBuffer[1] = KbootDriverState.command;
             break;
         case DevicePropertyId_I2cMainBusBaudRate:
-            GenericHidOutBuffer[1] = I2C_MAIN_BUS_BASEADDR->F;
+            GenericHidInBuffer[1] = I2C_MAIN_BUS_BASEADDR->F;
             SetUsbTxBufferUint32(2, I2cMainBusRequestedBaudRateBps);
             SetUsbTxBufferUint32(6, I2cMainBusActualBaudRateBps);
             break;

--- a/right/src/usb_commands/usb_command_get_module_property.c
+++ b/right/src/usb_commands/usb_command_get_module_property.c
@@ -17,9 +17,9 @@ void UsbCommand_GetModuleProperty()
         case ModulePropertyId_VersionNumbers: {
             uint8_t moduleDriverId = UhkModuleSlaveDriver_SlotIdToDriverId(slotId);
             uhk_module_state_t *moduleState = UhkModuleStates + moduleDriverId;
-            GenericHidOutBuffer[1] = moduleState->moduleId;
-            memcpy(GenericHidOutBuffer + 2, &moduleState->moduleProtocolVersion, sizeof(version_t));
-            memcpy(GenericHidOutBuffer + 8, &moduleState->firmwareVersion, sizeof(version_t));
+            GenericHidInBuffer[1] = moduleState->moduleId;
+            memcpy(GenericHidInBuffer + 2, &moduleState->moduleProtocolVersion, sizeof(version_t));
+            memcpy(GenericHidInBuffer + 8, &moduleState->firmwareVersion, sizeof(version_t));
             break;
         }
     }

--- a/right/src/usb_commands/usb_command_get_slave_i2c_errors.c
+++ b/right/src/usb_commands/usb_command_get_slave_i2c_errors.c
@@ -14,6 +14,6 @@ void UsbCommand_GetSlaveI2cErrors()
 
     i2c_slave_error_counter_t *i2cSlaveErrorCounter =  I2cSlaveErrorCounters + slaveId;
 
-    GenericHidOutBuffer[1] = i2cSlaveErrorCounter->errorTypeCount;
-    memcpy(GenericHidOutBuffer + 2, i2cSlaveErrorCounter->errors, sizeof(i2c_error_count_t) * MAX_LOGGED_I2C_ERROR_TYPES_PER_SLAVE);
+    GenericHidInBuffer[1] = i2cSlaveErrorCounter->errorTypeCount;
+    memcpy(GenericHidInBuffer + 2, i2cSlaveErrorCounter->errors, sizeof(i2c_error_count_t) * MAX_LOGGED_I2C_ERROR_TYPES_PER_SLAVE);
 }

--- a/right/src/usb_commands/usb_command_read_config.c
+++ b/right/src/usb_commands/usb_command_read_config.c
@@ -13,7 +13,7 @@ void UsbCommand_ReadConfig()
         SetUsbTxBufferUint8(0, UsbStatusCode_ReadConfig_InvalidConfigBufferId);
     }
 
-    if (length > USB_GENERIC_HID_OUT_BUFFER_LENGTH - USB_STATUS_CODE_SIZE) {
+    if (length > USB_GENERIC_HID_IN_BUFFER_LENGTH - USB_STATUS_CODE_SIZE) {
         SetUsbTxBufferUint8(0, UsbStatusCode_ReadConfig_LengthTooLarge);
         return;
     }
@@ -26,5 +26,5 @@ void UsbCommand_ReadConfig()
         return;
     }
 
-    memcpy(GenericHidOutBuffer + USB_STATUS_CODE_SIZE, buffer->buffer + offset, length);
+    memcpy(GenericHidInBuffer + USB_STATUS_CODE_SIZE, buffer->buffer + offset, length);
 }

--- a/right/src/usb_commands/usb_command_switch_keymap.c
+++ b/right/src/usb_commands/usb_command_switch_keymap.c
@@ -5,7 +5,7 @@
 void UsbCommand_SwitchKeymap(void)
 {
     uint32_t keymapLength = GetUsbRxBufferUint8(1);
-    char *keymapAbbrev = (char*)GenericHidInBuffer + 2;
+    char *keymapAbbrev = (char*)GenericHidOutBuffer + 2;
 
     if (keymapLength > KEYMAP_ABBREVIATION_LENGTH) {
         SetUsbTxBufferUint8(0, UsbStatusCode_SwitchKeymap_InvalidAbbreviationLength);

--- a/right/src/usb_commands/usb_command_write_config.c
+++ b/right/src/usb_commands/usb_command_write_config.c
@@ -9,7 +9,7 @@ void UsbCommand_WriteConfig(config_buffer_id_t configBufferId)
     uint16_t offset = GetUsbRxBufferUint16(2);
     const uint8_t paramsSize = USB_STATUS_CODE_SIZE + sizeof(length) + sizeof(offset);
 
-    if (length > USB_GENERIC_HID_OUT_BUFFER_LENGTH - paramsSize) {
+    if (length > USB_GENERIC_HID_IN_BUFFER_LENGTH - paramsSize) {
         SetUsbTxBufferUint8(0, UsbStatusCode_WriteConfig_LengthTooLarge);
         return;
     }
@@ -22,5 +22,5 @@ void UsbCommand_WriteConfig(config_buffer_id_t configBufferId)
         return;
     }
 
-    memcpy(buffer + offset, GenericHidInBuffer + paramsSize, length);
+    memcpy(buffer + offset, GenericHidOutBuffer + paramsSize, length);
 }

--- a/right/src/usb_interfaces/usb_interface_generic_hid.c
+++ b/right/src/usb_interfaces/usb_interface_generic_hid.c
@@ -2,8 +2,8 @@
 #include "usb_protocol_handler.h"
 
 uint32_t UsbGenericHidActionCounter;
-uint8_t GenericHidInBuffer[USB_GENERIC_HID_IN_BUFFER_LENGTH];
 uint8_t GenericHidOutBuffer[USB_GENERIC_HID_OUT_BUFFER_LENGTH];
+uint8_t GenericHidInBuffer[USB_GENERIC_HID_IN_BUFFER_LENGTH];
 
 static usb_status_t UsbReceiveData(void)
 {
@@ -13,7 +13,7 @@ static usb_status_t UsbReceiveData(void)
 
     return USB_DeviceHidRecv(UsbCompositeDevice.genericHidHandle,
                              USB_GENERIC_HID_ENDPOINT_OUT_INDEX,
-                             GenericHidInBuffer,
+                             GenericHidOutBuffer,
                              USB_GENERIC_HID_OUT_BUFFER_LENGTH);
 }
 
@@ -33,8 +33,8 @@ usb_status_t UsbGenericHidCallback(class_handle_t handle, uint32_t event, void *
 
             USB_DeviceHidSend(UsbCompositeDevice.genericHidHandle,
                               USB_GENERIC_HID_ENDPOINT_IN_INDEX,
-                              GenericHidOutBuffer,
-                              USB_GENERIC_HID_OUT_BUFFER_LENGTH);
+                              GenericHidInBuffer,
+                              USB_GENERIC_HID_IN_BUFFER_LENGTH);
             UsbGenericHidActionCounter++;
             return UsbReceiveData();
             break;

--- a/right/src/usb_protocol_handler.c
+++ b/right/src/usb_protocol_handler.c
@@ -22,7 +22,7 @@
 
 void UsbProtocolHandler(void)
 {
-    bzero(GenericHidOutBuffer, USB_GENERIC_HID_OUT_BUFFER_LENGTH);
+    bzero(GenericHidInBuffer, USB_GENERIC_HID_IN_BUFFER_LENGTH);
     uint8_t command = GetUsbRxBufferUint8(0);
     switch (command) {
         case UsbCommandId_GetDeviceProperty:
@@ -93,30 +93,30 @@ void UsbProtocolHandler(void)
 
 uint8_t GetUsbRxBufferUint8(uint32_t offset)
 {
-    return GetBufferUint8(GenericHidInBuffer, offset);
+    return GetBufferUint8(GenericHidOutBuffer, offset);
 }
 
 uint16_t GetUsbRxBufferUint16(uint32_t offset)
 {
-    return GetBufferUint16(GenericHidInBuffer, offset);
+    return GetBufferUint16(GenericHidOutBuffer, offset);
 }
 
 uint32_t GetUsbRxBufferUint32(uint32_t offset)
 {
-    return GetBufferUint32(GenericHidInBuffer, offset);
+    return GetBufferUint32(GenericHidOutBuffer, offset);
 }
 
 void SetUsbTxBufferUint8(uint32_t offset, uint8_t value)
 {
-    SetBufferUint8(GenericHidOutBuffer, offset, value);
+    SetBufferUint8(GenericHidInBuffer, offset, value);
 }
 
 void SetUsbTxBufferUint16(uint32_t offset, uint16_t value)
 {
-    SetBufferUint16(GenericHidOutBuffer, offset, value);
+    SetBufferUint16(GenericHidInBuffer, offset, value);
 }
 
 void SetUsbTxBufferUint32(uint32_t offset, uint32_t value)
 {
-    SetBufferUint32(GenericHidOutBuffer, offset, value);
+    SetBufferUint32(GenericHidInBuffer, offset, value);
 }


### PR DESCRIPTION
This isn't a compliance fix, more of a correctness patch. The USB In/Out terminology should always be used with respect to the host, so "In" transactions flow from device to host.

The generic HID code in the firmware has the names reversed for the report buffers, which confused me at first. This patch swaps them around to use the correct terminology, and fixes a (currently) benign mis-use of the wrong report size constant (which currently works as the in/out lengths are identical).