### PR TITLE
Fix secondary roles for mouse

### DIFF
--- a/right/src/macros.c
+++ b/right/src/macros.c
@@ -1789,6 +1789,17 @@ static macro_result_t processResolveSecondaryCommand(const char* arg1, const cha
 
 static macro_result_t processIfSecondaryCommand(bool negate, const char* arg, const char* argEnd)
 {
+    secondary_role_strategy_t strategy = SecondaryRoles_Strategy;
+
+    if (TokenMatches(arg, argEnd, "simpleStrategy")) {
+        arg = NextTok(arg, argEnd);
+        strategy = SecondaryRoleStrategy_Simple;
+    }
+    if (TokenMatches(arg, argEnd, "advancedStrategy")) {
+        arg = NextTok(arg, argEnd);
+        strategy = SecondaryRoleStrategy_Advanced;
+    }
+
     if (s->as.currentIfSecondaryConditionPassed) {
         if (s->as.currentConditionPassed) {
             goto conditionPassed;
@@ -1797,15 +1808,7 @@ static macro_result_t processIfSecondaryCommand(bool negate, const char* arg, co
         }
     }
 
-    secondary_role_strategy_t strategy = SecondaryRoles_Strategy;
-
-    if (TokenMatches(arg, argEnd, "simpleStrategy")) {
-        strategy = SecondaryRoleStrategy_Simple;
-    }
-    if (TokenMatches(arg, argEnd, "advancedStrategy")) {
-        strategy = SecondaryRoleStrategy_Advanced;
-    }
-
+    postponeCurrentCycle();
     secondary_role_result_t res = SecondaryRoles_ResolveState(s->ms.currentMacroKey, 0, strategy, !s->as.actionActive);
 
     s->as.actionActive = res.state == SecondaryRoleState_DontKnowYet;
@@ -1817,6 +1820,7 @@ static macro_result_t processIfSecondaryCommand(bool negate, const char* arg, co
         if (negate) {
             goto conditionPassed;
         } else {
+            postponeNextN(0);
             return MacroResult_Finished;
         }
     case SecondaryRoleState_Secondary:

--- a/right/src/mouse_controller.c
+++ b/right/src/mouse_controller.c
@@ -355,7 +355,7 @@ static tap_hold_action_t tapHoldStateMachine(tap_hold_event_t event)
     return 0;
 }
 
-static void feedTapHoldStateMachine()
+static void feedTapHoldStateMachine(touchpad_events_t events)
 {
     key_state_t* singleTap = &KeyStates[SlotId_RightModule][0];
     //todo: finetune this value. Low value will yield natural doubletaps, but requires fast doubletap to trigger tapAndHold.
@@ -368,13 +368,14 @@ static void feedTapHoldStateMachine()
     tap_hold_action_t action = 0;
     tap_hold_event_t event = 0;
 
-    if(!lastSingleTapValue && TouchpadEvents.singleTap) {
+    if(!lastSingleTapValue && events.singleTap) {
         event = Event_NewTap;
         lastSingleTapValue = true;
-    } else if (!lastTapAndHoldValue && TouchpadEvents.tapAndHold) {
+    } else if (!lastTapAndHoldValue && events.tapAndHold) {
         event = Event_TapAndHold;
+
         lastTapAndHoldValue = true;
-    } else if (lastFinger != (TouchpadEvents.noFingers == 1)) {
+    } else if (lastFinger != (events.noFingers == 1)) {
         event = lastFinger ? Event_FingerOut : Event_FingerIn ;
         lastFinger = !lastFinger;
     } else if(lastSingleTapTime + tapTimeout < CurrentTime) {
@@ -394,17 +395,17 @@ static void feedTapHoldStateMachine()
         PostponerCore_TrackKeyEvent(singleTap, true, 0xff);
     }
 
-    lastSingleTapValue &= TouchpadEvents.singleTap;
-    lastTapAndHoldValue &= TouchpadEvents.tapAndHold;
+    lastSingleTapValue &= events.singleTap;
+    lastTapAndHoldValue &= events.tapAndHold;
 }
 
-static void processTouchpadActions() {
+static void processTouchpadActions(touchpad_events_t events) {
 
-    if (TouchpadEvents.singleTap || TouchpadEvents.tapAndHold || tapHoldAutomatonState != State_Zero) {
-        feedTapHoldStateMachine();
+    if (events.singleTap || events.tapAndHold || tapHoldAutomatonState != State_Zero) {
+        feedTapHoldStateMachine(events);
     }
 
-    KeyStates[SlotId_RightModule][1].hardwareSwitchState = TouchpadEvents.twoFingerTap;
+    KeyStates[SlotId_RightModule][1].hardwareSwitchState = events.twoFingerTap;
 }
 
 static void progressZoomAction(module_kinetic_state_t* ks) {
@@ -691,9 +692,7 @@ static void resetKineticModuleState(module_kinetic_state_t* kineticState)
 }
 
 static layer_id_t determineEffectiveLayer() {
-    if(ActiveLayer == LayerId_Base && IS_SECONDARY_ROLE_LAYER_SWITCHER(SecondaryRolePreview)) {
-        return SECONDARY_ROLE_LAYER_TO_LAYER_ID(SecondaryRolePreview);
-    } else if (IS_MODIFIER_LAYER(ActiveLayer)) {
+    if (IS_MODIFIER_LAYER(ActiveLayer)) {
         return LayerId_Base;
     } else {
         return ActiveLayer;
@@ -756,6 +755,16 @@ static void processModuleActions(
     processModuleKineticState(x, y, moduleConfiguration, ks, forcedNavigationMode);
 }
 
+bool canWeRun()
+{
+    if (Postponer_MouseBlocked) {
+        PostponerExtended_RequestUnblockMouse();
+        return false;
+    } else {
+        return true;
+    }
+}
+
 void MouseController_ProcessMouseActions()
 {
     mouseElapsedTime = Timer_GetElapsedTimeAndSetCurrent(&mouseUsbReportUpdateTime);
@@ -775,7 +784,6 @@ void MouseController_ProcessMouseActions()
 
     if (Slaves[SlaveId_RightTouchpad].isConnected) {
         // TODO: this is still unsafe w.r.t interrupts
-        processTouchpadActions();
 
         module_kinetic_state_t *ks = getKineticState(ModuleId_TouchpadRight);
 
@@ -783,14 +791,25 @@ void MouseController_ProcessMouseActions()
             handleRunningCaretModeAction(ks);
         }
 
-        processModuleActions(ks, ModuleId_TouchpadRight, (int16_t)TouchpadEvents.x, (int16_t)TouchpadEvents.y, 0xFF);
-        processModuleActions(ks, ModuleId_TouchpadRight, (int16_t)TouchpadEvents.wheelX, (int16_t)TouchpadEvents.wheelY, NavigationMode_Scroll);
-        processModuleActions(ks, ModuleId_TouchpadRight, 0, (int16_t)TouchpadEvents.zoomLevel, NavigationMode_Zoom);
-        TouchpadEvents.zoomLevel = 0;
-        TouchpadEvents.wheelX = 0;
-        TouchpadEvents.wheelY = 0;
-        TouchpadEvents.x = 0;
-        TouchpadEvents.y = 0;
+        bool eventsIsNonzero = memcmp(&TouchpadEvents, &ZeroTouchpadEvents, sizeof TouchpadEvents) != 0;
+        if (!eventsIsNonzero || (eventsIsNonzero && canWeRun())) {
+            //eventsIsNonzero is needed for touchpad action state automaton timer
+            __disable_irq();
+            touchpad_events_t events = TouchpadEvents;
+            TouchpadEvents.zoomLevel = 0;
+            TouchpadEvents.wheelX = 0;
+            TouchpadEvents.wheelY = 0;
+            TouchpadEvents.x = 0;
+            TouchpadEvents.y = 0;
+            // note that not all fields are resetted and that's correct
+            __enable_irq();
+
+            processTouchpadActions(events);
+
+            processModuleActions(ks, ModuleId_TouchpadRight, (int16_t)events.x, (int16_t)events.y, 0xFF);
+            processModuleActions(ks, ModuleId_TouchpadRight, (int16_t)events.wheelX, (int16_t)events.wheelY, NavigationMode_Scroll);
+            processModuleActions(ks, ModuleId_TouchpadRight, 0, (int16_t)events.zoomLevel, NavigationMode_Zoom);
+        }
     }
 
     for (uint8_t moduleSlotId=0; moduleSlotId<UHK_MODULE_MAX_SLOT_COUNT; moduleSlotId++) {
@@ -799,23 +818,27 @@ void MouseController_ProcessMouseActions()
             continue;
         }
 
-        __disable_irq();
-        // Gcc compiles those int16_t assignments as sequences of
-        // single-byte instructions, therefore we need to make the
-        // sequence atomic.
-        int16_t x = moduleState->pointerDelta.x;
-        int16_t y = moduleState->pointerDelta.y;
-        moduleState->pointerDelta.x = 0;
-        moduleState->pointerDelta.y = 0;
-        __enable_irq();
-
         module_kinetic_state_t *ks = getKineticState(moduleState->moduleId);
 
         if (caretModeActionIsRunning(ks)) {
             handleRunningCaretModeAction(ks);
         }
 
-        processModuleActions(ks, moduleState->moduleId, x, y, 0xFF);
+
+        bool eventsIsNonzero = moduleState->pointerDelta.x || moduleState->pointerDelta.y;
+        if (eventsIsNonzero && canWeRun()) {
+            __disable_irq();
+            // Gcc compiles those int16_t assignments as sequences of
+            // single-byte instructions, therefore we need to make the
+            // sequence atomic.
+            int16_t x = moduleState->pointerDelta.x;
+            int16_t y = moduleState->pointerDelta.y;
+            moduleState->pointerDelta.x = 0;
+            moduleState->pointerDelta.y = 0;
+            __enable_irq();
+
+            processModuleActions(ks, moduleState->moduleId, x, y, 0xFF);
+        }
     }
 
     if (ActiveMouseStates[SerializedMouseAction_LeftClick]) {

--- a/right/src/mouse_controller.c
+++ b/right/src/mouse_controller.c
@@ -302,7 +302,8 @@ typedef enum {
 typedef enum {
     Action_ResetTimer = 1,
     Action_Press = 2,
-    Action_Release = 4
+    Action_Release = 4,
+    Action_Doubletap = 8,
 } tap_hold_action_t;
 
 static tap_hold_state_t tapHoldAutomatonState = State_Zero;
@@ -327,7 +328,7 @@ static tap_hold_action_t tapHoldStateMachine(tap_hold_event_t event)
         switch (event) {
         case Event_NewTap:
             tapHoldAutomatonState = State_Tap;
-            return Action_ResetTimer | Action_Release | Action_Press;
+            return Action_ResetTimer | Action_Doubletap;
         case Event_Timeout:
             tapHoldAutomatonState = State_Zero;
             return Action_Release;
@@ -344,7 +345,7 @@ static tap_hold_action_t tapHoldStateMachine(tap_hold_event_t event)
         switch (event) {
         case Event_NewTap:
             tapHoldAutomatonState = State_Tap;
-            return Action_ResetTimer | Action_Release | Action_Press;
+            return Action_ResetTimer | Action_Doubletap;
         case Event_FingerOut:
             tapHoldAutomatonState = State_Zero;
             return Action_Release;
@@ -389,11 +390,16 @@ static void feedTapHoldStateMachine(touchpad_events_t events)
     }
     if (action & Action_Release) {
         PostponerCore_TrackKeyEvent(singleTap, false, 0xff);
-        /** TODO: consider adding an explicit delay here - at least my linux machine does not like the idea of releases shorther than 25 ms */
     }
     if (action & Action_Press) {
         PostponerCore_TrackKeyEvent(singleTap, true, 0xff);
     }
+    if (action & Action_Doubletap) {
+        PostponerCore_TrackKeyEvent(singleTap, false, 0xff);
+        PostponerCore_TrackDelay(20);
+        PostponerCore_TrackKeyEvent(singleTap, true, 0xff);
+    }
+
 
     lastSingleTapValue &= events.singleTap;
     lastTapAndHoldValue &= events.tapAndHold;

--- a/right/src/postponer.c
+++ b/right/src/postponer.c
@@ -1,4 +1,5 @@
 #include "postponer.h"
+#include "key_states.h"
 #include "usb_report_updater.h"
 #include "macros.h"
 #include "timer.h"
@@ -16,12 +17,12 @@ uint8_t Postponer_LastKeyLayer = 255;
 static uint8_t cyclesUntilActivation = 0;
 static uint32_t lastPressTime;
 
-key_state_t* Postponer_NextEventKey;
-
 #define POS(idx) ((bufferPosition + POSTPONER_BUFFER_SIZE + (idx)) % POSTPONER_BUFFER_SIZE)
 
 uint8_t ChordingDelay = 0;
 uint32_t CurrentPostponedTime = 0;
+
+bool Postponer_MouseBlocked = false;
 
 static void chording();
 
@@ -33,7 +34,8 @@ static void chording();
 static uint8_t getPendingKeypressIdx(uint8_t n)
 {
     for ( int i = 0; i < bufferSize; i++ ) {
-        if (buffer[POS(i)].active) {
+        postponer_buffer_record_type_t* rec = &buffer[POS(i)];
+        if (rec->event.type == PostponerEventType_PressKey) {
             if (n == 0) {
                 return i;
             } else {
@@ -50,7 +52,7 @@ static key_state_t* getPendingKeypress(uint8_t n)
     if (idx == 255) {
         return NULL;
     } else {
-        return buffer[POS(idx)].key;
+        return buffer[POS(idx)].event.key.keyState;
     }
 }
 
@@ -58,9 +60,63 @@ static void consumeEvent(uint8_t count)
 {
     bufferPosition = POS(count);
     bufferSize = count > bufferSize ? 0 : bufferSize - count;
-    Postponer_NextEventKey = bufferSize == 0 ? NULL : buffer[bufferPosition].key;
 }
 
+static void applyEventAndConsume(postponer_buffer_record_type_t* rec) {
+    switch (rec->event.type) {
+        case PostponerEventType_PressKey:
+        case PostponerEventType_ReleaseKey:
+            rec->event.key.keyState->current = rec->event.key.active;
+            Postponer_LastKeyLayer = rec->event.key.layer;
+            // This gives the key two ticks (this and next) to get properly processed before execution of next queued event.
+            PostponerCore_PostponeNCycles(1);
+            WAKE_MACROS_ON_KEYSTATE_CHANGE();
+            consumeEvent(1);
+            break;
+        case PostponerEventType_UnblockMouse:
+            Postponer_MouseBlocked = false;
+            Postponer_LastKeyLayer = 255;
+            PostponerCore_PostponeNCycles(1);
+            consumeEvent(1);
+            break;
+    }
+}
+
+
+static void prependEvent(postponer_event_t event)
+{
+    uint8_t pos = POS(-1);
+
+    if (bufferSize == POSTPONER_BUFFER_SIZE) {
+        return;
+    }
+
+    buffer[pos].event = event;
+    buffer[pos].time = CurrentPostponedTime;
+
+    lastPressTime = true
+        && event.type == PostponerEventType_PressKey
+        && bufferSize == 0 ? CurrentTime : lastPressTime;
+    bufferSize = bufferSize < POSTPONER_BUFFER_SIZE ? bufferSize + 1 : bufferSize;
+    bufferPosition--;
+}
+
+static void appendEvent(postponer_event_t event)
+{
+
+    //if the buffer is totally filled, at least make sure the key doesn't get stuck
+    if (bufferSize == POSTPONER_BUFFER_SIZE) {
+        applyEventAndConsume(&buffer[bufferPosition]);
+    }
+
+    uint8_t pos = POS(bufferSize);
+
+    buffer[pos].event = event;
+    buffer[pos].time = CurrentTime;
+
+    lastPressTime = event.type == PostponerEventType_PressKey ? CurrentTime : lastPressTime;
+    bufferSize = bufferSize < POSTPONER_BUFFER_SIZE ? bufferSize + 1 : bufferSize;
+}
 
 //######################
 //### Core Functions ###
@@ -97,43 +153,32 @@ bool PostponerCore_IsActive(void)
 
 void PostponerCore_PrependKeyEvent(key_state_t *keyState, bool active, uint8_t layer)
 {
-    uint8_t pos = POS(-1);
-
-    if (bufferSize == POSTPONER_BUFFER_SIZE) {
-        return;
-    }
-
-    buffer[pos] = (postponer_buffer_record_type_t) {
-            .time = CurrentPostponedTime,
-            .key = keyState,
-            .active = active,
-            .layer = layer,
-    };
-    lastPressTime = active && bufferSize == 0 ? CurrentTime : lastPressTime;
-    bufferSize = bufferSize < POSTPONER_BUFFER_SIZE ? bufferSize + 1 : bufferSize;
-    bufferPosition--;
+    prependEvent(
+                (postponer_event_t){
+                    .type = active ? PostponerEventType_PressKey : PostponerEventType_ReleaseKey,
+                    .key = {
+                        .keyState = keyState,
+                        .active = active,
+                        .layer = layer,
+                    }
+                }
+            );
 }
-
 
 void PostponerCore_TrackKeyEvent(key_state_t *keyState, bool active, uint8_t layer)
 {
-    uint8_t pos = POS(bufferSize);
-
-    //if the buffer is totally filled, at least make sure the key doesn't get stuck
-    if (bufferSize == POSTPONER_BUFFER_SIZE) {
-        buffer[pos].key->current = buffer[bufferPosition].active;
-        consumeEvent(1);
-    }
-
-    buffer[pos] = (postponer_buffer_record_type_t) {
-            .time = CurrentTime,
-            .key = keyState,
-            .active = active,
-            .layer = layer,
-    };
-    lastPressTime = active ? CurrentTime : lastPressTime;
-    bufferSize = bufferSize < POSTPONER_BUFFER_SIZE ? bufferSize + 1 : bufferSize;
+    appendEvent(
+                (postponer_event_t){
+                    .type = active ? PostponerEventType_PressKey : PostponerEventType_ReleaseKey,
+                    .key = {
+                        .keyState = keyState,
+                        .active = active,
+                        .layer = layer,
+                    }
+                }
+            );
 }
+
 
 void PostponerCore_RunPostponedEvents(void)
 {
@@ -142,13 +187,7 @@ void PostponerCore_RunPostponedEvents(void)
     }
     // Process one event every two cycles. (Unless someone keeps Postponer active by touching cycles_until_activation.)
     if (bufferSize != 0 && (cyclesUntilActivation == 0 || bufferSize > POSTPONER_BUFFER_MAX_FILL)) {
-        buffer[bufferPosition].key->current = buffer[bufferPosition].active;
-        Postponer_LastKeyLayer = buffer[bufferPosition].layer;
-        consumeEvent(1);
-        // This gives the key two ticks (this and next) to get properly processed before execution of next queued event.
-        PostponerCore_PostponeNCycles(1);
-        // wake macros
-        WAKE_MACROS_ON_KEYSTATE_CHANGE();
+        applyEventAndConsume(&buffer[bufferPosition]);
     }
 }
 
@@ -169,7 +208,7 @@ uint8_t PostponerQuery_PendingKeypressCount()
 {
     uint8_t cnt = 0;
     for ( uint8_t i = 0; i < bufferSize; i++ ) {
-        if (buffer[POS(i)].active) {
+        if (buffer[POS(i)].event.type == PostponerEventType_PressKey) {
             cnt++;
         }
     }
@@ -183,7 +222,7 @@ bool PostponerQuery_IsKeyReleased(key_state_t* key)
         return false;
     }
     for ( uint8_t i = 0; i < bufferSize; i++ ) {
-        if (buffer[POS(i)].key == key && !buffer[POS(i)].active) {
+        if (buffer[POS(i)].event.type == PostponerEventType_ReleaseKey && buffer[POS(i)].event.key.keyState == key) {
             return true;
         }
     }
@@ -196,8 +235,8 @@ bool PostponerQuery_IsActiveEventually(key_state_t* key)
         return false;
     }
     for ( int8_t i = bufferSize - 1; i >= 0; i-- ) {
-        if (buffer[POS(i)].key == key) {
-            return buffer[POS(i)].active;
+        if (POSTPONER_IS_KEY_EVENT(buffer[POS(i)].event.type)) {
+            return buffer[POS(i)].event.key.active;
         }
     }
     return KeyState_Active(key);
@@ -208,12 +247,12 @@ void PostponerQuery_InfoByKeystate(key_state_t* key, postponer_buffer_record_typ
     *press = NULL;
     *release = NULL;
     for ( int i = 0; i < bufferSize; i++ ) {
-        postponer_buffer_record_type_t* record = &buffer[POS(i)];
-        if (record->key == key) {
-            if (record->active) {
-                *press = record;
+        postponer_buffer_record_type_t* rec = &buffer[POS(i)];
+        if (POSTPONER_IS_KEY_EVENT(rec->event.type) && rec->event.key.keyState == key) {
+            if (rec->event.key.active) {
+                *press = rec;
             } else {
-                *release = record;
+                *release = rec;
                 return;
             }
         }
@@ -230,9 +269,9 @@ void PostponerQuery_InfoByQueueIdx(uint8_t idx, postponer_buffer_record_type_t**
     }
     *press = &buffer[POS(startIdx)];
     for ( int i = startIdx; i < bufferSize; i++ ) {
-        postponer_buffer_record_type_t* record = &buffer[POS(i)];
-        if (!record->active && record->key == (*press)->key) {
-            *release = record;
+        postponer_buffer_record_type_t* rec = &buffer[POS(i)];
+        if (rec->event.type == PostponerEventType_ReleaseKey && rec->event.key.keyState == (*press)->event.key.keyState) {
+            *release = rec;
             return;
         }
     }
@@ -252,16 +291,15 @@ static void consumeOneKeypress()
         if (releaseFound) {
             continue;
         }
-        if (buffer[POS(i)].active && removedKeypress == NULL) {
+        if (buffer[POS(i)].event.type == PostponerEventType_PressKey && removedKeypress == NULL) {
             shifting_by++;
-            removedKeypress = buffer[POS(i)].key;
-        } else if (!buffer[POS(i)].active && buffer[POS(i)].key == removedKeypress) {
+            removedKeypress = buffer[POS(i)].event.key.keyState;
+        } else if (buffer[POS(i)].event.type == PostponerEventType_ReleaseKey && buffer[POS(i)].event.key.keyState == removedKeypress) {
             shifting_by++;
             releaseFound = true;
         }
     }
     bufferSize -= shifting_by;
-    Postponer_NextEventKey = bufferSize == 0 ? NULL : buffer[bufferPosition].key;
 }
 
 void PostponerExtended_ResetPostponer(void)
@@ -300,14 +338,24 @@ void PostponerExtended_PrintContent()
     Macros_SetStatusNum(bufferSize);
     Macros_SetStatusString("\n", NULL);
     for (int i = 0; i < POSTPONER_BUFFER_SIZE; i++) {
-        postponer_buffer_record_type_t* ptr = &buffer[i];
-        Macros_SetStatusNum(Utils_KeyStateToKeyId(ptr->key));
-        Macros_SetStatusString("/", NULL);
-        Macros_SetStatusNum(ptr->active);
-        if (ptr == first) {
+        postponer_buffer_record_type_t* rec = &buffer[i];
+        switch(rec->event.type) {
+        case PostponerEventType_PressKey:
+            Macros_SetStatusString("press ", NULL);
+            Macros_SetStatusNum(Utils_KeyStateToKeyId(rec->event.key.keyState));
+            break;
+        case PostponerEventType_ReleaseKey:
+            Macros_SetStatusString("release ", NULL);
+            Macros_SetStatusNum(Utils_KeyStateToKeyId(rec->event.key.keyState));
+            break;
+        case PostponerEventType_UnblockMouse:
+            Macros_SetStatusString("unblock mouse", NULL);
+            break;
+        }
+        if (rec == first) {
             Macros_SetStatusString(" <first", NULL);
         }
-        if (ptr == last) {
+        if (rec == last) {
             Macros_SetStatusString(" <last", NULL);
         }
         Macros_SetStatusString("\n", NULL);
@@ -322,13 +370,26 @@ bool PostponerQuery_ContainsKeyId(uint8_t keyid)
         return false;
     }
     for ( uint8_t i = 0; i < bufferSize; i++ ) {
-        if (buffer[POS(i)].key == key) {
+        if (POSTPONER_IS_KEY_EVENT(buffer[POS(i)].event.type) && buffer[POS(i)].event.key.keyState == key) {
             return true;
         }
     }
     return false;
 }
 
+void PostponerExtended_BlockMouse() {
+    Postponer_MouseBlocked = true;
+}
+
+void PostponerExtended_UnblockMouse() {
+    appendEvent((postponer_event_t){ .type = PostponerEventType_UnblockMouse });
+}
+
+void PostponerExtended_RequestUnblockMouse() {
+    if (Postponer_MouseBlocked) {
+        SecondaryRoles_ActivateSecondaryImmediately();
+    }
+}
 
 //##########################
 //### Chording ###
@@ -367,16 +428,22 @@ static void chording()
         for ( uint8_t i = 0; i < bufferSize - 1; i++ ) {
             postponer_buffer_record_type_t* a = &buffer[POS(i)];
             postponer_buffer_record_type_t* b = &buffer[POS(i+1)];
-            uint8_t pa = priority(a->key, a->active);
-            uint8_t pb = priority(b->key, b->active);
-            // Originally, this also swapped releases to go before presses.
-            // Not sure why anymore, but it caused race condition on secondary role.
-            if ( a->active && b->active && pa < pb ) {
-                if (a->key != b->key && b->time - a->time < ChordingDelay) {
-                    postponer_buffer_record_type_t tmp = *a;
-                    *a = *b;
-                    *b = tmp;
-                    activated = true;
+            if (POSTPONER_IS_KEY_EVENT(a->event.type) && POSTPONER_IS_KEY_EVENT(b->event.type)) {
+                bool aIsActive = a->event.type == PostponerEventType_PressKey;
+                bool bIsActive = b->event.type == PostponerEventType_PressKey;
+                uint8_t pa = priority(a->event.key.keyState, aIsActive);
+                uint8_t pb = priority(b->event.key.keyState, bIsActive);
+                key_state_t* aKeyState = a->event.key.keyState;
+                key_state_t* bKeyState = b->event.key.keyState;
+                // Originally, this also swapped releases to go before presses.
+                // Not sure why anymore, but it caused race condition on secondary role.
+                if ( aIsActive && bIsActive && pa < pb ) {
+                    if (aKeyState != bKeyState && b->time - a->time < ChordingDelay) {
+                        postponer_buffer_record_type_t tmp = *a;
+                        *a = *b;
+                        *b = tmp;
+                        activated = true;
+                    }
                 }
             }
         }
@@ -385,3 +452,4 @@ static void chording()
         }
     }
 }
+

--- a/right/src/postponer.h
+++ b/right/src/postponer.h
@@ -36,6 +36,7 @@
         PostponerEventType_PressKey,
         PostponerEventType_ReleaseKey,
         PostponerEventType_UnblockMouse,
+        PostponerEventType_Delay,
     } postponer_event_type_t;
 
     typedef struct {
@@ -71,6 +72,7 @@
     bool PostponerCore_RunKey(key_state_t* key, bool active);
     void PostponerCore_PrependKeyEvent(key_state_t *keyState, bool active, uint8_t layer);
     void PostponerCore_TrackKeyEvent(key_state_t *keyState, bool active, uint8_t layer);
+    void PostponerCore_TrackDelay(uint32_t length) ;
     void PostponerCore_RunPostponedEvents(void);
     void PostponerCore_FinishCycle(void);
 

--- a/right/src/postponer.h
+++ b/right/src/postponer.h
@@ -28,22 +28,41 @@
     #define POSTPONER_BUFFER_SAFETY_GAP 5
     #define POSTPONER_BUFFER_SIZE 32
     #define POSTPONER_BUFFER_MAX_FILL (POSTPONER_BUFFER_SIZE-POSTPONER_BUFFER_SAFETY_GAP)
+    #define POSTPONER_IS_KEY_EVENT(E) ((E) == PostponerEventType_PressKey || (E)==PostponerEventType_ReleaseKey)
 
 // Typedefs:
 
+    typedef enum {
+        PostponerEventType_PressKey,
+        PostponerEventType_ReleaseKey,
+        PostponerEventType_UnblockMouse,
+    } postponer_event_type_t;
+
+    typedef struct {
+        union {
+           struct {
+            key_state_t* keyState;
+            bool active;
+            uint8_t layer;
+           } ATTR_PACKED key;
+           struct {
+            uint32_t length;
+           } ATTR_PACKED delay;
+        };
+        postponer_event_type_t type;
+    } ATTR_PACKED postponer_event_t;
+
     typedef struct {
         uint32_t time;
-        key_state_t * key;
-        bool active;
-        uint8_t layer;
+        postponer_event_t event;
     } postponer_buffer_record_type_t;
 
 // Variables:
 
     extern uint8_t ChordingDelay;
-    extern key_state_t* Postponer_NextEventKey;
     extern uint8_t Postponer_LastKeyLayer;
     extern uint32_t CurrentPostponedTime;
+    extern bool Postponer_MouseBlocked;
 
 // Functions (Core hooks):
 
@@ -62,15 +81,19 @@
     bool PostponerQuery_IsActiveEventually(key_state_t* key);
     void PostponerQuery_InfoByKeystate(key_state_t* key, postponer_buffer_record_type_t** press, postponer_buffer_record_type_t** release);
     void PostponerQuery_InfoByQueueIdx(uint8_t idx, postponer_buffer_record_type_t** press, postponer_buffer_record_type_t** release);
+    bool PostponerQuery_ContainsKeyId(uint8_t keyid);
 
 // Functions (Query APIs extended):
     uint16_t PostponerExtended_PendingId(uint16_t idx);
     uint32_t PostponerExtended_LastPressTime(void);
     bool PostponerExtended_IsPendingKeyReleased(uint8_t idx);
-    bool PostponerQuery_ContainsKeyId(uint8_t keyid);
     void PostponerExtended_ConsumePendingKeypresses(int count, bool suppress);
     void PostponerExtended_ResetPostponer(void);
 
     void PostponerExtended_PrintContent();
+
+    void PostponerExtended_BlockMouse();
+    void PostponerExtended_UnblockMouse();
+    void PostponerExtended_RequestUnblockMouse();
 
 #endif /* SRC_POSTPONER_H_ */

--- a/right/src/secondary_role_driver.h
+++ b/right/src/secondary_role_driver.h
@@ -74,7 +74,6 @@
 
 // Variables:
 
-    extern secondary_role_t SecondaryRolePreview;
     extern secondary_role_strategy_t SecondaryRoles_Strategy;
     extern uint16_t SecondaryRoles_AdvancedStrategyDoubletapTime;
     extern uint16_t SecondaryRoles_AdvancedStrategyTimeout;
@@ -87,6 +86,7 @@
 
     secondary_role_result_t SecondaryRoles_ResolveState(key_state_t* keyState, secondary_role_t rolePreview, secondary_role_strategy_t strategy, bool isNewResolution);
     void SecondaryRoles_FakeActivation(secondary_role_result_t res);
+    void SecondaryRoles_ActivateSecondaryImmediately();
 
 
 

--- a/right/src/slave_drivers/touchpad_driver.c
+++ b/right/src/slave_drivers/touchpad_driver.c
@@ -73,6 +73,7 @@ static gesture_events_t gestureEvents;
 
 uint8_t address = I2C_ADDRESS_RIGHT_IQS5XX_FIRMWARE;
 touchpad_events_t TouchpadEvents;
+const touchpad_events_t ZeroTouchpadEvents;
 uint8_t phase = 0;
 static uint8_t enableEventMode[] = {0x05, 0x8f, 0x07};
 

--- a/right/src/slave_drivers/touchpad_driver.h
+++ b/right/src/slave_drivers/touchpad_driver.h
@@ -29,6 +29,7 @@
 
 // Variables:
 
+    extern const touchpad_events_t ZeroTouchpadEvents;
     extern touchpad_events_t TouchpadEvents;
 
 // Functions:


### PR DESCRIPTION
This also includes #638 which I therefore close. These should be 3 separate PRs, but they share a ton of code... ...so read them commit by commits.

Changes:
- Fix `ifPrimary` / `ifSecondary` which was not functional at all after reconnection onto default secondary role mechanism.
- Any module pointer action now triggers secondary roles.
- Artificial delay added between touchpad presses and releases, fixing doubletap-to-select-word for systems which ignore short (<20ms) mouse button releases (e.g., linux). 

Closes #565, Closes #334, Closes #476