### PR TITLE
Fix overflow of the HID idle period, when a period above 16 (64ms) is set.

### DIFF
--- a/right/src/usb_interfaces/usb_interface_basic_keyboard.c
+++ b/right/src/usb_interfaces/usb_interface_basic_keyboard.c
@@ -44,12 +44,12 @@ usb_status_t UsbBasicKeyboardAction(void)
 
 usb_status_t UsbBasicKeyboardCheckIdleElapsed()
 {
-    uint16_t idlePeriodUs = ((usb_device_hid_struct_t*)UsbCompositeDevice.basicKeyboardHandle)->idleRate * 4 * 1000; // idleRate is in 4ms units.
-    if (!idlePeriodUs) {
+    uint16_t idlePeriodMs = ((usb_device_hid_struct_t*)UsbCompositeDevice.basicKeyboardHandle)->idleRate * 4; // idleRate is in 4ms units.
+    if (!idlePeriodMs) {
         return kStatus_USB_Busy;
     }
 
-    bool hasIdleElapsed = Timer_GetElapsedTimeMicros(&usbBasicKeyboardReportLastSendTime) > idlePeriodUs;
+    bool hasIdleElapsed = (Timer_GetElapsedTimeMicros(&usbBasicKeyboardReportLastSendTime) / 1000) > idlePeriodMs;
     return hasIdleElapsed ? kStatus_USB_Success : kStatus_USB_Busy;
 }
 

--- a/right/src/usb_interfaces/usb_interface_generic_hid.c
+++ b/right/src/usb_interfaces/usb_interface_generic_hid.c
@@ -21,12 +21,12 @@ static usb_status_t UsbReceiveData(void)
 
 usb_status_t UsbGenericHidCheckIdleElapsed()
 {
-    uint16_t idlePeriodUs = ((usb_device_hid_struct_t*)UsbCompositeDevice.genericHidHandle)->idleRate * 4 * 1000; // idleRate is in 4ms units.
-    if (!idlePeriodUs) {
+    uint16_t idlePeriodMs = ((usb_device_hid_struct_t*)UsbCompositeDevice.genericHidHandle)->idleRate * 4; // idleRate is in 4ms units.
+    if (!idlePeriodMs) {
         return kStatus_USB_Busy;
     }
 
-    bool hasIdleElapsed = Timer_GetElapsedTimeMicros(&usbGenericHidReportLastSendTime) > idlePeriodUs;
+    bool hasIdleElapsed = (Timer_GetElapsedTimeMicros(&usbGenericHidReportLastSendTime) / 1000) > idlePeriodMs;
     return hasIdleElapsed ? kStatus_USB_Success : kStatus_USB_Busy;
 }
 

--- a/right/src/usb_interfaces/usb_interface_media_keyboard.c
+++ b/right/src/usb_interfaces/usb_interface_media_keyboard.c
@@ -40,12 +40,12 @@ usb_status_t UsbMediaKeyboardAction(void)
 
 usb_status_t UsbMediaKeyboardCheckIdleElapsed()
 {
-    uint16_t idlePeriodUs = ((usb_device_hid_struct_t*)UsbCompositeDevice.mediaKeyboardHandle)->idleRate * 4 * 1000; // idleRate is in 4ms units.
-    if (!idlePeriodUs) {
+    uint16_t idlePeriodMs = ((usb_device_hid_struct_t*)UsbCompositeDevice.mediaKeyboardHandle)->idleRate * 4; // idleRate is in 4ms units.
+    if (!idlePeriodMs) {
         return kStatus_USB_Busy;
     }
 
-    bool hasIdleElapsed = Timer_GetElapsedTimeMicros(&usbMediaKeyboardReportLastSendTime) > idlePeriodUs;
+    bool hasIdleElapsed = (Timer_GetElapsedTimeMicros(&usbMediaKeyboardReportLastSendTime) / 1000) > idlePeriodMs;
     return hasIdleElapsed ? kStatus_USB_Success : kStatus_USB_Busy;
 }
 

--- a/right/src/usb_interfaces/usb_interface_mouse.c
+++ b/right/src/usb_interfaces/usb_interface_mouse.c
@@ -41,12 +41,12 @@ usb_status_t UsbMouseAction(void)
 
 usb_status_t UsbMouseCheckIdleElapsed()
 {
-    uint16_t idlePeriodUs = ((usb_device_hid_struct_t*)UsbCompositeDevice.mouseHandle)->idleRate * 4 * 1000; // idleRate is in 4ms units.
-    if (!idlePeriodUs) {
+    uint16_t idlePeriodMs = ((usb_device_hid_struct_t*)UsbCompositeDevice.mouseHandle)->idleRate * 4; // idleRate is in 4ms units.
+    if (!idlePeriodMs) {
         return kStatus_USB_Busy;
     }
 
-    bool hasIdleElapsed = Timer_GetElapsedTimeMicros(&usbMouseReportLastSendTime) > idlePeriodUs;
+    bool hasIdleElapsed = (Timer_GetElapsedTimeMicros(&usbMouseReportLastSendTime) / 1000) > idlePeriodMs;
     return hasIdleElapsed ? kStatus_USB_Success : kStatus_USB_Busy;
 }
 


### PR DESCRIPTION
I did this originally, locally, but later changed it to `us` units to avoid the division and forgot to update the size of the intermediate types. As a result, this causes an arithmetic overflow on HID idle periods above 64ms, which is very likely.

If set, the actual idle period would be extremely uneven, and much faster than intended - so BIOS and other reduced feature hosts would see many key repeats rather than just one or two per second.