### PR TITLE
Allow overriding key rgb.

### DIFF
--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -128,6 +128,7 @@ The following grammar is supported:
     COMMAND = set keymapAction.LAYERID.KEYID ACTION
     COMMAND = set backlight.strategy { functional | constantRgb | perKeyRgb }
     COMMAND = set backlight.constantRgb.rgb <number 0-255 (NUMBER)> <number 0-255 (NUMBER)> <number 0-255 (NUMBER)><number 0-255 (NUMBER)>
+    COMMAND = set backlight.keyRgb.LAYERID.KEYID <number 0-255 (NUMBER)> <number 0-255 (NUMBER)> <number 0-255 (NUMBER)>
     COMMAND = set leds.enabled BOOLEAN
     COMMAND = set leds.brightness <0-1 multiple of default (FLOAT)>
     COMMAND = set leds.fadeTimeout <seconds to fade after (NUMBER)>
@@ -546,6 +547,7 @@ For the purpose of toggling functionality on and off, and for global constants m
 - backlight:
     - `backlight.strategy { functional | constantRgb | perKeyRgb }` sets backlight strategy.
     - `backlight.constantRgb.rgb NUMBER NUMBER NUMBER` allows setting custom constant colour for entire keyboard. E.g.: `set backlight.strategy constantRgb; set backlight.constantRgb.rgb 255 0 0` to make entire keyboard shine red.
+    - `backlight.keyRgb.LAYERID.KEYID NUMBER NUMBER NUMBER` allows overriding color of the key. This override will last until reload of keymap and will apply to all backlight strategies.
 
 - general led configuration:
     - `leds.enabled BOOLEAN` turns on/off all keyboard leds: i.e., backlight, indicator leds, segment display

--- a/right/src/config_parser/parse_keymap.c
+++ b/right/src/config_parser/parse_keymap.c
@@ -16,12 +16,12 @@ static void parseKeyActionColor(key_action_t *keyAction, config_buffer_t *buffer
         keyAction->color.red = ReadUInt8(buffer);
         keyAction->color.green = ReadUInt8(buffer);
         keyAction->color.blue = ReadUInt8(buffer);
-        keyAction->colorOverriden = false;
+        keyAction->colorOverridden = false;
     } else {
         keyAction->color.red = 0;
         keyAction->color.green = 0;
         keyAction->color.blue = 0;
-        keyAction->colorOverriden = false;
+        keyAction->colorOverridden = false;
     }
 }
 

--- a/right/src/config_parser/parse_keymap.c
+++ b/right/src/config_parser/parse_keymap.c
@@ -16,6 +16,12 @@ static void parseKeyActionColor(key_action_t *keyAction, config_buffer_t *buffer
         keyAction->color.red = ReadUInt8(buffer);
         keyAction->color.green = ReadUInt8(buffer);
         keyAction->color.blue = ReadUInt8(buffer);
+        keyAction->colorOverriden = false;
+    } else {
+        keyAction->color.red = 0;
+        keyAction->color.green = 0;
+        keyAction->color.blue = 0;
+        keyAction->colorOverriden = false;
     }
 }
 

--- a/right/src/key_action.h
+++ b/right/src/key_action.h
@@ -72,6 +72,7 @@
             } ATTR_PACKED playMacro;
         };
         rgb_t color;
+        bool colorOverriden;
     } ATTR_PACKED key_action_t;
 
     typedef struct {

--- a/right/src/key_action.h
+++ b/right/src/key_action.h
@@ -72,7 +72,7 @@
             } ATTR_PACKED playMacro;
         };
         rgb_t color;
-        bool colorOverriden;
+        bool colorOverridden;
     } ATTR_PACKED key_action_t;
 
     typedef struct {

--- a/right/src/ledmap.c
+++ b/right/src/ledmap.c
@@ -161,7 +161,7 @@ static void updateLedsByConstantRgbStrategy() {
     for (uint8_t slotId=0; slotId<SLOT_COUNT; slotId++) {
         for (uint8_t keyId=0; keyId<MAX_KEY_COUNT_PER_MODULE; keyId++) {
             key_action_t *keyAction = &CurrentKeymap[ActiveLayer][slotId][keyId];
-            if (keyAction->colorOverriden) {
+            if (keyAction->colorOverridden) {
                 setPerKeyRGB(&keyAction->color, slotId, keyId);
             } else {
                 setPerKeyRGB(&LedMap_ConstantRGB, slotId, keyId);
@@ -207,7 +207,7 @@ static void updateLedsByFunctionalStrategy() {
                     break;
             }
 
-            if (keyAction->colorOverriden) {
+            if (keyAction->colorOverridden) {
                 setPerKeyRGB(&keyAction->color, slotId, keyId);
             } else {
                 setPerKeyRGB(&KeyActionColors[keyActionColor], slotId, keyId);

--- a/right/src/ledmap.c
+++ b/right/src/ledmap.c
@@ -160,7 +160,12 @@ static void setPerKeyRGB(const rgb_t* color, uint8_t slotId, uint8_t keyId)
 static void updateLedsByConstantRgbStrategy() {
     for (uint8_t slotId=0; slotId<SLOT_COUNT; slotId++) {
         for (uint8_t keyId=0; keyId<MAX_KEY_COUNT_PER_MODULE; keyId++) {
-            setPerKeyRGB(&LedMap_ConstantRGB, slotId, keyId);
+            key_action_t *keyAction = &CurrentKeymap[ActiveLayer][slotId][keyId];
+            if (keyAction->colorOverriden) {
+                setPerKeyRGB(&keyAction->color, slotId, keyId);
+            } else {
+                setPerKeyRGB(&LedMap_ConstantRGB, slotId, keyId);
+            }
         }
     }
 }
@@ -202,7 +207,11 @@ static void updateLedsByFunctionalStrategy() {
                     break;
             }
 
-            setPerKeyRGB(&KeyActionColors[keyActionColor], slotId, keyId);
+            if (keyAction->colorOverriden) {
+                setPerKeyRGB(&keyAction->color, slotId, keyId);
+            } else {
+                setPerKeyRGB(&KeyActionColors[keyActionColor], slotId, keyId);
+            }
         }
     }
 }

--- a/right/src/macro_set_command.c
+++ b/right/src/macro_set_command.c
@@ -290,6 +290,35 @@ static void backlightStrategy(const char* arg1, const char *textEnd)
     }
 }
 
+static void keyRgb(const char* arg1, const char *textEnd)
+{
+    const char* arg2 = proceedByDot(arg1, textEnd);
+
+    layer_id_t layerId = Macros_ParseLayerId(arg1, textEnd);
+    uint8_t keyId = Macros_ParseInt(arg2, textEnd, NULL);
+    const char* r = NextTok(arg2,  textEnd);
+    const char* g = NextTok(r, textEnd);
+    const char* b = NextTok(g, textEnd);
+    rgb_t rgb;
+    rgb.red = Macros_ParseInt(r, textEnd, NULL);
+    rgb.green = Macros_ParseInt(g, textEnd, NULL);
+    rgb.blue = Macros_ParseInt(b, textEnd, NULL);
+
+    if (Macros_ParserError) {
+        return;
+    }
+
+    uint8_t slotIdx = keyId/64;
+    uint8_t inSlotIdx = keyId%64;
+
+    CurrentKeymap[layerId][slotIdx][inSlotIdx].colorOverriden = true;
+    CurrentKeymap[layerId][slotIdx][inSlotIdx].color = rgb;
+
+    SetLedBacklightingMode(BacklightingMode_PerKeyRgb);
+    LedSlaveDriver_UpdateLeds();
+}
+
+
 static void constantRgb(const char* arg1, const char *textEnd)
 {
     if (TokenMatches(arg1, textEnd, "rgb")) {
@@ -330,6 +359,9 @@ static void backlight(const char* arg1, const char *textEnd)
     }
     else if (TokenMatches(arg1, textEnd, "constantRgb")) {
         constantRgb(proceedByDot(arg1, textEnd), textEnd);
+    }
+    else if (TokenMatches(arg1, textEnd, "keyRgb")) {
+        keyRgb(proceedByDot(arg1, textEnd), textEnd);
     }
     else {
         Macros_ReportError("parameter not recognized:", arg1, textEnd);

--- a/right/src/macro_set_command.c
+++ b/right/src/macro_set_command.c
@@ -314,7 +314,6 @@ static void keyRgb(const char* arg1, const char *textEnd)
     CurrentKeymap[layerId][slotIdx][inSlotIdx].colorOverridden = true;
     CurrentKeymap[layerId][slotIdx][inSlotIdx].color = rgb;
 
-    SetLedBacklightingMode(BacklightingMode_PerKeyRgb);
     LedSlaveDriver_UpdateLeds();
 }
 

--- a/right/src/macro_set_command.c
+++ b/right/src/macro_set_command.c
@@ -311,7 +311,7 @@ static void keyRgb(const char* arg1, const char *textEnd)
     uint8_t slotIdx = keyId/64;
     uint8_t inSlotIdx = keyId%64;
 
-    CurrentKeymap[layerId][slotIdx][inSlotIdx].colorOverriden = true;
+    CurrentKeymap[layerId][slotIdx][inSlotIdx].colorOverridden = true;
     CurrentKeymap[layerId][slotIdx][inSlotIdx].color = rgb;
 
     SetLedBacklightingMode(BacklightingMode_PerKeyRgb);


### PR DESCRIPTION
In the end, it turns out that resetting the overrides is too tricky. (Now I wonder if, on the contrary, it would be better to make these overrides persist across keymap switches.)