### PR TITLE
feat(doc): open links in browser when running in the Agent

### DIFF
--- a/doc/dist/script.mjs
+++ b/doc/dist/script.mjs
@@ -229,6 +229,7 @@ const app = createApp({
     data() {
         return {
             modules: [],
+            isRunningInAgent: false,
             moduleStrings: {
                 2: 'keycluster',
                 3: 'trackball',
@@ -571,18 +572,23 @@ const app = createApp({
         const self = this;
         window.addEventListener('message', function(event) {
             switch (event.data.action) {
+                case 'agent-message-context': {
+                    const data = event.data;
+                    self.modules = data.modules;
+                    self.isRunningInAgent = data.isRunningInAgent;
+                    updateWidgets();
+                    break;
+                }
+
                 case 'agent-message-editor-got-focus': {
                     const data = event.data;
                     currentCommand = data.command;
-                    self.modules = data.modules;
                     updateWidgets();
                     break;
                 }
 
                 case 'agent-message-editor-lost-focus': {
-                    const data = event.data;
                     currentCommand = '';
-                    self.modules = data.modules;
                     updateWidgets();
                     break;
                 }
@@ -620,6 +626,24 @@ const app = createApp({
             const scancode = this.scancode === '(none)' ? '' : this.scancode;
             return `${modifierMask}${separator}${scancode}`;
         }
+    },
+    mounted() {
+        const self = this;
+        function handleAnchorClick(event) {
+            if (self.isRunningInAgent) {
+                event.preventDefault();
+                const message = {
+                    action: 'doc-message-open-link',
+                    url: event.target.href
+                };
+                window.parent.postMessage(message, '*');
+            }
+        }
+        document
+          .querySelectorAll('a[target="_blank"]')
+          .forEach(element => {
+              element.addEventListener('click', handleAnchorClick)
+          })
     },
     computed: {
         rightModules() {

--- a/doc/test.mjs
+++ b/doc/test.mjs
@@ -14,11 +14,23 @@ const app = createApp({
         };
     },
     mounted() {
+        const self = this;
         Split(['#left', '#right'], {
             sizes: [50, 50],
         });
         window.addEventListener('message', function(event) {
             switch (event.data.action) {
+                case 'doc-message-inited': {
+                    const message = {
+                        action: 'agent-message-context',
+                        isRunningInAgent: false,
+                        modules: self.getModules(),
+                        version: '1.0.0'
+                    }
+                    self.sendMessage(message)
+                    break;
+                }
+
                 case 'doc-message-set-macro': {
                     currentTarget.value = event.data.command;
                     break;
@@ -31,25 +43,37 @@ const app = createApp({
             if (event !== 'module') {
                 currentTarget = event.target;
                 this.command = currentTarget.value;
+                const message = {
+                    action: 'agent-message-editor-got-focus',
+                    command: this.command,
+                };
+
+                this.sendMessage(message)
+            } else {
+                const message = {
+                    action: 'agent-message-context',
+                    isRunningInAgent: false,
+                    modules: this.getModules(),
+                    version: '1.0.0'
+                }
+                this.sendMessage(message)
             }
 
+        },
+        getModules() {
             const modules = [
                 {moduleId: 2, isAttached: this.keycluster},
                 {moduleId: 3, isAttached: this.trackball},
                 {moduleId: 4, isAttached: this.trackpoint},
                 {moduleId: 5, isAttached: this.touchpad},
             ].filter(module => module.isAttached)
-            .map(module => module.moduleId);
+              .map(module => module.moduleId);
 
-            const message = {
-                version: '1.0.0',
-                action: 'agent-message-editor-got-focus',
-                modules,
-                command: this.command,
-            };
-
-            this.$refs.iframe.contentWindow.postMessage(message, '*');
+            return modules;
         },
+        sendMessage(message) {
+            this.$refs.iframe.contentWindow.postMessage(message, '*');
+        }
     },
 });
 


### PR DESCRIPTION
Summary
 - introduced the `agent-message-context` event. The event will dispatch if any of the message property changes. Currently, the `modules` relevant
 - removed the `modules` property from the `gent-message-editor-got-focus` and `agent-message-editor-lost-focus` actions
 - introduced the `doc-message-open-link` action. Parameters of the message:
   - 'url': Agent will open the URL in a browser window