### PR TITLE
Fix macro-activated sticky modifiers.

### DIFF
--- a/right/src/macros.c
+++ b/right/src/macros.c
@@ -291,10 +291,10 @@ static macro_result_t processKey(macro_action_t macro_action)
     s->ms.reportsUsed = true;
     macro_sub_action_t action = macro_action.key.action;
     keystroke_type_t type = macro_action.key.type;
-    uint8_t outputModMask = macro_action.key.outputModMask;
     uint8_t inputModMask = macro_action.key.inputModMask;
+    uint8_t outputModMask = macro_action.key.outputModMask;
+    uint8_t stickyModMask = macro_action.key.stickyModMask;
     uint16_t scancode = macro_action.key.scancode;
-    bool stickyModMask = macro_action.key.stickyModMask;
 
     s->as.actionPhase++;
 

--- a/right/src/macros.h
+++ b/right/src/macros.h
@@ -88,9 +88,9 @@
                 macro_sub_action_t action;
                 keystroke_type_t type;
                 uint16_t scancode;
+                uint8_t inputModMask;
                 uint8_t outputModMask;
                 uint8_t stickyModMask;
-                uint8_t inputModMask;
             } ATTR_PACKED key;
             struct {
                 macro_sub_action_t action;


### PR DESCRIPTION
Reported here: https://forum.ultimatehackingkeyboard.com/t/sticky-shift-how/303

Steps to reproduce:
- create macro `holdKey sS-A` and map it somewhere
- test it: observe ctrl+a being produced instead