### PR TITLE
Unify layer switching implementations.

### DIFF
--- a/doc-dev/user-guide.md
+++ b/doc-dev/user-guide.md
@@ -190,9 +190,7 @@ There is also a concept of modifiers, which can modify keyboard's or command's b
 
 ### Handling layers
 
-**WARNING:** macro engine has separate layer system from the native layer action. Layers toggled from macros need to also be untoggled from macros. There may be some other problems regarding integration of these two system - if you notice any, please do report them.
-
-Main benefit of the macro layer system is that it keeps full-fledged layer stack, therefore allowing nested layer holds, and various interactive features.
+In case of layer handling, macro layer switching commands have slightly different semantics from the native layer switching commands, allowing for more fine-tuned control of the behavior such as nested layer holds or toggles.
 
 Following macro will result in switching to QWR keymap.
 
@@ -200,7 +198,7 @@ Following macro will result in switching to QWR keymap.
 switchKeymap QWR
 ```
 
-Implementation of standard double-tap-locking hold modifier in recursive version could look like: ("Recursivity" refers to ability to toggle another layer on top of the toggled layer.)
+Implementation of standard double-tap-locking hold modifier in nested version could look like:
 
 ```
 holdLayer fn

--- a/right/src/layer.h
+++ b/right/src/layer.h
@@ -26,6 +26,7 @@
         LayerId_Gui,
         LayerId_Last = LayerId_Gui,
         LayerId_Count = LayerId_Last + 1,
+        LayerId_None = 255,
     } layer_id_t;
 
     typedef struct {

--- a/right/src/layer_stack.c
+++ b/right/src/layer_stack.c
@@ -1,0 +1,119 @@
+#include "layer_stack.h"
+#include "keymap.h"
+#include "layer.h"
+#include "layer_switcher.h"
+
+layer_id_t LayerStack_ActiveLayer = LayerId_Base;
+bool LayerStack_ActiveLayerHeld = false;
+layer_stack_record_t LayerStack[LAYER_STACK_SIZE];
+uint8_t LayerStack_TopIdx;
+uint8_t LayerStack_Size;
+
+#define POS(i) ((LayerStack_TopIdx + LAYER_STACK_SIZE + i) % LAYER_STACK_SIZE)
+
+/**
+ * This ensures integration/interface between macro layer mechanism
+ * and official layer mechanism - we expose our layer via
+ * Macros_ActiveLayer/Macros_ActiveLayerHeld and let the layer switcher
+ * make its mind.
+ */
+static void activateLayer(layer_id_t layer)
+{
+    LayerStack_ActiveLayer = layer;
+    LayerStack_ActiveLayerHeld = LayerStack[LayerStack_TopIdx].held;
+    if (LayerStack_ActiveLayerHeld) {
+        LayerSwitcher_HoldLayer(layer, true);
+    } else {
+        LayerSwitcher_RecalculateLayerComposition();
+    }
+}
+
+uint8_t LayerStack_FindPreviousLayerRecordIdx()
+{
+    for (int i = 1; i < LayerStack_Size; i++) {
+        uint8_t pos = POS(-i);
+        if (!LayerStack[pos].removed) {
+            return pos;
+        }
+    }
+    return LayerStack_TopIdx;
+}
+
+static void removeStackTop(bool toggledInsteadOfTop)
+{
+    if (toggledInsteadOfTop) {
+        for (int i = 0; i < LayerStack_Size; i++) {
+            uint8_t pos = POS(-i);
+            if (!LayerStack[pos].held && !LayerStack[pos].removed) {
+                LayerStack[pos].removed = true;
+                return;
+            }
+        }
+    } else {
+        LayerStack_TopIdx = POS(-1);
+        LayerStack_Size--;
+    }
+}
+
+void LayerStack_RemoveRecord(uint8_t stackIndex)
+{
+    LayerStack[stackIndex].removed = true;
+    LayerStack[stackIndex].held = false;
+}
+
+
+void LayerStack_Pop(bool forceRemoveTop, bool toggledInsteadOfTop)
+{
+    if (LayerStack_Size > 0 && forceRemoveTop) {
+        removeStackTop(toggledInsteadOfTop);
+    }
+    while(LayerStack_Size > 0 && LayerStack[LayerStack_TopIdx].removed) {
+        removeStackTop(false);
+    }
+    if (LayerStack_Size == 0) {
+        LayerStack_Reset();
+    }
+    if (LayerStack[LayerStack_TopIdx].keymap != CurrentKeymapIndex) {
+        SwitchKeymapById(LayerStack[LayerStack_TopIdx].keymap);
+    }
+    activateLayer(LayerStack[LayerStack_TopIdx].layer);
+}
+
+// Always maintain protected base layer record. This record cannot be implicit
+// due to *KeymapLayer commands.
+void LayerStack_Reset()
+{
+    LayerStack_Size = 1;
+    LayerStack[LayerStack_TopIdx].keymap = CurrentKeymapIndex;
+    LayerStack[LayerStack_TopIdx].layer = LayerId_Base;
+    LayerStack[LayerStack_TopIdx].removed = false;
+    LayerStack[LayerStack_TopIdx].held = false;
+}
+
+void LayerStack_Push(uint8_t layer, uint8_t keymap, bool hold)
+{
+    LayerStack_TopIdx = POS(1);
+    LayerStack[LayerStack_TopIdx].layer = layer;
+    LayerStack[LayerStack_TopIdx].keymap = keymap;
+    LayerStack[LayerStack_TopIdx].held = hold;
+    LayerStack[LayerStack_TopIdx].removed = false;
+    LayerStack_Size = LayerStack_Size < LAYER_STACK_SIZE - 1 ? LayerStack_Size+1 : LayerStack_Size;
+    if (keymap != CurrentKeymapIndex) {
+        SwitchKeymapById(keymap);
+    }
+    activateLayer(LayerStack[LayerStack_TopIdx].layer);
+}
+
+
+void LayerStack_LegacyPush(layer_id_t layer)
+{
+    LayerStack_Push(layer, CurrentKeymapIndex, false);
+}
+
+void LayerStack_LegacyPop(layer_id_t layer)
+{
+    if (LayerStack[LayerStack_TopIdx].held == false && LayerStack[LayerStack_TopIdx].layer == layer) {
+        LayerStack_Pop(true, true);
+    }
+}
+

--- a/right/src/layer_stack.h
+++ b/right/src/layer_stack.h
@@ -1,0 +1,39 @@
+#ifndef SRC_LAYER_STACK_H_
+#define SRC_LAYER_STACK_H_
+
+// Includes:
+
+    #include "layer.h"
+
+// Macros:
+
+    #define LAYER_STACK_SIZE 10
+
+// Typedefs:
+    typedef struct {
+        uint8_t layer;
+        uint8_t keymap;
+        bool held;
+        bool removed;
+    } layer_stack_record_t;
+
+// Variables:
+
+
+    extern layer_stack_record_t LayerStack[LAYER_STACK_SIZE];
+    extern uint8_t LayerStack_TopIdx;
+    extern uint8_t LayerStack_Size;
+    extern layer_id_t LayerStack_ActiveLayer;
+    extern bool LayerStack_ActiveLayerHeld;
+
+// Functions:
+
+    void LayerStack_Reset();
+    void LayerStack_Push(uint8_t layer, uint8_t keymap, bool hold);
+    void LayerStack_RemoveRecord(uint8_t stackIndex);
+    void LayerStack_Pop(bool forceRemoveTop, bool toggledInsteadOfTop);
+    void LayerStack_LegacyPush(layer_id_t layer);
+    void LayerStack_LegacyPop(layer_id_t layer);
+    uint8_t LayerStack_FindPreviousLayerRecordIdx();
+
+#endif /* SRC_LAYER_SWITCHER_H_ */

--- a/right/src/layer_switcher.c
+++ b/right/src/layer_switcher.c
@@ -1,5 +1,7 @@
 #include "layer_switcher.h"
+#include "keymap.h"
 #include "layer.h"
+#include "layer_stack.h"
 #include "ledmap.h"
 #include "macro_events.h"
 #include "timer.h"
@@ -15,10 +17,7 @@ layer_id_t ActiveLayer = LayerId_Base;
 bool ActiveLayerHeld = false;
 uint8_t ActiveLayerModifierMask = 0;
 
-#define NONE 0xFF
-
-static layer_id_t toggledLayer = NONE;
-static layer_id_t heldLayer = NONE;
+static layer_id_t heldLayer = LayerId_None;
 
 
 /**
@@ -42,7 +41,7 @@ static layer_id_t heldLayer = NONE;
  *     Yet, when the first one is released, the second one takes place.
  *
  * Secondary roles:
- * - if possible, secondary role holds behave as standard holds (experimental, toggled by SECONDARY_AS_REGULAR_HOLD).
+ * - if possible, secondary role holds behave as standard holds.
  *   Otherwise:
  *   - Secondary layer hold is superior to standard holds.
  *   - Secondary layer hold is triggered by press/release and behaves as standard actions.
@@ -55,33 +54,32 @@ void updateActiveLayer() {
 
     // apply stock layer switching
     layer_id_t previousLayer = ActiveLayer;
-    layer_id_t activeLayer = NONE;
+    layer_id_t activeLayer = LayerId_None;
     bool activeLayerHeld = false;
-    if(activeLayer == NONE) {
-        activeLayer = toggledLayer;
-    }
-    if(activeLayer == NONE) {
-        activeLayer = heldLayer;
-    }
-    activeLayerHeld = activeLayer == heldLayer && activeLayer != NONE;
 
-    // apply macro engine layer
-    if(activeLayer == NONE) {
-        activeLayer = Macros_ActiveLayer;
-        activeLayerHeld = Macros_ActiveLayerHeld;
+    // apply toggles and macro holds
+    if(activeLayer == LayerId_None) {
+        activeLayer = LayerStack_ActiveLayer;
+        activeLayerHeld = LayerStack_ActiveLayerHeld;
+    }
+
+    // apply native holds
+    if(activeLayer == LayerId_None || activeLayer == LayerId_Base) {
+        activeLayer = heldLayer;
+        activeLayerHeld = activeLayer != LayerId_None;
     }
 
     // apply default
-    if(activeLayer == NONE) {
+    if(activeLayer == LayerId_None) {
         activeLayer = LayerId_Base;
     }
 
     //(write actual ActiveLayer atomically, so that random observer is not confused)
     ActiveLayer = activeLayer;
     ActiveLayerHeld = activeLayerHeld;
-    LedDisplay_SetLayer(ActiveLayer);
 
     if (ActiveLayer != previousLayer) {
+        LedDisplay_SetLayer(ActiveLayer);
         Ledmap_UpdateBacklightLeds();
         MacroEvent_OnLayerChange(activeLayer);
     }
@@ -105,24 +103,22 @@ void LayerSwitcher_DoubleTapToggle(layer_id_t layer, key_state_t* keyState) {
     static uint32_t doubleTapSwitchLayerTriggerTime = 0;
 
     if(KeyState_ActivatedNow(keyState)) {
-        toggledLayer = NONE;
+        LayerStack_LegacyPop(layer);
         if (doubleTapSwitchLayerKey == keyState && Timer_GetElapsedTimeAndSetCurrent(&doubleTapSwitchLayerStartTime) < DoubleTapSwitchLayerTimeout) {
-            toggledLayer = layer;
+            LayerStack_LegacyPush(layer);
             doubleTapSwitchLayerTriggerTime = CurrentTime;
             doubleTapSwitchLayerStartTime = CurrentTime;
         } else {
             doubleTapSwitchLayerKey = keyState;
             doubleTapSwitchLayerStartTime = CurrentTime;
         }
-        updateActiveLayer();
     }
 
     if(KeyState_DeactivatedNow(keyState)) {
         //If current press is too long, cancel current toggle
         if ( doubleTapSwitchLayerKey == keyState && Timer_GetElapsedTime(&doubleTapSwitchLayerTriggerTime) > DoubleTapSwitchLayerReleaseTimeout)
         {
-            toggledLayer = NONE;
-            updateActiveLayer();
+            LayerStack_LegacyPop(layer);
         }
     }
 }
@@ -130,26 +126,23 @@ void LayerSwitcher_DoubleTapToggle(layer_id_t layer, key_state_t* keyState) {
 // If some other key is pressed between taps of a possible doubletap, discard the doubletap
 // Also, doubleTapSwitchKey is used to cancel long hold toggle, so reset it only if no layer is locked
 void LayerSwitcher_DoubleTapInterrupt(key_state_t* keyState) {
-    if (doubleTapSwitchLayerKey != keyState && toggledLayer == NONE) {
+    bool noLayerIsToggled = LayerStack_Size == 1;
+    if (doubleTapSwitchLayerKey != keyState && noLayerIsToggled) {
         doubleTapSwitchLayerKey = NULL;
     }
 }
 
 void LayerSwitcher_ToggleLayer(layer_id_t layer) {
-    if(toggledLayer == NONE) {
-        toggledLayer = layer;
+    if(LayerStack[LayerStack_TopIdx].held == false && LayerStack[LayerStack_TopIdx].layer == layer) {
+        LayerStack_LegacyPop(layer);
     } else {
-        toggledLayer = NONE;
+        LayerStack_LegacyPush(layer);
     }
-    updateActiveLayer();
 }
 
 
 void LayerSwitcher_UnToggleLayerOnly(layer_id_t layer) {
-    if (toggledLayer != NONE) {
-        toggledLayer = NONE;
-        updateActiveLayer();
-    }
+    LayerStack_LegacyPop(layer);
 }
 
 /*
@@ -174,7 +167,7 @@ static bool heldLayers[LayerId_Count];
 void LayerSwitcher_HoldLayer(layer_id_t layer, bool forceSwap) {
     heldLayers[layer] = true;
     //no other switcher is active, so we may as well activate it straight away.
-    if(heldLayer == NONE || forceSwap) {
+    if(heldLayer == LayerId_None || forceSwap) {
         heldLayer = layer;
         updateActiveLayer();
     }
@@ -204,19 +197,19 @@ void LayerSwitcher_UpdateActiveLayer() {
     layer_id_t previousHeldLayer = heldLayer;
 
     // Include macro held layer into computation
-    if (Macros_ActiveLayer != NONE && Macros_ActiveLayerHeld) {
-        heldLayers[Macros_ActiveLayer] = true;
+    if (LayerStack_ActiveLayer != LayerId_None && LayerStack_ActiveLayerHeld) {
+        heldLayers[LayerStack_ActiveLayer] = true;
     }
 
     // Reset held layer if no longer relevant
-    if (heldLayer != NONE && !layerMeetsHoldConditions(heldLayer, NULL)) {
-        heldLayer = NONE;
+    if (heldLayer != LayerId_None && !layerMeetsHoldConditions(heldLayer, NULL)) {
+        heldLayer = LayerId_None;
     }
 
     // Find first relevant layer, and reset the array
     for (layer_id_t layerId = LayerId_Base; layerId < LayerId_Count; layerId++) {
         // normal layer should take precedence over modifier layers
-        bool heldLayerCanBeOverriden = heldLayer == NONE || (IS_MODIFIER_LAYER(heldLayer) && !IS_MODIFIER_LAYER(layerId));
+        bool heldLayerCanBeOverriden = heldLayer == LayerId_None || (IS_MODIFIER_LAYER(heldLayer) && !IS_MODIFIER_LAYER(layerId));
         if (heldLayerCanBeOverriden && layerMeetsHoldConditions(layerId, &ActiveLayerModifierMask)) {
             heldLayer = layerId;
         }

--- a/right/src/macros.h
+++ b/right/src/macros.h
@@ -14,7 +14,6 @@
 
     #define MAX_MACRO_NUM 255
     #define STATUS_BUFFER_MAX_LENGTH 1024
-    #define LAYER_STACK_SIZE 10
     #define MACRO_STATE_POOL_SIZE 16
     #define MAX_REG_COUNT 32
 
@@ -38,13 +37,6 @@
         uint8_t macroActionsCount;
         uint8_t macroNameOffset; //negative w.r.t. firstMacroActionOffset
     } macro_reference_t;
-
-    typedef struct {
-        uint8_t layer;
-        uint8_t keymap;
-        bool held;
-        bool removed;
-    } layerStackRecord;
 
     typedef enum {
         MacroSubAction_Tap,
@@ -189,7 +181,7 @@
                 } secondaryRoleData;
 
                 struct {
-                    uint8_t layerIdx;
+                    uint8_t layerStackIdx;
 
                 } holdLayerData;
                 struct {
@@ -234,8 +226,6 @@
     extern uint8_t AllMacrosCount;
     extern macro_state_t MacroState[MACRO_STATE_POOL_SIZE];
     extern bool MacroPlaying;
-    extern layer_id_t Macros_ActiveLayer;
-    extern bool Macros_ActiveLayerHeld;
     extern macro_scheduler_t Macros_Scheduler;
     extern bool Macros_ExtendedCommands;
     extern uint8_t Macros_MaxBatchSize;
@@ -267,7 +257,6 @@
     void Macros_SetStatusNum(int32_t n);
     void Macros_SetStatusNumSpaced(int32_t n, bool space);
     void Macros_SetStatusChar(char n);
-    void Macros_ResetLayerStack();
     void Macros_Initialize();
     void Macros_ClearStatus();
     bool Macros_IsLayerHeld();

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -21,6 +21,7 @@
 #include "secondary_role_driver.h"
 #include "slave_drivers/touchpad_driver.h"
 #include "layer_switcher.h"
+#include "layer_stack.h"
 #include "mouse_controller.h"
 #include "debug.h"
 
@@ -284,7 +285,7 @@ void ApplyKeyAction(key_state_t *keyState, key_action_cached_t *cachedAction, ke
                 stickyModifiers = 0;
                 stickyModifiersNegative = cachedAction->modifierLayerMask;
                 SwitchKeymapById(action->switchKeymap.keymapId);
-                Macros_ResetLayerStack();
+                LayerStack_Reset();
             }
             break;
         case KeyActionType_PlayMacro:


### PR DESCRIPTION
Closes #324.

This finally ensures full interoperability of macro layer switching commands and native switching commands. Most importantly, layers can be untoggled with either of the methods irrespectively of how they were locked. Also, this probably fixes some composition scenarios in which multiple layer activations were stacked on one another via different methods.