### PR TITLE
Add support for additional mandatory HID class requests.

### DIFF
--- a/right/src/ksdk_usb/usb_device_hid.c
+++ b/right/src/ksdk_usb/usb_device_hid.c
@@ -454,7 +454,7 @@ usb_status_t USB_DeviceHidEvent(void *handle, uint32_t event, void *param)
                     case USB_DEVICE_HID_REQUEST_GET_PROTOCOL:
                         /* Get protocol request */
                         error = hidHandle->configStruct->classCallback(
-                            (class_handle_t)hidHandle, kUSB_DeviceHidEventGetIdle, &hidHandle->protocol);
+                            (class_handle_t)hidHandle, kUSB_DeviceHidEventGetProtocol, &hidHandle->protocol);
                         controlRequest->buffer = &hidHandle->protocol;
                         break;
                     case USB_DEVICE_HID_REQUEST_SET_REPORT:

--- a/right/src/usb_descriptors/usb_descriptor_hid.c
+++ b/right/src/usb_descriptors/usb_descriptor_hid.c
@@ -68,7 +68,7 @@ usb_status_t USB_DeviceGetHidReportDescriptor(
             break;
         case USB_SYSTEM_KEYBOARD_INTERFACE_INDEX:
             hidReportDescriptor->buffer = UsbSystemKeyboardReportDescriptor;
-            hidReportDescriptor->length = USB_MEDIA_KEYBOARD_REPORT_DESCRIPTOR_LENGTH;
+            hidReportDescriptor->length = USB_SYSTEM_KEYBOARD_REPORT_DESCRIPTOR_LENGTH;
             break;
         case USB_MOUSE_INTERFACE_INDEX:
             hidReportDescriptor->buffer = UsbMouseReportDescriptor;

--- a/right/src/usb_interfaces/usb_interface_basic_keyboard.c
+++ b/right/src/usb_interfaces/usb_interface_basic_keyboard.c
@@ -1,13 +1,16 @@
 #include "led_display.h"
 #include "usb_composite_device.h"
 #include "usb_report_updater.h"
+#include "timer.h"
 
 static usb_basic_keyboard_report_t usbBasicKeyboardReports[2];
+static uint8_t usbBasicKeyboardProtocol = 1;
+static uint8_t usbBasicKeyboardInBuffer[USB_BASIC_KEYBOARD_REPORT_LENGTH];
+static uint32_t usbBasicKeyboardReportLastSendTime = 0;
 uint32_t UsbBasicKeyboardActionCounter;
 usb_basic_keyboard_report_t* ActiveUsbBasicKeyboardReport = usbBasicKeyboardReports;
-static uint8_t usbBasicKeyboardInBuffer[USB_BASIC_KEYBOARD_REPORT_LENGTH];
 
-usb_basic_keyboard_report_t* GetInactiveUsbBasicKeyboardReport(void)
+static usb_basic_keyboard_report_t* GetInactiveUsbBasicKeyboardReport(void)
 {
     return ActiveUsbBasicKeyboardReport == usbBasicKeyboardReports ? usbBasicKeyboardReports+1 : usbBasicKeyboardReports;
 }
@@ -17,7 +20,7 @@ static void SwitchActiveUsbBasicKeyboardReport(void)
     ActiveUsbBasicKeyboardReport = GetInactiveUsbBasicKeyboardReport();
 }
 
-void ResetActiveUsbBasicKeyboardReport(void)
+void UsbBasicKeyboardResetActiveReport(void)
 {
     bzero(ActiveUsbBasicKeyboardReport, USB_BASIC_KEYBOARD_REPORT_LENGTH);
 }
@@ -32,10 +35,30 @@ usb_status_t UsbBasicKeyboardAction(void)
         UsbCompositeDevice.basicKeyboardHandle, USB_BASIC_KEYBOARD_ENDPOINT_INDEX,
         (uint8_t *)ActiveUsbBasicKeyboardReport, USB_BASIC_KEYBOARD_REPORT_LENGTH);
     if (usb_status == kStatus_USB_Success) {
+        usbBasicKeyboardReportLastSendTime = CurrentTime;
         UsbBasicKeyboardActionCounter++;
         SwitchActiveUsbBasicKeyboardReport();
     }
     return usb_status;
+}
+
+usb_status_t UsbBasicKeyboardCheckIdleElapsed()
+{
+    uint16_t idlePeriodUs = ((usb_device_hid_struct_t*)UsbCompositeDevice.basicKeyboardHandle)->idleRate * 4 * 1000; // idleRate is in 4ms units.
+    if (!idlePeriodUs) {
+        return kStatus_USB_Busy;
+    }
+
+    bool hasIdleElapsed = Timer_GetElapsedTimeMicros(&usbBasicKeyboardReportLastSendTime) > idlePeriodUs;
+    return hasIdleElapsed ? kStatus_USB_Success : kStatus_USB_Busy;
+}
+
+usb_status_t UsbBasicKeyboardCheckReportReady()
+{
+    if (memcmp(ActiveUsbBasicKeyboardReport, GetInactiveUsbBasicKeyboardReport(), sizeof(usb_basic_keyboard_report_t)) != 0)
+        return kStatus_USB_Success;
+
+    return UsbBasicKeyboardCheckIdleElapsed();
 }
 
 usb_status_t UsbBasicKeyboardCallback(class_handle_t handle, uint32_t event, void *param)
@@ -43,7 +66,6 @@ usb_status_t UsbBasicKeyboardCallback(class_handle_t handle, uint32_t event, voi
     usb_status_t error = kStatus_USB_Error;
 
     switch (event) {
-        // This event is received when the report has been sent
         case kUSB_DeviceHidEventSendResponse:
             UsbReportUpdateSemaphore &= ~(1 << USB_BASIC_KEYBOARD_INTERFACE_INDEX);
             if (UsbCompositeDevice.attach) {
@@ -51,9 +73,23 @@ usb_status_t UsbBasicKeyboardCallback(class_handle_t handle, uint32_t event, voi
             }
             break;
         case kUSB_DeviceHidEventRecvResponse:
-        case kUSB_DeviceHidEventGetReport:
             error = kStatus_USB_InvalidRequest;
             break;
+
+        case kUSB_DeviceHidEventGetReport: {
+            usb_device_hid_report_struct_t *report = (usb_device_hid_report_struct_t*)param;
+            if (report->reportType == USB_DEVICE_HID_REQUEST_GET_REPORT_TYPE_INPUT && report->reportId == 0 && report->reportLength <= USB_BASIC_KEYBOARD_REPORT_LENGTH) {
+                report->reportBuffer = (void*)ActiveUsbBasicKeyboardReport;
+
+                usbBasicKeyboardReportLastSendTime = CurrentTime;
+                UsbBasicKeyboardActionCounter++;
+                SwitchActiveUsbBasicKeyboardReport();
+            } else {
+                error = kStatus_USB_InvalidRequest;
+            }
+            break;
+        }
+
         case kUSB_DeviceHidEventSetReport: {
             usb_device_hid_report_struct_t *report = (usb_device_hid_report_struct_t*)param;
             if (report->reportType == USB_DEVICE_HID_REQUEST_GET_REPORT_TYPE_OUPUT && report->reportId == 0 && report->reportLength == 1) {
@@ -74,11 +110,31 @@ usb_status_t UsbBasicKeyboardCallback(class_handle_t handle, uint32_t event, voi
             }
             break;
         }
+
         case kUSB_DeviceHidEventGetIdle:
-        case kUSB_DeviceHidEventGetProtocol:
-        case kUSB_DeviceHidEventSetIdle:
-        case kUSB_DeviceHidEventSetProtocol:
+            error = kStatus_USB_Success;
             break;
+
+        case kUSB_DeviceHidEventSetIdle:
+            usbBasicKeyboardReportLastSendTime = CurrentTime;
+            error = kStatus_USB_Success;
+            break;
+
+        case kUSB_DeviceHidEventGetProtocol:
+            *(uint8_t*)param = usbBasicKeyboardProtocol;
+            error = kStatus_USB_Success;
+            break;
+
+        case kUSB_DeviceHidEventSetProtocol:
+            if (*(uint8_t*)param <= 1) {
+                usbBasicKeyboardProtocol = *(uint8_t*)param;
+                error = kStatus_USB_Success;
+            }
+            else {
+                error = kStatus_USB_InvalidRequest;
+            }
+            break;
+
         default:
             break;
     }
@@ -88,6 +144,7 @@ usb_status_t UsbBasicKeyboardCallback(class_handle_t handle, uint32_t event, voi
 
 usb_status_t UsbBasicKeyboardSetConfiguration(class_handle_t handle, uint8_t configuration)
 {
+    usbBasicKeyboardProtocol = 1; // HID Interfaces with boot protocol support start in report protocol mode.
     return kStatus_USB_Error;
 }
 

--- a/right/src/usb_interfaces/usb_interface_basic_keyboard.h
+++ b/right/src/usb_interfaces/usb_interface_basic_keyboard.h
@@ -23,6 +23,12 @@
 
 // Typedefs:
 
+    // Note: We support boot protocol mode in this interface, thus the keyboard
+    // report may not exceed 8 bytes and must conform to the HID keyboard boot
+    // protocol as specified in the USB HID specification. If a different or
+    // longer format is desired in the future, we will need to translate sent
+    // reports to the boot protocol format when the host has set boot protocol
+    // mode.
     typedef struct {
         uint8_t modifiers;
         uint8_t reserved; // Always must be 0
@@ -40,8 +46,9 @@
     usb_status_t UsbBasicKeyboardSetConfiguration(class_handle_t handle, uint8_t configuration);
     usb_status_t UsbBasicKeyboardSetInterface(class_handle_t handle, uint8_t interface, uint8_t alternateSetting);
 
-    void ResetActiveUsbBasicKeyboardReport(void);
-    usb_basic_keyboard_report_t* GetInactiveUsbBasicKeyboardReport(void);
+    void UsbBasicKeyboardResetActiveReport(void);
     usb_status_t UsbBasicKeyboardAction(void);
+    usb_status_t UsbBasicKeyboardCheckIdleElapsed();
+    usb_status_t UsbBasicKeyboardCheckReportReady();
 
 #endif

--- a/right/src/usb_interfaces/usb_interface_generic_hid.c
+++ b/right/src/usb_interfaces/usb_interface_generic_hid.c
@@ -1,9 +1,11 @@
 #include "usb_composite_device.h"
 #include "usb_protocol_handler.h"
+#include "timer.h"
 
 uint32_t UsbGenericHidActionCounter;
 uint8_t GenericHidOutBuffer[USB_GENERIC_HID_OUT_BUFFER_LENGTH];
 uint8_t GenericHidInBuffer[USB_GENERIC_HID_IN_BUFFER_LENGTH];
+static uint32_t usbGenericHidReportLastSendTime = 0;
 
 static usb_status_t UsbReceiveData(void)
 {
@@ -17,12 +19,27 @@ static usb_status_t UsbReceiveData(void)
                              USB_GENERIC_HID_OUT_BUFFER_LENGTH);
 }
 
+usb_status_t UsbGenericHidCheckIdleElapsed()
+{
+    uint16_t idlePeriodUs = ((usb_device_hid_struct_t*)UsbCompositeDevice.genericHidHandle)->idleRate * 4 * 1000; // idleRate is in 4ms units.
+    if (!idlePeriodUs) {
+        return kStatus_USB_Busy;
+    }
+
+    bool hasIdleElapsed = Timer_GetElapsedTimeMicros(&usbGenericHidReportLastSendTime) > idlePeriodUs;
+    return hasIdleElapsed ? kStatus_USB_Success : kStatus_USB_Busy;
+}
+
+usb_status_t UsbGenericHidCheckReportReady()
+{
+    return UsbGenericHidCheckIdleElapsed();
+}
+
 usb_status_t UsbGenericHidCallback(class_handle_t handle, uint32_t event, void *param)
 {
     usb_status_t error = kStatus_USB_Error;
 
     switch (event) {
-        // This event is received when the report has been sent
         case kUSB_DeviceHidEventSendResponse:
             if (UsbCompositeDevice.attach) {
                 error = kStatus_USB_Success;
@@ -37,17 +54,39 @@ usb_status_t UsbGenericHidCallback(class_handle_t handle, uint32_t event, void *
                               USB_GENERIC_HID_IN_BUFFER_LENGTH);
             UsbGenericHidActionCounter++;
             return UsbReceiveData();
+
+        case kUSB_DeviceHidEventGetReport: {
+            usb_device_hid_report_struct_t *report = (usb_device_hid_report_struct_t*)param;
+            if (report->reportType == USB_DEVICE_HID_REQUEST_GET_REPORT_TYPE_INPUT && report->reportId == 0 && report->reportLength <= USB_GENERIC_HID_IN_BUFFER_LENGTH) {
+                report->reportBuffer = GenericHidInBuffer;
+                UsbGenericHidActionCounter++;
+            } else {
+                error = kStatus_USB_InvalidRequest;
+            }
             break;
-        case kUSB_DeviceHidEventGetReport:
+        }
+
+        // SetReport is not required for this interface.
         case kUSB_DeviceHidEventSetReport:
         case kUSB_DeviceHidEventRequestReportBuffer:
             error = kStatus_USB_InvalidRequest;
             break;
+
         case kUSB_DeviceHidEventGetIdle:
-        case kUSB_DeviceHidEventGetProtocol:
-        case kUSB_DeviceHidEventSetIdle:
-        case kUSB_DeviceHidEventSetProtocol:
+            error = kStatus_USB_Success;
             break;
+
+        case kUSB_DeviceHidEventSetIdle:
+            usbGenericHidReportLastSendTime = CurrentTime;
+            error = kStatus_USB_Success;
+            break;
+
+        // No boot protocol support for this interface.
+        case kUSB_DeviceHidEventGetProtocol:
+        case kUSB_DeviceHidEventSetProtocol:
+            error = kStatus_USB_InvalidRequest;
+            break;
+
         default:
             break;
     }

--- a/right/src/usb_interfaces/usb_interface_generic_hid.h
+++ b/right/src/usb_interfaces/usb_interface_generic_hid.h
@@ -34,5 +34,7 @@
     usb_status_t UsbGenericHidCallback(class_handle_t handle, uint32_t event, void *param);
     usb_status_t UsbGenericHidSetConfiguration(class_handle_t handle, uint8_t configuration);
     usb_status_t UsbGenericHidSetInterface(class_handle_t handle, uint8_t interface, uint8_t alternateSetting);
+    usb_status_t UsbGenericHidCheckIdleElapsed();
+    usb_status_t UsbGenericHidCheckReportReady();
 
 #endif

--- a/right/src/usb_interfaces/usb_interface_media_keyboard.h
+++ b/right/src/usb_interfaces/usb_interface_media_keyboard.h
@@ -37,8 +37,9 @@
     usb_status_t UsbMediaKeyboardSetConfiguration(class_handle_t handle, uint8_t configuration);
     usb_status_t UsbMediaKeyboardSetInterface(class_handle_t handle, uint8_t interface, uint8_t alternateSetting);
 
-    void ResetActiveUsbMediaKeyboardReport(void);
-    usb_media_keyboard_report_t* GetInactiveUsbMediaKeyboardReport(void);
+    void UsbMediaKeyboardResetActiveReport(void);
     usb_status_t UsbMediaKeyboardAction();
+    usb_status_t UsbMediaKeyboardCheckIdleElapsed();
+    usb_status_t UsbMediaKeyboardCheckReportReady();
 
 #endif

--- a/right/src/usb_interfaces/usb_interface_mouse.c
+++ b/right/src/usb_interfaces/usb_interface_mouse.c
@@ -1,11 +1,14 @@
 #include "usb_composite_device.h"
 #include "usb_report_updater.h"
+#include "timer.h"
 
-uint32_t UsbMouseActionCounter;
 static usb_mouse_report_t usbMouseReports[2];
+static uint8_t usbMouseProtocol = 1;
+static uint32_t usbMouseReportLastSendTime = 0;
+uint32_t UsbMouseActionCounter;
 usb_mouse_report_t* ActiveUsbMouseReport = usbMouseReports;
 
-usb_mouse_report_t* GetInactiveUsbMouseReport(void)
+static usb_mouse_report_t* GetInactiveUsbMouseReport(void)
 {
     return ActiveUsbMouseReport == usbMouseReports ? usbMouseReports+1 : usbMouseReports;
 }
@@ -15,7 +18,7 @@ static void SwitchActiveUsbMouseReport(void)
     ActiveUsbMouseReport = GetInactiveUsbMouseReport();
 }
 
-void ResetActiveUsbMouseReport(void)
+void UsbMouseResetActiveReport(void)
 {
     bzero(ActiveUsbMouseReport, USB_MOUSE_REPORT_LENGTH);
 }
@@ -36,12 +39,30 @@ usb_status_t UsbMouseAction(void)
     return usb_status;
 }
 
+usb_status_t UsbMouseCheckIdleElapsed()
+{
+    uint16_t idlePeriodUs = ((usb_device_hid_struct_t*)UsbCompositeDevice.mouseHandle)->idleRate * 4 * 1000; // idleRate is in 4ms units.
+    if (!idlePeriodUs) {
+        return kStatus_USB_Busy;
+    }
+
+    bool hasIdleElapsed = Timer_GetElapsedTimeMicros(&usbMouseReportLastSendTime) > idlePeriodUs;
+    return hasIdleElapsed ? kStatus_USB_Success : kStatus_USB_Busy;
+}
+
+usb_status_t UsbMouseCheckReportReady()
+{
+    if (memcmp(ActiveUsbMouseReport, GetInactiveUsbMouseReport(), sizeof(usb_mouse_report_t)) != 0)
+        return kStatus_USB_Success;
+
+    return UsbMouseCheckIdleElapsed();
+}
+
 usb_status_t UsbMouseCallback(class_handle_t handle, uint32_t event, void *param)
 {
     usb_status_t error = kStatus_USB_Error;
 
     switch (event) {
-        // This event is received when the report has been sent
         case kUSB_DeviceHidEventSendResponse:
             UsbReportUpdateSemaphore &= ~(1 << USB_MOUSE_INTERFACE_INDEX);
             if (UsbCompositeDevice.attach) {
@@ -49,16 +70,51 @@ usb_status_t UsbMouseCallback(class_handle_t handle, uint32_t event, void *param
             }
             break;
         case kUSB_DeviceHidEventRecvResponse:
-        case kUSB_DeviceHidEventGetReport:
+            error = kStatus_USB_InvalidRequest;
+            break;
+
+        case kUSB_DeviceHidEventGetReport: {
+            usb_device_hid_report_struct_t *report = (usb_device_hid_report_struct_t*)param;
+            if (report->reportType == USB_DEVICE_HID_REQUEST_GET_REPORT_TYPE_INPUT && report->reportId == 0 && report->reportLength <= USB_MOUSE_REPORT_LENGTH) {
+                report->reportBuffer = (void*)ActiveUsbMouseReport;
+                UsbMouseActionCounter++;
+                SwitchActiveUsbMouseReport();
+            } else {
+                error = kStatus_USB_InvalidRequest;
+            }
+            break;
+        }
+
+        // SetReport is not required for this interface.
         case kUSB_DeviceHidEventSetReport:
         case kUSB_DeviceHidEventRequestReportBuffer:
             error = kStatus_USB_InvalidRequest;
             break;
+
         case kUSB_DeviceHidEventGetIdle:
-        case kUSB_DeviceHidEventGetProtocol:
-        case kUSB_DeviceHidEventSetIdle:
-        case kUSB_DeviceHidEventSetProtocol:
+            error = kStatus_USB_Success;
             break;
+
+        case kUSB_DeviceHidEventSetIdle:
+            usbMouseReportLastSendTime = CurrentTime;
+            error = kStatus_USB_Success;
+            break;
+
+        case kUSB_DeviceHidEventGetProtocol:
+            *(uint8_t*)param = usbMouseProtocol;
+            error = kStatus_USB_Success;
+            break;
+
+        case kUSB_DeviceHidEventSetProtocol:
+            if (*(uint8_t*)param <= 1) {
+                usbMouseProtocol = *(uint8_t*)param;
+                error = kStatus_USB_Success;
+            }
+            else {
+                error = kStatus_USB_InvalidRequest;
+            }
+            break;
+
         default:
             break;
     }
@@ -68,6 +124,7 @@ usb_status_t UsbMouseCallback(class_handle_t handle, uint32_t event, void *param
 
 usb_status_t UsbMouseSetConfiguration(class_handle_t handle, uint8_t configuration)
 {
+    usbMouseProtocol = 1; // HID Interfaces with boot protocol support start in report protocol mode.
     return kStatus_USB_Error;
 }
 

--- a/right/src/usb_interfaces/usb_interface_mouse.h
+++ b/right/src/usb_interfaces/usb_interface_mouse.h
@@ -21,6 +21,12 @@
 
 // Typedefs:
 
+    // Note: We support boot protocol mode in this interface, thus the mouse
+    // report may not exceed 8 bytes and must conform to the HID mouse boot
+    // protocol as specified in the USB HID specification. If a different or
+    // longer format is desired in the future, we will need to translate sent
+    // reports to the boot protocol format when the host has set boot protocol
+    // mode.
     typedef struct {
         uint8_t buttons;
         int16_t x;
@@ -40,8 +46,9 @@
     usb_status_t UsbMouseSetConfiguration(class_handle_t handle, uint8_t configuration);
     usb_status_t UsbMouseSetInterface(class_handle_t handle, uint8_t interface, uint8_t alternateSetting);
 
-    void ResetActiveUsbMouseReport(void);
-    usb_mouse_report_t* GetInactiveUsbMouseReport(void);
+    void UsbMouseResetActiveReport(void);
     usb_status_t UsbMouseAction(void);
+    usb_status_t UsbMouseCheckIdleElapsed();
+    usb_status_t UsbMouseCheckReportReady();
 
 #endif

--- a/right/src/usb_interfaces/usb_interface_system_keyboard.h
+++ b/right/src/usb_interfaces/usb_interface_system_keyboard.h
@@ -38,8 +38,9 @@
     usb_status_t UsbSystemKeyboardSetConfiguration(class_handle_t handle, uint8_t configuration);
     usb_status_t UsbSystemKeyboardSetInterface(class_handle_t handle, uint8_t interface, uint8_t alternateSetting);
 
-    void ResetActiveUsbSystemKeyboardReport(void);
-    usb_system_keyboard_report_t* GetInactiveUsbSystemKeyboardReport();
+    void UsbSystemKeyboardResetActiveReport(void);
     usb_status_t UsbSystemKeyboardAction(void);
+    usb_status_t UsbSystemKeyboardCheckIdleElapsed();
+    usb_status_t UsbSystemKeyboardCheckReportReady();
 
 #endif

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -424,7 +424,7 @@ void UpdateUsbReports(void)
         }
     }
 
-    if(Timer_GetElapsedTime(&lastReportTime) < keystrokeDelay) {
+    if (Timer_GetElapsedTime(&lastReportTime) < keystrokeDelay) {
         justPreprocessInput();
         return;
     }
@@ -432,19 +432,14 @@ void UpdateUsbReports(void)
     lastUpdateTime = CurrentTime;
     UsbReportUpdateCounter++;
 
-    ResetActiveUsbBasicKeyboardReport();
-    ResetActiveUsbMediaKeyboardReport();
-    ResetActiveUsbSystemKeyboardReport();
-    ResetActiveUsbMouseReport();
+    UsbBasicKeyboardResetActiveReport();
+    UsbMediaKeyboardResetActiveReport();
+    UsbSystemKeyboardResetActiveReport();
+    UsbMouseResetActiveReport();
 
     updateActiveUsbReports();
 
-    bool HasUsbBasicKeyboardReportChanged = memcmp(ActiveUsbBasicKeyboardReport, GetInactiveUsbBasicKeyboardReport(), sizeof(usb_basic_keyboard_report_t)) != 0;
-    bool HasUsbMediaKeyboardReportChanged = memcmp(ActiveUsbMediaKeyboardReport, GetInactiveUsbMediaKeyboardReport(), sizeof(usb_media_keyboard_report_t)) != 0;
-    bool HasUsbSystemKeyboardReportChanged = memcmp(ActiveUsbSystemKeyboardReport, GetInactiveUsbSystemKeyboardReport(), sizeof(usb_system_keyboard_report_t)) != 0;
-    bool HasUsbMouseReportChanged = memcmp(ActiveUsbMouseReport, GetInactiveUsbMouseReport(), sizeof(usb_mouse_report_t)) != 0;
-
-    if (HasUsbBasicKeyboardReportChanged) {
+    if (UsbBasicKeyboardCheckReportReady() == kStatus_USB_Success) {
         UsbReportUpdateSemaphore |= 1 << USB_BASIC_KEYBOARD_INTERFACE_INDEX;
         usb_status_t status = UsbBasicKeyboardAction();
         //The semaphore has to be set before the call. Assume what happens if a bus reset happens asynchronously here. (Deadlock.)
@@ -456,7 +451,7 @@ void UpdateUsbReports(void)
         lastReportTime = CurrentTime;
     }
 
-    if (HasUsbMediaKeyboardReportChanged) {
+    if (UsbMediaKeyboardCheckReportReady() == kStatus_USB_Success) {
         UsbReportUpdateSemaphore |= 1 << USB_MEDIA_KEYBOARD_INTERFACE_INDEX;
         usb_status_t status = UsbMediaKeyboardAction();
         if (status != kStatus_USB_Success) {
@@ -464,7 +459,7 @@ void UpdateUsbReports(void)
         }
     }
 
-    if (HasUsbSystemKeyboardReportChanged) {
+    if (UsbSystemKeyboardCheckReportReady() == kStatus_USB_Success) {
         UsbReportUpdateSemaphore |= 1 << USB_SYSTEM_KEYBOARD_INTERFACE_INDEX;
         usb_status_t status = UsbSystemKeyboardAction();
         if (status != kStatus_USB_Success) {
@@ -473,7 +468,7 @@ void UpdateUsbReports(void)
     }
 
     // Send out the mouse position and wheel values continuously if the report is not zeros, but only send the mouse button states when they change.
-    if (HasUsbMouseReportChanged || ActiveUsbMouseReport->x || ActiveUsbMouseReport->y ||
+    if (UsbMouseCheckReportReady() == kStatus_USB_Success || ActiveUsbMouseReport->x || ActiveUsbMouseReport->y ||
             ActiveUsbMouseReport->wheelX || ActiveUsbMouseReport->wheelY) {
         UsbReportUpdateSemaphore |= 1 << USB_MOUSE_INTERFACE_INDEX;
         usb_status_t status = UsbMouseAction();


### PR DESCRIPTION
Fixes #374.

This implements the remaining HID class requests, several of which are mandatory for HID class interfaces that implement boot protocol functionality (the restricted subset of HID that is used by limited hosts, such as PC BIOS).

1) Add `SetProtocol`/`GetProtocol`:
Only mandatory for the boot protocol keyboard/mouse interfaces, as they advertise boot protocol support in the configuration descriptors. These should initially report 1 (report protocol) but should be settable to 0 (boot protocol) by the host on demand. 

Happily we don't actually need to translate the reports themselves right now, as they are already boot protocol keyboard and mouse compliant - i.e. they are no more than 8 bytes in length, and the first N bytes match the boot protocol report structure given in the HID specification.

If the reports are adjusted later on, we might need to revisit this and add additional code to translate the complex reports to the restricted boot protocol subset when the host has enabled boot protocol mode.

The Kinetis SDK has a bug here which I've fixed, where it gives the wrong event callback to the application code.

2) Add `SetIdle`/`GetIdle`:
Mandatory in all cases; this allows the host to request that the device only send changed reports (idle period of 0) or to keep automatically re-issuing the same previous report every N*4 milliseconds. Implemented with software timers.

This one's tricky to validate as the compliance tool only does surface tests (can the idle period be adjusted) without actually verifying the correct number of reports per interval are issued.


