### PR TITLE
Make oneShot last one more cycle, and prevent oneShot from sleeping.

### DIFF
--- a/right/src/macros.h
+++ b/right/src/macros.h
@@ -148,6 +148,7 @@
             uint8_t postponeNextNCommands;
             uint8_t commandAddress;
             uint8_t nextSlot;
+            uint8_t oneShotState : 2;
             bool macroInterrupted : 1;
             bool macroSleeping : 1;
             bool macroBroken : 1;
@@ -157,7 +158,6 @@
             bool wakeMeOnTime : 1;
             bool wakeMeOnKeystateChange: 1;
             bool autoRepeatInitialDelayPassed: 1;
-            bool oneShotActive : 1;
             macro_autorepeat_state_t autoRepeatPhase: 1;
 
             uint8_t inputModifierMask;


### PR DESCRIPTION
One more cycle is needed for proper composition of modifiers. (Otherwise end of layer hold may cancel sticky modifiers before their scancode is applied.)

Sleeping is a problem because modified command may enter sleep from which we would not be waken up that one cycle later.

Steps to reproduce:
- have `oneShot holdLayer fn`
- bind shift+c scancode in your fn layer 
- tap your oneshot switcher; tap that shift+c key; observe `c` being produced instead of `C`

Closes #634