### PR TITLE
ci: deploy smart macro docs to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -20,5 +20,6 @@ jobs:
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.0.0
         with:
-          folder: doc/dist
           clean: true
+          folder: doc/dist
+          target-folder: doc

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,24 @@
+name: Deploy GH Pages
+
+on:
+  release:
+    types:
+      - released
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    name: Deploy GitHup Pages
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@4.0.0
+        with:
+          folder: doc/dist
+          clean: true


### PR DESCRIPTION
CI will automatically deploy the `doc/dist` to GitHub Pages after released a new version.

It is a first part of UltimateHackingKeyboard/agent#1912