### PR TITLE
Rename super to gui and control to ctrl, for sake of consistency.

### DIFF
--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -122,7 +122,7 @@ The following grammar is supported:
     COMMAND = set leds.enabled BOOLEAN
     COMMAND = set leds.brightness <0-1 multiple of default (FLOAT)>
     COMMAND = set leds.fadeTimeout <minutes to fade after (NUMBER)>
-    COMMAND = set modifierLayerTriggers.{shift|alt|gui|ctrl} {left|right|both}
+    COMMAND = set modifierLayerTriggers.{shift|alt|super|ctrl} {left|right|both}
     CONDITION = {ifShortcut | ifNotShortcut} [IFSHORTCUTFLAGS]* [KEYID]+
     CONDITION = {ifGesture | ifNotGesture} [IFSHORTCUTFLAGS]* [KEYID]+
     CONDITION = {ifPrimary | ifSecondary}
@@ -147,7 +147,7 @@ The following grammar is supported:
     MODIFIER = autoRepeat
     IFSHORTCUTFLAGS = noConsume | transitive | anyOrder | orGate | timeoutIn <time in ms (NUMBER)> | cancelIn <time in ms(NUMBER)>
     DIRECTION = {left|right|up|down}
-    LAYERID = {fn|mouse|mod|base|fn2|fn3|fn4|fn5|alt|shift|gui|ctrl}|last|previous
+    LAYERID = {fn|mouse|mod|base|fn2|fn3|fn4|fn5|alt|shift|super|ctrl}|last|previous
     KEYMAPID = <abbrev>|last
     MACROID = last|CHAR|NUMBER
     NUMBER = [0-9]+ | -[0-9]+ | #<register idx (NUMBER)> | #key | @<relative macro action index(NUMBER)> | %<key idx in postponer queue (NUMBER)>
@@ -193,8 +193,8 @@ The following grammar is supported:
     COMMAND = switchLayer LAYERID
     COMMAND = switchKeymapLayer KEYMAPID LAYERID
     COMMAND = resolveNextKeyEq <queue position (NUMBER)> KEYID {<time in ms>|untilRelease} <action adr (ADDRESS)> <action adr (ADDRESS)>
-    COMMAND = set modifierLayerTriggers.{super|control} {left|right|both}
-    LAYERID = super | control
+    COMMAND = set modifierLayerTriggers.{control} {left|right|both}
+    LAYERID = control
     #########
     #REMOVED#
     #########
@@ -514,7 +514,7 @@ For the purpose of toggling functionality on and off, and for global constants m
     - `backlight.constantRgb.rgb NUMBER NUMBER NUMBER` allows setting custom constant colour for entire keyboard. E.g.: `set backlight.strategy constantRgb; set backlight.constantRgb.rgb 255 0 0` to make entire keyboard shine red.
 
 - modifier layer triggers:
-    - `set modifierLayerTriggers.{shift|alt|gui|ctrl} { left | right | both }` controls whether modifier layers are triggered by left or right or either of the modifiers.
+    - `set modifierLayerTriggers.{shift|alt|super|ctrl} {left|right|both}` controls whether modifier layers are triggered by left or right or either of the modifiers.
 
 ### Argument parsing rules:
 

--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -122,7 +122,7 @@ The following grammar is supported:
     COMMAND = set leds.enabled BOOLEAN
     COMMAND = set leds.brightness <0-1 multiple of default (FLOAT)>
     COMMAND = set leds.fadeTimeout <minutes to fade after (NUMBER)>
-    COMMAND = set modifierLayerTriggers.{shift|alt|super|control} {left|right|both}
+    COMMAND = set modifierLayerTriggers.{shift|alt|gui|ctrl} {left|right|both}
     CONDITION = {ifShortcut | ifNotShortcut} [IFSHORTCUTFLAGS]* [KEYID]+
     CONDITION = {ifGesture | ifNotGesture} [IFSHORTCUTFLAGS]* [KEYID]+
     CONDITION = {ifPrimary | ifSecondary}
@@ -147,7 +147,7 @@ The following grammar is supported:
     MODIFIER = autoRepeat
     IFSHORTCUTFLAGS = noConsume | transitive | anyOrder | orGate | timeoutIn <time in ms (NUMBER)> | cancelIn <time in ms(NUMBER)>
     DIRECTION = {left|right|up|down}
-    LAYERID = {fn|mouse|mod|base|fn2|fn3|fn4|fn5|alt|shift|super|control}|last|previous
+    LAYERID = {fn|mouse|mod|base|fn2|fn3|fn4|fn5|alt|shift|gui|ctrl}|last|previous
     KEYMAPID = <abbrev>|last
     MACROID = last|CHAR|NUMBER
     NUMBER = [0-9]+ | -[0-9]+ | #<register idx (NUMBER)> | #key | @<relative macro action index(NUMBER)> | %<key idx in postponer queue (NUMBER)>
@@ -193,9 +193,11 @@ The following grammar is supported:
     COMMAND = switchLayer LAYERID
     COMMAND = switchKeymapLayer KEYMAPID LAYERID
     COMMAND = resolveNextKeyEq <queue position (NUMBER)> KEYID {<time in ms>|untilRelease} <action adr (ADDRESS)> <action adr (ADDRESS)>
-    ##########
-    #REMOVEWD#
-    ##########
+    COMMAND = set modifierLayerTriggers.{super|control} {left|right|both}
+    LAYERID = super | control
+    #########
+    #REMOVED#
+    #########
     COMMAND = setExpDriver <baseSpeed (FLOAT:0.0)> <speed (FLOAT:1.0)> <acceleration (FLOAT:0.5)> <midSpeed (FLOAT:3000)>
     COMMAND = setSplitCompositeKeystroke {0|1}
     COMMAND = setActivateOnRelease {0|1}
@@ -239,6 +241,7 @@ The following grammar is supported:
         - normal non-macro modifiers (not accompanied by a scancode) are treated as `input` by default.
         - macro modifiers are treated as `output`.
     - `{p|r|h|t}` - press release hold tap - by default corresponds to the command used to invoke the sequence, but can be overriden for any.
+    - windows, super, gui - all these are different names for the same key. For sake of consistency, we choose `gui`.
 
 ### Control flow, macro execution (aka "functions"):
 
@@ -511,7 +514,7 @@ For the purpose of toggling functionality on and off, and for global constants m
     - `backlight.constantRgb.rgb NUMBER NUMBER NUMBER` allows setting custom constant colour for entire keyboard. E.g.: `set backlight.strategy constantRgb; set backlight.constantRgb.rgb 255 0 0` to make entire keyboard shine red.
 
 - modifier layer triggers:
-    - `set modifierLayerTriggers.{shift|alt|super|control} { left | right | both }` controls whether modifier layers are triggered by left or right or either of the modifiers.
+    - `set modifierLayerTriggers.{shift|alt|gui|ctrl} { left | right | both }` controls whether modifier layers are triggered by left or right or either of the modifiers.
 
 ### Argument parsing rules:
 

--- a/doc/dist/index.html
+++ b/doc/dist/index.html
@@ -416,7 +416,7 @@ Syntax is <code>set navigationModeAction.{mode}.{direction} {action}</code><br>
 Syntax is <code>set modifierLayerTriggers.{layer} {modifiers}</code><br>
 
 <ul>
-<li><code>{layer}</code> is of <code>shift</code>, <code>alt</code>, <code>super</code>, <code>control</code></li>
+<li><code>{layer}</code> is of <code>shift</code>, <code>alt</code>, <code>super</code>, <code>ctrl</code></li>
 <li><code>{modifiers}</code> is of <code>left</code>, <code>right</code>, <code>both (default)</code></li>
 </ul>
 

--- a/right/src/layer.h
+++ b/right/src/layer.h
@@ -7,7 +7,7 @@
 
 // Macros:
 
-#define IS_MODIFIER_LAYER(L) (LayerId_Shift <= (L) && (L) <= LayerId_Super)
+#define IS_MODIFIER_LAYER(L) (LayerId_Shift <= (L) && (L) <= LayerId_Gui)
 
 // Typedefs:
 
@@ -21,10 +21,10 @@
         LayerId_Fn4,
         LayerId_Fn5,
         LayerId_Shift,
-        LayerId_Control,
+        LayerId_Ctrl,
         LayerId_Alt,
-        LayerId_Super,
-        LayerId_Last = LayerId_Super,
+        LayerId_Gui,
+        LayerId_Last = LayerId_Gui,
         LayerId_Count = LayerId_Last + 1,
     } layer_id_t;
 

--- a/right/src/macro_set_command.c
+++ b/right/src/macro_set_command.c
@@ -372,7 +372,7 @@ static void modLayerTriggers(const char* arg1, const char *textEnd)
         left = HID_KEYBOARD_MODIFIER_LEFTSHIFT ;
         right = HID_KEYBOARD_MODIFIER_RIGHTSHIFT ;
         break;
-    case LayerId_Control:
+    case LayerId_Ctrl:
         left = HID_KEYBOARD_MODIFIER_LEFTCTRL ;
         right = HID_KEYBOARD_MODIFIER_RIGHTCTRL ;
         break;
@@ -380,7 +380,7 @@ static void modLayerTriggers(const char* arg1, const char *textEnd)
         left = HID_KEYBOARD_MODIFIER_LEFTALT ;
         right = HID_KEYBOARD_MODIFIER_RIGHTALT ;
         break;
-    case LayerId_Super:
+    case LayerId_Gui:
         left = HID_KEYBOARD_MODIFIER_LEFTGUI ;
         right = HID_KEYBOARD_MODIFIER_RIGHTGUI ;
         break;

--- a/right/src/macros.c
+++ b/right/src/macros.c
@@ -1013,15 +1013,10 @@ uint8_t Macros_ParseLayerId(const char* arg1, const char* cmdEnd)
         case 'c':
             if (TokenMatches(arg1, cmdEnd, "current")) {
                 return ActiveLayer;
+            } else if (TokenMatches(arg1, cmdEnd, "ctrl")) {
+                return LayerId_Ctrl;
             } else if (TokenMatches(arg1, cmdEnd, "control")) {
-                return LayerId_Control;
-            }
-            break;
-        case 'm':
-            if (TokenMatches(arg1, cmdEnd, "mouse")) {
-                return LayerId_Mouse;
-            } else if (TokenMatches(arg1, cmdEnd, "mod")) {
-                return LayerId_Mod;
+                return LayerId_Ctrl;
             }
             break;
         case 'f':
@@ -1037,9 +1032,21 @@ uint8_t Macros_ParseLayerId(const char* arg1, const char* cmdEnd)
                 return LayerId_Fn5;
             }
             break;
+        case 'g':
+            if (TokenMatches(arg1, cmdEnd, "gui")) {
+                return LayerId_Gui;
+            }
+            break;
         case 'l':
             if (TokenMatches(arg1, cmdEnd, "last")) {
                 return lastLayerIdx;
+            }
+            break;
+        case 'm':
+            if (TokenMatches(arg1, cmdEnd, "mouse")) {
+                return LayerId_Mouse;
+            } else if (TokenMatches(arg1, cmdEnd, "mod")) {
+                return LayerId_Mod;
             }
             break;
         case 'p':
@@ -1051,7 +1058,7 @@ uint8_t Macros_ParseLayerId(const char* arg1, const char* cmdEnd)
             if (TokenMatches(arg1, cmdEnd, "shift")) {
                 return LayerId_Shift;
             } else if (TokenMatches(arg1, cmdEnd, "super")) {
-                return LayerId_Super;
+                return LayerId_Gui;
             }
             break;
     }


### PR DESCRIPTION
This change is mostly about `control` -> ctrl, but when refactoring, I have also noticed the 'super' discrepancy. I think we should prefer a single consistent naming, at least in the macro language. Due to 's' mnemonic being taken by shift, I have changed it to 'gui', which we are already using anyways (`ifGui`, shortcut notation...).

Original syntax is still accepted.

Closes #566.

@mondalaci do you have any strong opinion on the super vs gui? 

Since 'g' has to be used in the shortcut notation and super is more intuitive in agent, I guess we can't fully unify the terminology anyways.