### PR TITLE
Fix double unschedule on call macro command.

### DIFF
--- a/right/src/debug.h
+++ b/right/src/debug.h
@@ -56,6 +56,8 @@
 
     #define ASSERT(C) if (!(C)) { Macros_ReportError("Assertion failed: "#C, NULL, NULL); }
 
+    #define IF_DEBUG(CMD) CMD
+
 // Variables:
 
     extern uint8_t CurrentWatch;
@@ -94,5 +96,6 @@
     #define ERR(E)
     #define ERRN(E, N)
     #define ASSERT(C)
+    #define IF_DEBUG(CMD)
 
 #endif

--- a/right/src/macros.c
+++ b/right/src/macros.c
@@ -86,6 +86,7 @@ uint16_t DoubletapConditionTimeout = 400;
 uint16_t AutoRepeatInitialDelay = 500;
 uint16_t AutoRepeatDelayRate = 50;
 
+static void checkSchedulerHealth(const char* tag);
 static void wakeMacroInSlot(uint8_t slotIdx);
 static void scheduleSlot(uint8_t slotIdx);
 static void unscheduleCurrentSlot();
@@ -3274,6 +3275,61 @@ static void wakeMacroInSlot(uint8_t slotIdx)
     }
 }
 
+static void __attribute__((__unused__)) checkSchedulerHealth(const char* tag) {
+    static const char* lastCmd = NULL;
+    uint8_t scheduledCount = 0;
+    uint8_t playingCount = 0;
+
+    // count active macros
+    for (uint8_t i = 0; i < MACRO_STATE_POOL_SIZE; i++) {
+        if (MacroState[i].ms.macroPlaying && !MacroState[i].ms.macroSleeping) {
+            playingCount++;
+        }
+    }
+
+    // count length of the scheduling loop
+    if (scheduler.activeSlotCount != 0) {
+        uint8_t currentSlot = scheduler.currentSlotIdx;
+        uint8_t startedAt = currentSlot;
+        for (uint8_t i = 0; i < MACRO_STATE_POOL_SIZE; i++) {
+            scheduledCount++;
+
+            if (!MacroState[currentSlot].ms.macroPlaying) {
+                Macros_ReportErrorNum("This slot is not playing, but is scheduled!", currentSlot);
+            }
+
+            if (MacroState[currentSlot].ms.macroSleeping) {
+                Macros_ReportErrorNum("This slot is sleeping, but is scheduled!", currentSlot);
+            }
+
+            currentSlot = MacroState[currentSlot].ms.nextSlot;
+            if (currentSlot == startedAt) {
+                break;
+            }
+        }
+    }
+
+    const char* thisCmd = NULL;
+
+    // retrieve currently running command if possible
+    if (s != NULL && s->ms.currentMacroAction.type == MacroActionType_Command) {
+        thisCmd = s->ms.currentMacroAction.cmd.text + s->ms.commandBegin;
+    }
+
+    // check the results
+    if (scheduledCount != playingCount || scheduledCount != scheduler.activeSlotCount) {
+        Macros_ReportError("Scheduled counts don't match up!", tag, NULL);
+        Macros_ReportErrorNum("Scheduled", scheduledCount);
+        Macros_ReportErrorNum("Playing", playingCount);
+        Macros_ReportErrorNum("Active slot count", scheduler.activeSlotCount);
+        Macros_ReportError("Prev cmd", lastCmd, lastCmd+10);
+        Macros_ReportError("This cmd", thisCmd, thisCmd+10);
+        processStatsActiveMacrosCommand();
+    }
+
+    lastCmd = thisCmd;
+}
+
 static void scheduleSlot(uint8_t slotIdx)
 {
     if (!MacroState[slotIdx].ms.macroScheduled) {
@@ -3304,13 +3360,19 @@ static void scheduleSlot(uint8_t slotIdx)
 
 static void unscheduleCurrentSlot()
 {
-    if (MacroState[scheduler.currentSlotIdx].ms.macroScheduled) {
+    if (scheduler.currentSlotIdx == (s - MacroState) && MacroState[scheduler.currentSlotIdx].ms.macroScheduled) {
         MacroState[scheduler.previousSlotIdx].ms.nextSlot = MacroState[scheduler.currentSlotIdx].ms.nextSlot;
         MacroState[scheduler.currentSlotIdx].ms.macroScheduled = false;
         scheduler.lastQueuedSlot = scheduler.lastQueuedSlot == scheduler.currentSlotIdx ? scheduler.previousSlotIdx : scheduler.lastQueuedSlot;
         scheduler.currentSlotIdx = scheduler.previousSlotIdx;
         scheduler.activeSlotCount--;
+    } else if (scheduler.currentSlotIdx != (s - MacroState) && !s->ms.macroScheduled) {
+        // This means that current slot is already unscheduled but scheduler state is fine.
+        // This may happen (for instance) if callMacro is the last command of a macro.
+        // (We get one unschedule attempt for sleeping the macro, but at the same time for macro end.)
+        return;
     } else {
+        // this means that the state is inconsistent for some reason
         ERR("Unsechuling non-scheduled slot attempted!");
     }
 }
@@ -3337,7 +3399,9 @@ static void executeBlocking(void)
         s = &MacroState[scheduler.currentSlotIdx];
 
         if (s->ms.macroPlaying && !s->ms.macroSleeping) {
+            IF_DEBUG(checkSchedulerHealth("co1"));
             res = continueMacro();
+            IF_DEBUG(checkSchedulerHealth("co2"));
         }
 
         if ((someoneBlocking = (res & MacroResult_BlockingFlag))) {


### PR DESCRIPTION
In order to reproduce the problem:

- use this config: [UserConfiguration_kt.txt](https://github.com/UltimateHackingKeyboard/firmware/files/10304856/UserConfiguration_kt.txt)
- tap left Mod
- tap backspace
- repeat 4x or so until ERR appears
- read out the error using 'p' (it complains about too many macros running)
- further `statsActiveMacros` would show that 12 `$onKeymapChange` macros got stuck, 4 in active state (but not progressing) and 8 in sleeping state (waiting for those other 4)
- further debug would probably show that some `$onKeymapChange` hooks did not work

----

In simple terms, this fixes a bug that would cause some macros get stuck during or after using the `call` command.

----

technical description of the problem:

callMacro manually unschedules the macro when putting it to sleep, and
returns as finished. If it is also the last command of a macro, the macro
gets unscheduled again because it has ended.

This would lead to unscheduleCurrentSlot() being called twice. Original
double-unschedule protection would not work, because
scheduler.currentSlotIdx gets automatically updated when unscheduling the
slot, therefore leading to another macro being unscheduled forever.

