### PR TITLE
Sanitize inputs via Macros_ParseError.

### DIFF
--- a/right/src/macro_set_command.c
+++ b/right/src/macro_set_command.c
@@ -32,6 +32,10 @@ static void moduleNavigationMode(const char* arg1, const char *textEnd, module_c
     layer_id_t layerId = Macros_ParseLayerId(arg1, textEnd);
     navigation_mode_t modeId = ParseNavigationModeId(NextTok(arg1, textEnd), textEnd);
 
+    if (Macros_ParserError) {
+        return;
+    }
+
     module->navigationModes[layerId] = modeId;
 }
 
@@ -86,6 +90,10 @@ static void module(const char* arg1, const char *textEnd)
     module_configuration_t* module = GetModuleConfiguration(moduleId);
 
     const char* arg2 = proceedByDot(arg1, textEnd);
+
+    if (Macros_ParserError) {
+        return;
+    }
 
     if (TokenMatches(arg2, textEnd, "navigationMode")) {
         const char* arg3 = proceedByDot(arg2, textEnd);
@@ -235,8 +243,12 @@ static void navigationModeAction(const char* arg1, const char *textEnd)
 
     navigationMode = ParseNavigationModeId(arg1, textEnd);
 
-    if(navigationMode != NavigationMode_Caret && navigationMode != NavigationMode_Media && navigationMode != NavigationMode_Zoom) {
+    if(navigationMode < NavigationMode_RemappableFirst || navigationMode > NavigationMode_RemappableLast) {
         Macros_ReportError("Invalid or non-remapable navigation mode", arg1, textEnd);
+    }
+
+    if (Macros_ParserError) {
+        return;
     }
 
     if (TokenMatches(arg2, textEnd, "left")) {
@@ -286,6 +298,10 @@ static void keymapAction(const char* arg1, const char *textEnd)
         Macros_ReportError("invalid key id:", arg2, textEnd);
     }
 
+    if (Macros_ParserError) {
+        return;
+    }
+
     key_action_t* action = &CurrentKeymap[layerId][slotIdx][inSlotIdx];
 
     if(macroIndex == 255) {
@@ -322,6 +338,10 @@ static void modLayerTriggers(const char* arg1, const char *textEnd)
         break;
     default:
         Macros_ReportError("This layer does not allow modifier triggers.", arg1, specifier);
+        return;
+    }
+
+    if (Macros_ParserError) {
         return;
     }
 

--- a/right/src/macros.h
+++ b/right/src/macros.h
@@ -226,6 +226,7 @@
     extern bool Macros_WakedBecauseOfTime;
     extern bool Macros_WakedBecauseOfKeystateChange;
     extern uint16_t DoubletapConditionTimeout;
+    extern bool Macros_ParserError;
 
 // Functions:
 

--- a/right/src/module.h
+++ b/right/src/module.h
@@ -14,14 +14,21 @@
 // Typedefs:
 
     typedef enum {
+        /* fixed behaviour */
         NavigationMode_Cursor,
         NavigationMode_Scroll,
+        NavigationMode_Zoom,
+        NavigationMode_None,
+
+        /* action_t mapped behaviour */
         NavigationMode_Caret,
         NavigationMode_Media,
-        NavigationMode_Zoom,
         NavigationMode_ZoomPc,
         NavigationMode_ZoomMac,
-        NavigationMode_None,
+
+        /* helpers */
+        NavigationMode_RemappableFirst = NavigationMode_Caret,
+        NavigationMode_RemappableLast = NavigationMode_ZoomMac,
     } navigation_mode_t;
 
     typedef struct {


### PR DESCRIPTION
I am not sanitizing value reads at the moment - like Int or Float parsing. I will consider it when dealing with the config management, and relative value adjustments - I hope it will be possible to deal with these in some reasonable generic fashion.