### PR TITLE
Secondaries new port

### DIFF
--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -95,7 +95,18 @@ The following grammar is supported:
     COMMAND = set module.MODULEID.invertScrollDirection BOOLEAN
     COMMAND = set module.touchpad.pinchZoomDivisor <1-100 (FLOAT)>
     COMMAND = set module.touchpad.pinchZoomMode NAVIGATIONMODE
-    #NOTIMPLEMENTED COMMAND = set secondaryRoles
+
+    COMMAND = set secondaryRole.defaultStrategy { simple | advanced }
+    COMMAND = set secondaryRole.advanced.timeout <ms, 350 (NUMBER)>
+    COMMAND = set secondaryRole.advanced.timeoutAction { primary | secondary }
+    COMMAND = set secondaryRole.advanced.safetyMargin <ms, 50 (NUMBER)>
+    COMMAND = set secondaryRole.advanced.triggerByRelease BOOLEAN
+    COMMAND = set secondaryRole.advanced.doubletapToPrimary BOOLEAN
+    COMMAND = set secondaryRole.advanced.doubletapTime <ms, 200 (NUMBER)>
+
+    TODO: write docs
+    TODO: connect macros to regular secondary role
+
     COMMAND = set mouseKeys.{move|scroll}.initialSpeed <px/s, -100/20 (NUMBER)>
     COMMAND = set mouseKeys.{move|scroll}.baseSpeed <px/s, -800/20 (NUMBER)>
     COMMAND = set mouseKeys.{move|scroll}.initialAcceleration <px/s, ~1700/20 (NUMBER)>

--- a/doc-dev/user-guide.md
+++ b/doc-dev/user-guide.md
@@ -326,7 +326,7 @@ tapKey escape
 This strategy does the same as the `ifNotInterrupted` version, except it activates secondary role only after the other key is pressed. This strategy does not use any complicated postponing.
 
 Pros: it is reliable.
-Cons: it will activate during writing if you put it on alphanumeric key.
+Cons: it will activate during writing if you put it on an alphanumeric key.
 
 #### Native secondary role - advanced strategy
 

--- a/doc-dev/user-guide.md
+++ b/doc-dev/user-guide.md
@@ -275,15 +275,22 @@ In order to bind some action to doubletap, you may use two strategies:
     holdKey a
 ```
 
-Another concept which may or may not use our time machine is secondary roles.
+Another concept which may or may not use our time machine is secondary roles, namely the advanced strategy.
 
-Secondary role is a role which becomes active if another key is pressed with this key. It can be implemented in two variants: regular and postponed.
+### Secondary roles
 
-- Regular version can be implemented using `ifNotInterrupted`  - such macro always triggers secondary role, and once the key is released it either triggers primary role or not.
+Secondary role is a role which becomes active if another key is pressed with this key. It can be implemented in following variants: 
 
-- Postponed version postpones all other keypresses until it can distinguish between primary and secondary role. This is handy for alphabetic keys, or if the secondary role is not a no-op. The postponed version can be used either via `ifPrimary` and `ifSecondary` conditions, or via a `resolveSecondary`.
+- Using `ifInterrupted` command.
+- Using native secondary role driver (via `ifPrimary`/`ifSecondary` or GUI-mapping) with one of following resolution strategies:
+  - simple strategy
+  - advanced strategy which uses our time machine
 
-Regular implementation of secondary role:
+#### Simulating secondary roles without secondary roles
+
+Secondary role can be implemented using `ifNotInterrupted` condition  - such macro always triggers secondary role, and once the key is released it either triggers primary role or not.
+
+For instance:
 
 ```
 holdLayer mouse
@@ -299,21 +306,74 @@ ifPlaytime 200 break
 tapKey S-9
 ```
 
-Postponed secondary role switch using `ifPrimary`:
+#### Native secondary role - simple strategy
+
+Simple strategy can be activated by `ifSecondary simpleStrategy` or `ifPrimary simpleStrategy`, or from agent GUI.
+
+It can be explicitly set by:
+
+```
+set secondaryRole.defaultStrategy advanced
+```
+
+However, at the moment of writing this, it already is the default strategy, so even without above command, it can be activated by:
+
+```
+ifSecondary final holdLayer mouse
+tapKey escape
+```
+
+This strategy does the same as the `ifNotInterrupted` version, except it activates secondary role only after the other key is pressed. This strategy does not use any complicated postponing.
+
+Pros: it is reliable.
+Cons: it will activate during writing if you put it on alphanumeric key.
+
+#### Native secondary role - advanced strategy
+
+Advanced strategy postpones all other keypresses until it can distinguish between primary and secondary role. This is handy for alphabetic keys, or if the secondary role is not a no-op. This strategy can be used via `ifPrimary advancedStrategy` and `ifSecondary advancedStrategy` conditions.
+
+It can be made default by:
+```
+set secondaryRole.defaultStrategy advanced
+```
+
+Then it can be activated via GUI-mapped secondary role, or simply:
 
 ```
 ifPrimary final holdKey a
 holdLayer mouse
 ```
 
-Postponed secondary role switch - `resolveSeccondary` is a bit more flexible and less user-friendly version of the `ifPrimary`/`ifSecondary` command. The `resolveSecondary` will listen for some time and once it decides whether the current situation fits primary or secondary action, it will issue goTo to the "second" line (line 1 since we index from 0) or the last line (line 3). Actions are indexed from 0.
+Advanced strategy has the disadvantage that its configuration depends on typing style of the user. Please see reference manual for meaning of all its configuration values. Two example configurations follow.
+
+Release-order configuration:
 
 ```
-resolveSecondary 350 1 3
-write f
-break
-holdLayer mod
+set secondaryRole.defaultStrategy advanced
+set secondaryRole.advanced.timeout 350
+set secondaryRole.advanced.timeoutAction secondary
+set secondaryRole.advanced.safetyMargin 50
+set secondaryRole.advanced.triggerByRelease true
+set secondaryRole.advanced.doubletapToPrimary false
 ```
+
+This configuration distinguishes roles based on release order of the keys. I.e., `press-A, press-B, release-B, releaseA` leads to secondary action; `press-A, press-B, release-A, release-B` leads to primary action. This configuration does not mind if you release keys lazily during writing.
+
+More conventional timeout-triggered configuration:
+
+```
+set secondaryRole.defaultStrategy advanced
+set secondaryRole.advanced.timeout 200
+set secondaryRole.advanced.timeoutAction secondary
+set secondaryRole.advanced.safetyMargin 0
+set secondaryRole.advanced.triggerByRelease false
+set secondaryRole.advanced.doubletapToPrimary true
+set secondaryRole.advanced.doubletapTime 200
+```
+
+This configuration will trigger secondary role whenever the dual-role key is pressed for more than 200ms, i.e., just a very slightly prolonged activation will trigger secondary role.
+
+Furthermore, this configuration allows you to activate primary role by doubletap and hold. You may want this on your space key, or other primary key that is often used to produce a row of characters.
 
 ### Advanced key binding
 

--- a/doc-dev/user-guide.md
+++ b/doc-dev/user-guide.md
@@ -353,11 +353,11 @@ set secondaryRole.defaultStrategy advanced
 set secondaryRole.advanced.timeout 350
 set secondaryRole.advanced.timeoutAction secondary
 set secondaryRole.advanced.safetyMargin 50
-set secondaryRole.advanced.triggerByRelease true
-set secondaryRole.advanced.doubletapToPrimary false
+set secondaryRole.advanced.triggerByRelease 1
+set secondaryRole.advanced.doubletapToPrimary 0
 ```
 
-This configuration distinguishes roles based on release order of the keys. I.e., `press-A, press-B, release-B, releaseA` leads to secondary action; `press-A, press-B, release-A, release-B` leads to primary action. This configuration does not mind if you release keys lazily during writing.
+Above configuration distinguishes roles based on release order of the keys. I.e., `press-A, press-B, release-B, releaseA` leads to secondary action; `press-A, press-B, release-A, release-B` leads to primary action. This configuration does not mind if you release keys lazily during writing.
 
 More conventional timeout-triggered configuration:
 
@@ -366,12 +366,12 @@ set secondaryRole.defaultStrategy advanced
 set secondaryRole.advanced.timeout 200
 set secondaryRole.advanced.timeoutAction secondary
 set secondaryRole.advanced.safetyMargin 0
-set secondaryRole.advanced.triggerByRelease false
-set secondaryRole.advanced.doubletapToPrimary true
+set secondaryRole.advanced.triggerByRelease 0
+set secondaryRole.advanced.doubletapToPrimary 1
 set secondaryRole.advanced.doubletapTime 200
 ```
 
-This configuration will trigger secondary role whenever the dual-role key is pressed for more than 200ms, i.e., just a very slightly prolonged activation will trigger secondary role.
+Above configuration will trigger secondary role whenever the dual-role key is pressed for more than 200ms, i.e., just a very slightly prolonged activation will trigger secondary role.
 
 Furthermore, this configuration allows you to activate primary role by doubletap and hold. You may want this on your space key, or other primary key that is often used to produce a row of characters.
 

--- a/right/src/key_states.h
+++ b/right/src/key_states.h
@@ -27,6 +27,7 @@
         bool current : 1;
         bool previous : 1;
         bool debouncing : 1;
+        bool secondary : 1;
     } key_state_t;
 
 // Variables:

--- a/right/src/macro_set_command.c
+++ b/right/src/macro_set_command.c
@@ -475,7 +475,7 @@ macro_result_t MacroSetCommand(const char* arg1, const char *textEnd)
     if (TokenMatches(arg1, textEnd, "module")) {
         module(proceedByDot(arg1, textEnd), textEnd);
     }
-    else if (TokenMatches(arg1, textEnd, "secondaryRoles")) {
+    else if (TokenMatches(arg1, textEnd, "secondaryRole")) {
         secondaryRoles(proceedByDot(arg1, textEnd), textEnd);
     }
     else if (TokenMatches(arg1, textEnd, "mouseKeys")) {

--- a/right/src/macro_set_command.c
+++ b/right/src/macro_set_command.c
@@ -2,6 +2,7 @@
 #include "layer.h"
 #include "ledmap.h"
 #include "macros.h"
+#include "secondary_role_driver.h"
 #include "timer.h"
 #include "keymap.h"
 #include "key_matrix.h"
@@ -119,9 +120,61 @@ static void module(const char* arg1, const char *textEnd)
     }
 }
 
+static void secondaryRoleAdvanced(const char* arg1, const char *textEnd)
+{
+    const char* arg2 = NextTok(arg1, textEnd);
+
+    if (TokenMatches(arg1, textEnd, "timeout")) {
+        SecondaryRoles_AdvancedStrategyTimeout = Macros_ParseInt(arg2, textEnd, NULL);
+    }
+    else if (TokenMatches(arg1, textEnd, "timeoutAction")) {
+        if (TokenMatches(arg2, textEnd, "primary")) {
+            SecondaryRoles_AdvancedStrategyTimeoutAction = SecondaryRoleState_Primary;
+        }
+        else if (TokenMatches(arg2, textEnd, "secondary")) {
+            SecondaryRoles_AdvancedStrategyTimeoutAction = SecondaryRoleState_Secondary;
+        }
+        else {
+            Macros_ReportError("parameter not recognized:", arg2, textEnd);
+        }
+    }
+    else if (TokenMatches(arg1, textEnd, "safetyMargin")) {
+        SecondaryRoles_AdvancedStrategySafetyMargin = Macros_ParseInt(arg2, textEnd, NULL);
+    }
+    else if (TokenMatches(arg1, textEnd, "triggerByRelease")) {
+        SecondaryRoles_AdvancedStrategyTriggerByRelease = Macros_ParseBoolean(arg2, textEnd);
+    }
+    else if (TokenMatches(arg1, textEnd, "doubletapToPrimary")) {
+        SecondaryRoles_AdvancedStrategyDoubletapToPrimary = Macros_ParseBoolean(arg2, textEnd);
+    }
+    else if (TokenMatches(arg1, textEnd, "doubletapTime")) {
+        SecondaryRoles_AdvancedStrategyDoubletapTime = Macros_ParseInt(arg2, textEnd, NULL);
+    }
+    else {
+        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+    }
+}
+
 static void secondaryRoles(const char* arg1, const char *textEnd)
 {
-    Macros_ReportError("command not recognized:", arg1, textEnd);
+    if (TokenMatches(arg1, textEnd, "defaultStrategy")) {
+        const char* arg2 = NextTok(arg1, textEnd);
+        if (TokenMatches(arg2, textEnd, "simple")) {
+            SecondaryRoles_Strategy = SecondaryRoleStrategy_Simple;
+        }
+        else if (TokenMatches(arg2, textEnd, "advanced")) {
+            SecondaryRoles_Strategy = SecondaryRoleStrategy_Advanced;
+        }
+        else {
+            Macros_ReportError("parameter not recognized:", arg2, textEnd);
+        }
+    }
+    else if (TokenMatches(arg1, textEnd, "advanced")) {
+        secondaryRoleAdvanced(proceedByDot(arg1, textEnd), textEnd);
+    }
+    else {
+        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+    }
 }
 
 static void mouseKeys(const char* arg1, const char *textEnd)
@@ -413,6 +466,7 @@ static void modLayerTriggers(const char* arg1, const char *textEnd)
         Macros_ReportError("Specifier not recognized", specifier, textEnd);
     }
 }
+
 
 macro_result_t MacroSetCommand(const char* arg1, const char *textEnd)
 {

--- a/right/src/macros.c
+++ b/right/src/macros.c
@@ -1,5 +1,6 @@
 #include "macros.h"
 #include <math.h>
+#include "secondary_role_driver.h"
 #include "usb_interfaces/usb_interface_basic_keyboard.h"
 #include "usb_interfaces/usb_interface_media_keyboard.h"
 #include "usb_interfaces/usb_interface_mouse.h"
@@ -1709,80 +1710,6 @@ static macro_result_t processNoOpCommand()
     }
 }
 
-#define RESOLVESEC_RESULT_DONTKNOWYET 0
-#define RESOLVESEC_RESULT_PRIMARY 1
-#define RESOLVESEC_RESULT_SECONDARY 2
-
-
-static uint8_t processResolveSecondary(uint16_t timeout1, uint16_t timeout2)
-{
-    postponeCurrentCycle();
-    bool pendingReleased = PostponerExtended_IsPendingKeyReleased(0);
-    bool currentKeyIsActive = currentMacroKeyIsActive();
-
-    //phase 1 - wait until some other key is released, then write down its release time
-    bool timer1Exceeded = Timer_GetElapsedTime(&s->ms.currentMacroStartTime) >= timeout1;
-    if (!timer1Exceeded && currentKeyIsActive && !pendingReleased) {
-        s->as.secondaryRoleData.phase2Start = 0;
-        return RESOLVESEC_RESULT_DONTKNOWYET;
-    }
-    if (s->as.secondaryRoleData.phase2Start == 0) {
-        s->as.secondaryRoleData.phase2Start = CurrentTime;
-    }
-    //phase 2 - "safety margin" - wait another `timeout2` ms, and if the switcher is released during this time, still interpret it as a primary action
-    bool timer2Exceeded = Timer_GetElapsedTime(&s->as.secondaryRoleData.phase2Start) >= timeout2;
-    if (!timer1Exceeded && !timer2Exceeded &&  currentKeyIsActive && pendingReleased && PostponerQuery_PendingKeypressCount() < 3) {
-        return RESOLVESEC_RESULT_DONTKNOWYET;
-    }
-    //phase 3 - resolve the situation - if the switcher is released first or within the "safety margin", interpret it as primary action, otherwise secondary
-    if (timer1Exceeded || (pendingReleased && timer2Exceeded)) {
-        return RESOLVESEC_RESULT_SECONDARY;
-    }
-    else {
-        return RESOLVESEC_RESULT_PRIMARY;
-    }
-
-}
-
-static macro_result_t processResolveSecondaryCommand(const char* arg1, const char* argEnd)
-{
-    const char* arg2 = NextTok(arg1, argEnd);
-    const char* arg3 = NextTok(arg2, argEnd);
-    const char* arg4 = NextTok(arg3, argEnd);
-
-    const char* primaryAdr;
-    const char* secondaryAdr;
-    uint16_t timeout1;
-    uint16_t timeout2;
-
-    if (arg4 == argEnd) {
-        timeout1 = parseNUM(arg1, argEnd);
-        timeout2 = timeout1;
-        primaryAdr = arg2;
-        secondaryAdr = arg3;
-    } else {
-        timeout1 = parseNUM(arg1, argEnd);
-        timeout2 = parseNUM(arg2, argEnd);
-        primaryAdr = arg3;
-        secondaryAdr = arg4;
-    }
-
-    uint8_t res = processResolveSecondary(timeout1, timeout2);
-
-    switch(res) {
-    case RESOLVESEC_RESULT_DONTKNOWYET:
-        return MacroResult_Waiting;
-    case RESOLVESEC_RESULT_PRIMARY:
-        postponeNextN(1);
-        return goTo(primaryAdr, argEnd);
-    case RESOLVESEC_RESULT_SECONDARY:
-        return goTo(secondaryAdr, argEnd);
-    }
-    //this is unreachable, prevents warning
-    return MacroResult_Finished;
-}
-
-
 static macro_result_t processIfSecondaryCommand(bool negate, const char* arg, const char* argEnd)
 {
     if (s->as.currentIfSecondaryConditionPassed) {
@@ -1793,18 +1720,29 @@ static macro_result_t processIfSecondaryCommand(bool negate, const char* arg, co
         }
     }
 
-    uint8_t res = processResolveSecondary(350, 50);
+    secondary_role_strategy_t strategy = SecondaryRoles_Strategy;
 
-    switch(res) {
-    case RESOLVESEC_RESULT_DONTKNOWYET:
+    if (TokenMatches(arg, argEnd, "simpleStrategy")) {
+        strategy = SecondaryRoleStrategy_Simple;
+    }
+    if (TokenMatches(arg, argEnd, "advancedStrategy")) {
+        strategy = SecondaryRoleStrategy_Advanced;
+    }
+
+    secondary_role_result_t res = SecondaryRoles_ResolveState(s->ms.currentMacroKey, 0, strategy, !s->as.actionActive);
+
+    s->as.actionActive = res.state == SecondaryRoleState_DontKnowYet;
+
+    switch(res.state) {
+    case SecondaryRoleState_DontKnowYet:
         return MacroResult_Waiting;
-    case RESOLVESEC_RESULT_PRIMARY:
+    case SecondaryRoleState_Primary:
         if (negate) {
             goto conditionPassed;
         } else {
             return MacroResult_Finished;
         }
-    case RESOLVESEC_RESULT_SECONDARY:
+    case SecondaryRoleState_Secondary:
         if (negate) {
             return MacroResult_Finished;
         } else {
@@ -2724,9 +2662,6 @@ static macro_result_t processCommand(const char* cmd, const char* cmdEnd)
             }
             else if (TokenMatches(cmd, cmdEnd, "recordMacroDelay")) {
                 return processRecordMacroDelayCommand();
-            }
-            else if (TokenMatches(cmd, cmdEnd, "resolveSecondary")) {
-                return processResolveSecondaryCommand(arg1, cmdEnd);
             }
             else if (TokenMatches(cmd, cmdEnd, "resolveNextKeyId")) {
                 return processResolveNextKeyIdCommand();

--- a/right/src/postponer.c
+++ b/right/src/postponer.c
@@ -203,12 +203,12 @@ bool PostponerQuery_IsActiveEventually(key_state_t* key)
     return KeyState_Active(key);
 }
 
-void PostponerQuery_InfoByKeystate(key_state_t* key, struct postponer_buffer_record_type_t** press, struct postponer_buffer_record_type_t** release)
+void PostponerQuery_InfoByKeystate(key_state_t* key, postponer_buffer_record_type_t** press, postponer_buffer_record_type_t** release)
 {
     *press = NULL;
     *release = NULL;
     for ( int i = 0; i < bufferSize; i++ ) {
-        struct postponer_buffer_record_type_t* record = &buffer[POS(i)];
+        postponer_buffer_record_type_t* record = &buffer[POS(i)];
         if (record->key == key) {
             if (record->active) {
                 *press = record;
@@ -220,7 +220,7 @@ void PostponerQuery_InfoByKeystate(key_state_t* key, struct postponer_buffer_rec
     }
 }
 
-void PostponerQuery_InfoByQueueIdx(uint8_t idx, struct postponer_buffer_record_type_t** press, struct postponer_buffer_record_type_t** release)
+void PostponerQuery_InfoByQueueIdx(uint8_t idx, postponer_buffer_record_type_t** press, postponer_buffer_record_type_t** release)
 {
     *press = NULL;
     *release = NULL;
@@ -230,7 +230,7 @@ void PostponerQuery_InfoByQueueIdx(uint8_t idx, struct postponer_buffer_record_t
     }
     *press = &buffer[POS(startIdx)];
     for ( int i = startIdx; i < bufferSize; i++ ) {
-        struct postponer_buffer_record_type_t* record = &buffer[POS(i)];
+        postponer_buffer_record_type_t* record = &buffer[POS(i)];
         if (!record->active && record->key == (*press)->key) {
             *release = record;
             return;

--- a/right/src/postponer.c
+++ b/right/src/postponer.c
@@ -8,18 +8,21 @@
 #include "key_action.h"
 
 postponer_buffer_record_type_t buffer[POSTPONER_BUFFER_SIZE];
-uint8_t bufferSize = 0;
-uint8_t bufferPosition = 0;
+static uint8_t bufferSize = 0;
+static uint8_t bufferPosition = 0;
 
 uint8_t Postponer_LastKeyLayer = 255;
 
-uint8_t cyclesUntilActivation = 0;
+static uint8_t cyclesUntilActivation = 0;
+static uint32_t lastPressTime;
+
 key_state_t* Postponer_NextEventKey;
-uint32_t lastPressTime;
 
 #define POS(idx) ((bufferPosition + POSTPONER_BUFFER_SIZE + (idx)) % POSTPONER_BUFFER_SIZE)
 
 uint8_t ChordingDelay = 0;
+uint32_t CurrentPostponedTime = 0;
+
 static void chording();
 
 
@@ -79,6 +82,10 @@ static void consumeEvent(uint8_t count)
 // call this once with the required number.
 void PostponerCore_PostponeNCycles(uint8_t n)
 {
+    if(bufferSize == 0 && cyclesUntilActivation == 0) {
+        // ensure correct CurrentPostponedTime when postponing starts, since current postponed time is the time of last executed action
+        buffer[POS(0-1+POSTPONER_BUFFER_SIZE)].time = CurrentTime;
+	}
     cyclesUntilActivation = MAX(n + 1, cyclesUntilActivation);
 }
 
@@ -148,6 +155,9 @@ void PostponerCore_RunPostponedEvents(void)
 void PostponerCore_FinishCycle(void)
 {
     cyclesUntilActivation -= cyclesUntilActivation > 0 ? 1 : 0;
+    if(bufferSize == 0 && cyclesUntilActivation == 0) {
+        CurrentPostponedTime = CurrentTime;
+    }
 }
 
 //#######################
@@ -191,6 +201,41 @@ bool PostponerQuery_IsActiveEventually(key_state_t* key)
         }
     }
     return KeyState_Active(key);
+}
+
+void PostponerQuery_InfoByKeystate(key_state_t* key, struct postponer_buffer_record_type_t** press, struct postponer_buffer_record_type_t** release)
+{
+    *press = NULL;
+    *release = NULL;
+    for ( int i = 0; i < bufferSize; i++ ) {
+        struct postponer_buffer_record_type_t* record = &buffer[POS(i)];
+        if (record->key == key) {
+            if (record->active) {
+                *press = record;
+            } else {
+                *release = record;
+                return;
+            }
+        }
+    }
+}
+
+void PostponerQuery_InfoByQueueIdx(uint8_t idx, struct postponer_buffer_record_type_t** press, struct postponer_buffer_record_type_t** release)
+{
+    *press = NULL;
+    *release = NULL;
+    uint8_t startIdx = getPendingKeypressIdx(idx);
+    if(startIdx == 255) {
+        return;
+    }
+    *press = &buffer[POS(startIdx)];
+    for ( int i = startIdx; i < bufferSize; i++ ) {
+        struct postponer_buffer_record_type_t* record = &buffer[POS(i)];
+        if (!record->active && record->key == (*press)->key) {
+            *release = record;
+            return;
+        }
+    }
 }
 
 //##########################

--- a/right/src/postponer.c
+++ b/right/src/postponer.c
@@ -104,7 +104,7 @@ void PostponerCore_PrependKeyEvent(key_state_t *keyState, bool active, uint8_t l
     }
 
     buffer[pos] = (postponer_buffer_record_type_t) {
-            .time = CurrentTime,
+            .time = CurrentPostponedTime,
             .key = keyState,
             .active = active,
             .layer = layer,

--- a/right/src/postponer.h
+++ b/right/src/postponer.h
@@ -60,8 +60,8 @@
     uint8_t PostponerQuery_PendingKeypressCount();
     bool PostponerQuery_IsKeyReleased(key_state_t* key);
     bool PostponerQuery_IsActiveEventually(key_state_t* key);
-    void PostponerQuery_InfoByKeystate(key_state_t* key, struct postponer_buffer_record_type_t** press, struct postponer_buffer_record_type_t** release);
-    void PostponerQuery_InfoByQueueIdx(uint8_t idx, struct postponer_buffer_record_type_t** press, struct postponer_buffer_record_type_t** release);
+    void PostponerQuery_InfoByKeystate(key_state_t* key, postponer_buffer_record_type_t** press, postponer_buffer_record_type_t** release);
+    void PostponerQuery_InfoByQueueIdx(uint8_t idx, postponer_buffer_record_type_t** press, postponer_buffer_record_type_t** release);
 
 // Functions (Query APIs extended):
     uint16_t PostponerExtended_PendingId(uint16_t idx);

--- a/right/src/postponer.h
+++ b/right/src/postponer.h
@@ -43,6 +43,7 @@
     extern uint8_t ChordingDelay;
     extern key_state_t* Postponer_NextEventKey;
     extern uint8_t Postponer_LastKeyLayer;
+    extern uint32_t CurrentPostponedTime;
 
 // Functions (Core hooks):
 
@@ -59,6 +60,8 @@
     uint8_t PostponerQuery_PendingKeypressCount();
     bool PostponerQuery_IsKeyReleased(key_state_t* key);
     bool PostponerQuery_IsActiveEventually(key_state_t* key);
+    void PostponerQuery_InfoByKeystate(key_state_t* key, struct postponer_buffer_record_type_t** press, struct postponer_buffer_record_type_t** release);
+    void PostponerQuery_InfoByQueueIdx(uint8_t idx, struct postponer_buffer_record_type_t** press, struct postponer_buffer_record_type_t** release);
 
 // Functions (Query APIs extended):
     uint16_t PostponerExtended_PendingId(uint16_t idx);

--- a/right/src/secondary_role_driver.c
+++ b/right/src/secondary_role_driver.c
@@ -1,11 +1,65 @@
 #include "secondary_role_driver.h"
 #include "postponer.h"
 #include "led_display.h"
+#include "timer.h"
+#include "math.h"
+#include "debug.h"
 
-key_state_t* resolutionKey;
-secondary_role_state_t resolutionState;
+/*
+ * ## Strategies:
+ *
+ * - simple
+ * - timeout (advanced alphanumeric-friendly)
+ *
+ * ## Simple strategy:
+ *
+ * Simple strategy works simply with press events (i.e., keyDown events). If there is any action pressed when a dual-role key is held, the secondary role goes to secondary role mode. Otherwise, it produces its primary action on its release event.
+ *
+ * ## Timeout strategy:
+ *
+ * Timeout strategy works mainly with key releases:
+ *
+ * - Secondary role is activated if timeout (i.e., triggerTime) is reached.
+ * - Secondary role is activated if action key is pressed and released within the span of press of the dual role key. (If allowTriggerByRelease is active.)
+ * - Long hold of primary action can be achieved by doubletapping the key. (If doubletapActivatedPrimary is active.)
+ *
+ * Configuration params:
+ *
+ * - DoubletapTime - if dual-role key is tapped and press within this time (press-to-press), then primary role is activated.
+ * - TriggerTime configures the basic timeout of the dual-role key.
+ * - TimeoutAction - after triggerTime, the key is defaulted to timeoutAction. Typically to secondary role.
+ * - SafetyMargin decreases probability of unintentional secondary role, by offsetting release time of the keys by the amount.
+ * - AllowTriggerByRelease - if set to false, the only way to trigger secondary role is to press it for more than triggerTime.
+ * - DoubletapActivatesPrimary - if set to false, doubletap logic is disabled. Useful if you prefer tap and hold evaluate to primary role.
+ *
+ * This yields two most basic activation modes:
+ *
+ * - Via timeout. Triggered via distinct and slightly prolonged press of the shortcut.
+ *   - Pros: works with short timeout.
+ *   - Cons: some typing styles may cause unwanted activations of secondary role.
+ *   - Recommended params:
+ *     - TriggerTime = 200
+ *     - SafetyMargin = 0
+ *     - AllowTriggerByRelease = false
+ *
+ * - Via release order. Triggered mainly by correct release sequence.
+ *   - Pros: is more reliable in suppressing unwanted secondary role activations.
+ *   - Cons: activation might require a bit longer hold.
+ *   - Recommended params:
+ *     - TriggerTime = 350
+ *     - SafetyMargin = 50
+ *     - AllowTriggerByRelease = true
+ */
 
 secondary_role_t SecondaryRolePreview;
+static key_state_t *resolutionKey;
+static secondary_role_state_t resolutionState;
+static uint32_t resolutionStartTime;
+
+static secondary_role_strategy_t strategy = SecondaryRoleStrategy_Timeout;
+
+static key_state_t *previousResolutionKey;
+static uint32_t previousResolutionTime;
 
 static void activatePrimary()
 {
@@ -13,6 +67,7 @@ static void activatePrimary()
     // Activate the key "again", but now in "SecondaryRoleState_Primary".
     resolutionKey->current = true;
     resolutionKey->previous = false;
+    resolutionKey->secondary = false;
     // Give the key two cycles (this and next) of activity before allowing postponer to replay any events (esp., the key's own release).
     PostponerCore_PostponeNCycles(1);
 }
@@ -23,16 +78,104 @@ static void activateSecondary()
     // Activate the key "again", but now in "SecondaryRoleState_Secondary".
     resolutionKey->current = true;
     resolutionKey->previous = false;
+    resolutionKey->secondary = true;
     // Let the secondary role take place before allowing the affected key to execute. Postponing rest of this cycle should suffice.
     PostponerCore_PostponeNCycles(0); //just for aesthetics - we are already postponed for this cycle so this is no-op
 }
 
-static secondary_role_state_t resolveCurrentKeyRoleIfDontKnow()
+/*
+ * Conservative settings (safely preventing collisions) (triggered via distinct && correct release sequence):
+ * TriggerTime = 350
+ * SafetyMargin = 50
+ * AllowTriggerByRelease = true
+ *
+ * Less conservative (triggered via prolonged press of modifier):
+ * TriggerTime = 200
+ * SafetyMargin = 0
+ * AllowTriggerByRelease = false
+ */
+
+uint16_t timeoutStrategyDoubletapTime = 200;
+uint16_t timeoutStrategyTriggerTime = 350;
+uint16_t timeoutStrategySafetyMargin = 50;
+bool timeoutStrategyAllowTriggerByRelease = true;
+bool timeoutStrategyDoubletapActivatesPrimary = true;
+secondary_role_state_t timeoutStrategyTimeoutAction = SecondaryRoleState_Secondary;
+
+static secondary_role_state_t resolveCurrentKeyRoleIfDontKnowTimeout()
 {
-    if ( PostponerQuery_PendingKeypressCount() > 0 && !PostponerQuery_IsKeyReleased(resolutionKey) ) {
+    //gather data
+    uint32_t dualRolePressTime = resolutionStartTime;
+    struct postponer_buffer_record_type_t *dummy;
+    struct postponer_buffer_record_type_t *dualRoleRelease;
+    struct postponer_buffer_record_type_t *actionPress;
+    struct postponer_buffer_record_type_t *actionRelease;
+
+    PostponerQuery_InfoByKeystate(resolutionKey, &dummy, &dualRoleRelease);
+    PostponerQuery_InfoByQueueIdx(0, &actionPress, &actionRelease);
+
+    //handle doubletap logic
+    if (
+        timeoutStrategyDoubletapActivatesPrimary
+        && resolutionKey == previousResolutionKey
+        && resolutionStartTime - previousResolutionTime < timeoutStrategyDoubletapTime) {
+        activatePrimary();
+        return SecondaryRoleState_Primary;
+    }
+
+    //action key has not been pressed yet -> timeout scenarios
+    if (actionPress == NULL) {
+        if (dualRoleRelease != NULL) {
+            activatePrimary();
+            return SecondaryRoleState_Primary;
+        } else if (CurrentTime - dualRolePressTime > timeoutStrategyTriggerTime) {
+            switch (timeoutStrategyTimeoutAction) {
+            case SecondaryRoleState_Primary:
+                activatePrimary();
+                return SecondaryRoleState_Primary;
+            case SecondaryRoleState_Secondary:
+                activateSecondary();
+                return SecondaryRoleState_Secondary;
+            default:
+                return SecondaryRoleState_DontKnowYet;
+            }
+        } else {
+            return SecondaryRoleState_DontKnowYet;
+        }
+    }
+
+    //handle trigger by release
+    if (timeoutStrategyAllowTriggerByRelease) {
+        bool actionKeyWasReleasedButDualkeyNot = actionRelease != NULL && (dualRoleRelease == NULL && CurrentTime - actionRelease->time > timeoutStrategySafetyMargin);
+        bool actionKeyWasReleasedFirst = actionRelease != NULL && (actionRelease->time < dualRoleRelease->time - timeoutStrategySafetyMargin);
+
+        if (actionKeyWasReleasedFirst || actionKeyWasReleasedButDualkeyNot) {
+            activateSecondary();
+            return SecondaryRoleState_Secondary;
+        }
+    }
+
+    uint32_t activeTime = (dualRoleRelease == NULL ? CurrentTime : dualRoleRelease->time) - dualRolePressTime;
+
+    if (activeTime > timeoutStrategyTriggerTime + timeoutStrategySafetyMargin) {
         activateSecondary();
         return SecondaryRoleState_Secondary;
-    } else if ( PostponerQuery_IsKeyReleased(resolutionKey) /*assume PostponerQuery_PendingKeypressCount() == 0, but gather race conditions too*/ ) {
+    } else {
+        if (dualRoleRelease != NULL) {
+            activatePrimary();
+            return SecondaryRoleState_Primary;
+        } else {
+            return SecondaryRoleState_DontKnowYet;
+        }
+    }
+}
+
+static secondary_role_state_t resolveCurrentKeyRoleIfDontKnowSimple()
+{
+    if (PostponerQuery_PendingKeypressCount() > 0 && !PostponerQuery_IsKeyReleased(resolutionKey)) {
+        activateSecondary();
+        return SecondaryRoleState_Secondary;
+    } else if (PostponerQuery_IsKeyReleased(resolutionKey) /*assume PostponerQuery_PendingKeypressCount() == 0, but gather race conditions too*/) {
         activatePrimary();
         return SecondaryRoleState_Primary;
     } else {
@@ -47,15 +190,24 @@ static secondary_role_state_t resolveCurrentKey()
     case SecondaryRoleState_Secondary:
         return resolutionState;
     case SecondaryRoleState_DontKnowYet:
-        return resolveCurrentKeyRoleIfDontKnow();
+        switch (strategy) {
+        case SecondaryRoleStrategy_Simple:
+            return resolveCurrentKeyRoleIfDontKnowSimple();
+        default:
+        case SecondaryRoleStrategy_Timeout:
+            return resolveCurrentKeyRoleIfDontKnowTimeout();
+        }
     default:
         return SecondaryRoleState_DontKnowYet; // prevent warning
     }
 }
 
-static secondary_role_state_t startResolution(key_state_t* keyState)
+static secondary_role_state_t startResolution(key_state_t *keyState)
 {
+    previousResolutionKey = resolutionKey;
+    previousResolutionTime = resolutionStartTime;
     resolutionKey = keyState;
+    resolutionStartTime = CurrentPostponedTime;
     return SecondaryRoleState_DontKnowYet;
 }
 
@@ -64,9 +216,9 @@ secondary_role_state_t SecondaryRoles_ResolveState(key_state_t* keyState, second
     // Since postponer is active during resolutions, KeyState_ActivatedNow can happen only after previous
     // resolution has finished - i.e., if primary action has been activated, carried out and
     // released, or if previous resolution has been resolved as secondary. Therefore,
-    // it suffices to deal with the `resolutionKey` only. Any other queried key is an active secondary role.
+    // it suffices to deal with the `resolutionKey` only. Any other queried key is a finished resoluton.
 
-    if ( KeyState_ActivatedNow(keyState) ) {
+    if (KeyState_ActivatedNow(keyState)) {
         //start new resolution
         resolutionState = startResolution(keyState);
         resolutionState = resolveCurrentKey();
@@ -78,8 +230,7 @@ secondary_role_state_t SecondaryRoles_ResolveState(key_state_t* keyState, second
             resolutionState = resolveCurrentKey();
             return resolutionState;
         } else {
-            return SecondaryRoleState_Secondary;
+            return keyState->secondary ? SecondaryRoleState_Secondary : SecondaryRoleState_Primary;
         }
     }
 }
-

--- a/right/src/secondary_role_driver.h
+++ b/right/src/secondary_role_driver.h
@@ -67,6 +67,11 @@
         SecondaryRoleStrategy_Advanced
     } secondary_role_strategy_t;
 
+    typedef struct {
+        secondary_role_state_t state;
+        bool activatedNow;
+    } secondary_role_result_t;
+
 // Variables:
 
     extern secondary_role_t SecondaryRolePreview;
@@ -80,7 +85,8 @@
 
 // Functions:
 
-    secondary_role_state_t SecondaryRoles_ResolveState(key_state_t* keyState, secondary_role_t rolePreview);
+    secondary_role_result_t SecondaryRoles_ResolveState(key_state_t* keyState, secondary_role_t rolePreview, secondary_role_strategy_t strategy, bool isNewResolution);
+    void SecondaryRoles_FakeActivation(secondary_role_result_t res);
 
 
 

--- a/right/src/secondary_role_driver.h
+++ b/right/src/secondary_role_driver.h
@@ -64,12 +64,19 @@
 
     typedef enum {
         SecondaryRoleStrategy_Simple,
-        SecondaryRoleStrategy_Timeout
+        SecondaryRoleStrategy_Advanced
     } secondary_role_strategy_t;
 
 // Variables:
 
     extern secondary_role_t SecondaryRolePreview;
+    extern secondary_role_strategy_t SecondaryRoles_Strategy;
+    extern uint16_t SecondaryRoles_AdvancedStrategyDoubletapTime;
+    extern uint16_t SecondaryRoles_AdvancedStrategyTimeout;
+    extern uint16_t SecondaryRoles_AdvancedStrategySafetyMargin;
+    extern bool SecondaryRoles_AdvancedStrategyTriggerByRelease;
+    extern bool SecondaryRoles_AdvancedStrategyDoubletapToPrimary;
+    extern secondary_role_state_t SecondaryRoles_AdvancedStrategyTimeoutAction;
 
 // Functions:
 

--- a/right/src/secondary_role_driver.h
+++ b/right/src/secondary_role_driver.h
@@ -62,6 +62,11 @@
         SecondaryRoleState_Primary,
     } secondary_role_state_t;
 
+    typedef enum {
+        SecondaryRoleStrategy_Simple,
+        SecondaryRoleStrategy_Timeout
+    } secondary_role_strategy_t;
+
 // Variables:
 
     extern secondary_role_t SecondaryRolePreview;

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -231,7 +231,11 @@ static void applyKeystroke(key_state_t *keyState, key_action_cached_t *cachedAct
 {
     key_action_t* action = &cachedAction->action;
     if (action->keystroke.secondaryRole) {
-        switch (SecondaryRoles_ResolveState(keyState, action->keystroke.secondaryRole)) {
+        secondary_role_result_t res = SecondaryRoles_ResolveState(keyState, action->keystroke.secondaryRole, SecondaryRoles_Strategy, KeyState_ActivatedNow(keyState));
+        if (res.activatedNow) {
+            SecondaryRoles_FakeActivation(res);
+        }
+        switch (res.state) {
             case SecondaryRoleState_Primary:
                 applyKeystrokePrimary(keyState, cachedAction);
                 return;


### PR DESCRIPTION
Suggested changelog notes (feel free to reformulate or fix):
- Added alphanumeric-friendly secondary role resolution strategy.
  - `ifPrimary`/`ifSecondary` macro commands have been connected to the standard secondary role mechanism. Please, migrate `ifPrimary` to `ifPrimary advancedStrategy` and `ifSecondary` to `ifSecondary advancedStrategy` in your macro commands.
  - `resolveSecondary` is kept for backward compatibility without changes. We strongly advise to avoid it.

See user guide for more info / examples.

Closes #207.

