### PR TITLE
Fix / refactor GetNavigationModeConfiguration.

### DIFF
--- a/right/src/caret_config.c
+++ b/right/src/caret_config.c
@@ -2,71 +2,67 @@
 #include "arduino_hid/ConsumerAPI.h"
 #include "arduino_hid/SystemAPI.h"
 #include "macros.h"
+#include "module.h"
 
-caret_configuration_t caretMediaMode = {
-    .axisActions = { //axis array
-        { // horizontal axis
-            .positiveAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Media, .scancode = MEDIA_NEXT }},
-            .negativeAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Media, .scancode = MEDIA_PREVIOUS }},
-        },
-        { // vertical axis
-            .positiveAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Media, .scancode = MEDIA_VOLUME_UP }},
-            .negativeAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Media, .scancode = MEDIA_VOLUME_DOWN }},
-         }
-    }
-};
-
-
-caret_configuration_t caretCaretMode = {
-    .axisActions = { //axis array
-        { // horizontal axis
-            .positiveAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_RIGHT_ARROW }},
-            .negativeAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_LEFT_ARROW }},
-        },
-        { // vertical axis
-            .positiveAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_UP_ARROW }},
-            .negativeAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_DOWN_ARROW }},
+caret_configuration_t remappableModes[] = {
+    {
+        // caret mode
+        .axisActions = { //axis array
+            { // horizontal axis
+                .positiveAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_RIGHT_ARROW }},
+                .negativeAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_LEFT_ARROW }},
+            },
+            { // vertical axis
+                .positiveAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_UP_ARROW }},
+                .negativeAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_DOWN_ARROW }},
+            }
         }
-    }
-};
-
-caret_configuration_t zoomMacMode = {
-    .axisActions = { //axis array
-        { // horizontal axis
-            .positiveAction = { .type = KeyActionType_None },
-            .negativeAction = { .type = KeyActionType_None },
-        },
-        { // vertical axis
-            .positiveAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_EQUAL_AND_PLUS, .modifiers = HID_KEYBOARD_MODIFIER_LEFTGUI | HID_KEYBOARD_MODIFIER_LEFTSHIFT}},
-            .negativeAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_MINUS_AND_UNDERSCORE, .modifiers = HID_KEYBOARD_MODIFIER_LEFTGUI}},
+    },
+    {
+        // media mode
+        .axisActions = { //axis array
+            { // horizontal axis
+                .positiveAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Media, .scancode = MEDIA_NEXT }},
+                .negativeAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Media, .scancode = MEDIA_PREVIOUS }},
+            },
+            { // vertical axis
+                .positiveAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Media, .scancode = MEDIA_VOLUME_UP }},
+                .negativeAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Media, .scancode = MEDIA_VOLUME_DOWN }},
+            }
         }
-    }
-};
-
-caret_configuration_t zoomPcMode = {
-    .axisActions = { //axis array
-        { // horizontal axis
-            .positiveAction = { .type = KeyActionType_None },
-            .negativeAction = { .type = KeyActionType_None },
-        },
-        { // vertical axis
-            .positiveAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_EQUAL_AND_PLUS, .modifiers = HID_KEYBOARD_MODIFIER_LEFTCTRL | HID_KEYBOARD_MODIFIER_LEFTSHIFT}},
-            .negativeAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_MINUS_AND_UNDERSCORE, .modifiers = HID_KEYBOARD_MODIFIER_LEFTCTRL}},
+    },
+    {
+        // zoomMac
+        .axisActions = { //axis array
+            { // horizontal axis
+                .positiveAction = { .type = KeyActionType_None },
+                .negativeAction = { .type = KeyActionType_None },
+            },
+            { // vertical axis
+                .positiveAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_EQUAL_AND_PLUS, .modifiers = HID_KEYBOARD_MODIFIER_LEFTGUI | HID_KEYBOARD_MODIFIER_LEFTSHIFT}},
+                .negativeAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_MINUS_AND_UNDERSCORE, .modifiers = HID_KEYBOARD_MODIFIER_LEFTGUI}},
+            }
         }
-    }
+    },
+    {
+        // zoomPc
+        .axisActions = { //axis array
+            { // horizontal axis
+                .positiveAction = { .type = KeyActionType_None },
+                .negativeAction = { .type = KeyActionType_None },
+            },
+            { // vertical axis
+                .positiveAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_EQUAL_AND_PLUS, .modifiers = HID_KEYBOARD_MODIFIER_LEFTCTRL | HID_KEYBOARD_MODIFIER_LEFTSHIFT}},
+                .negativeAction = { .type = KeyActionType_Keystroke, .keystroke = { .keystrokeType = KeystrokeType_Basic, .scancode = HID_KEYBOARD_SC_MINUS_AND_UNDERSCORE, .modifiers = HID_KEYBOARD_MODIFIER_LEFTCTRL}},
+            }
+        }
+    },
 };
 
-caret_configuration_t* GetModuleCaretConfiguration(int8_t moduleId, navigation_mode_t mode) {
-    switch (mode) {
-        case NavigationMode_Caret:
-            return &caretCaretMode;
-        case NavigationMode_Media:
-            return &caretMediaMode;
-        case NavigationMode_ZoomPc:
-            return &zoomPcMode;
-        case NavigationMode_ZoomMac:
-            return &zoomMacMode;
-        default:
+caret_configuration_t* GetNavigationModeConfiguration(navigation_mode_t mode) {
+    if (NavigationMode_RemappableFirst <= mode && mode < NavigationMode_RemappableLast) {
+        return &remappableModes[mode - NavigationMode_RemappableFirst];
+    } else {
             Macros_ReportErrorNum("Mode referenced in in valid context:", mode);
             return NULL;
     }
@@ -75,11 +71,7 @@ caret_configuration_t* GetModuleCaretConfiguration(int8_t moduleId, navigation_m
 
 void SetModuleCaretConfiguration(navigation_mode_t mode, caret_axis_t axis, bool positive, key_action_t action)
 {
-    caret_configuration_t* config = &caretMediaMode;
-
-    if(mode == NavigationMode_Caret) {
-        config = &caretCaretMode;
-    }
+    caret_configuration_t* config = GetNavigationModeConfiguration(mode);
 
     key_action_t* actionSlot = positive ? &config->axisActions[axis].positiveAction : &config->axisActions[axis].negativeAction;
 

--- a/right/src/caret_config.c
+++ b/right/src/caret_config.c
@@ -60,10 +60,10 @@ caret_configuration_t remappableModes[] = {
 };
 
 caret_configuration_t* GetNavigationModeConfiguration(navigation_mode_t mode) {
-    if (NavigationMode_RemappableFirst <= mode && mode < NavigationMode_RemappableLast) {
+    if (NavigationMode_RemappableFirst <= mode && mode <= NavigationMode_RemappableLast) {
         return &remappableModes[mode - NavigationMode_RemappableFirst];
     } else {
-            Macros_ReportErrorNum("Mode referenced in in valid context:", mode);
+            Macros_ReportErrorNum("Mode referenced in invalid context. Only remappable modes are supported here.", mode);
             return NULL;
     }
 }

--- a/right/src/caret_config.h
+++ b/right/src/caret_config.h
@@ -28,7 +28,7 @@
 
 // Functions:
 
-    caret_configuration_t* GetModuleCaretConfiguration(int8_t moduleId, navigation_mode_t mode);
+    caret_configuration_t* GetNavigationModeConfiguration(navigation_mode_t mode);
     void SetModuleCaretConfiguration(navigation_mode_t mode, caret_axis_t axis, bool positive, key_action_t action);
 
 #endif

--- a/right/src/mouse_controller.c
+++ b/right/src/mouse_controller.c
@@ -428,7 +428,7 @@ static void progressZoomAction(module_kinetic_state_t* ks) {
             return;
         }
 
-        caret_configuration_t* currentCaretConfig = GetModuleCaretConfiguration(ks->currentModuleId, mode);
+        caret_configuration_t* currentCaretConfig = GetNavigationModeConfiguration(mode);
         caret_dir_action_t* dirActions = &currentCaretConfig->axisActions[CaretAxis_Vertical];
         ks->caretAction.action = ks->zoomSign > 0 ? dirActions->positiveAction : dirActions->negativeAction;
     }
@@ -453,7 +453,7 @@ static void handleNewCaretModeAction(caret_axis_t axis, uint8_t resultSign, int1
         case NavigationMode_ZoomPc:
         case NavigationMode_Media:
         case NavigationMode_Caret: {
-            caret_configuration_t* currentCaretConfig = GetModuleCaretConfiguration(ks->currentModuleId, ks->currentNavigationMode);
+            caret_configuration_t* currentCaretConfig = GetNavigationModeConfiguration(ks->currentNavigationMode);
             caret_dir_action_t* dirActions = &currentCaretConfig->axisActions[ks->caretAxis];
             ks->caretAction.action = resultSign > 0 ? dirActions->positiveAction : dirActions->negativeAction;
             ks->caretFakeKeystate.current = true;


### PR DESCRIPTION
SetModuleCaretConfiguration was not properly extended when zoom modes were added. As a result, attempts to rebind zoom mode would alter media mode instead.

Steps to reproduce:

```
set navigationModeAction.zoomPc.left keystroke a
set navigationModeAction.zoomPc.right keystroke b
set navigationModeAction.zoomPc.up keystroke c
set navigationModeAction.zoomPc.down keystroke d
```

Now, media mode produces a,b,c,d while zoom mode is unaltered.