### PR TITLE
Fix navigation mode in modifier layers.

### DIFF
--- a/right/src/mouse_controller.c
+++ b/right/src/mouse_controller.c
@@ -691,9 +691,13 @@ static void resetKineticModuleState(module_kinetic_state_t* kineticState)
 }
 
 static layer_id_t determineEffectiveLayer() {
-    bool secondaryRoleResolutionInProgress = ActiveLayer == LayerId_Base && IS_SECONDARY_ROLE_LAYER_SWITCHER(SecondaryRolePreview);
-
-    return secondaryRoleResolutionInProgress ? SECONDARY_ROLE_LAYER_TO_LAYER_ID(SecondaryRolePreview) : ActiveLayer;
+    if(ActiveLayer == LayerId_Base && IS_SECONDARY_ROLE_LAYER_SWITCHER(SecondaryRolePreview)) {
+        return SECONDARY_ROLE_LAYER_TO_LAYER_ID(SecondaryRolePreview);
+    } else if (IS_MODIFIER_LAYER(ActiveLayer)) {
+        return LayerId_Base;
+    } else {
+        return ActiveLayer;
+    }
 }
 
 static module_kinetic_state_t* getKineticState(uint8_t moduleId)


### PR DESCRIPTION
It should always correspond to base layer. At the moment it is uninitialized, therefore yielding cursor.

Reported in https://github.com/UltimateHackingKeyboard/agent/issues/2033

Steps to reproduce:
- have `set module.keycluster.navigationMode.base scroll`
- enable shift layer
- hold shift and move the keycluster ball; Observe cursor moving (instead of scrolling).