### PR TITLE
Fix race condition on chording delay and secondary role.

### DIFF
--- a/right/src/postponer.c
+++ b/right/src/postponer.c
@@ -324,7 +324,9 @@ static void chording()
             postponer_buffer_record_type_t* b = &buffer[POS(i+1)];
             uint8_t pa = priority(a->key, a->active);
             uint8_t pb = priority(b->key, b->active);
-            if ( (a->active && !b->active) || (a->active && b->active && pa < pb) ) {
+            // Originally, this also swapped releases to go before presses.
+            // Not sure why anymore, but it caused race condition on secondary role.
+            if ( a->active && b->active && pa < pb ) {
                 if (a->key != b->key && b->time - a->time < ChordingDelay) {
                     postponer_buffer_record_type_t tmp = *a;
                     *a = *b;


### PR DESCRIPTION
Assume simple resolution strategy and chording delay of 50ms. Assume two presses that should produce secondary role. Instead, secondary role is active, but chording swaps the order of releases (since releases always have priority 0), so the second key acts as if primary role was activated.

Steps to reproduce:
- set `set chordingDelay 50`
- map a key to scancode 'p' with mod as secondary role
- map another key to 'x' on base layer and 'y' on mod layer
- tap both keys in a rapid sequence

Observe only 'x' being produced, but also mod indicator blinking. This is clearly wrong, because either secondary role should have been activated and `y` produced, or not activated and `px` produced.

(This is a race condition because secondary role acts based on the postponing queue *before* the swap takes place, and therefore chooses action inconsistently.)