### PR TITLE
Postponed time fix

### DIFF
--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -64,19 +64,8 @@ The following grammar is supported:
     COMMAND = noOp
     COMMAND = yield
     COMMAND = {exec|call|fork} MACRONAME
-    COMMAND = stopAllMacros
-    COMMAND = statsRuntime
-    COMMAND = statsLayerStack
-    COMMAND = statsPostponerStack
-    COMMAND = statsActiveKeys
-    COMMAND = statsActiveMacros
-    COMMAND = statsRegs
-    COMMAND = statsRecordKeyTiming
     COMMAND = resetTrackpoint
-    COMMAND = diagnose
     COMMAND = printStatus
-    COMMAND = {setStatus  | setStatusPart} <custom text>
-    COMMAND = clearStatus
     COMMAND = setLedTxt <timeout (NUMBER)> <custom text>
     COMMAND = write <custom text>
     COMMAND = writeExpr NUMBER
@@ -131,7 +120,6 @@ The following grammar is supported:
     COMMAND = set keystrokeDelay <time in ms, at most 65535 (NUMBER)>
     COMMAND = set autoRepeatDelay <time in ms, at most 65535 (NUMBER)>
     COMMAND = set autoRepeatRate <time in ms, at most 65535 (NUMBER)>
-    COMMAND = set setEmergencyKey KEYID
     COMMAND = set macroEngine.batchSize <number of commands to execute per one update cycle NUMBER>
     COMMAND = set navigationModeAction.NAVIGATION_MODE_CUSTOM.DIRECTION ACTION
     COMMAND = set keymapAction.LAYERID.KEYID ACTION
@@ -208,6 +196,21 @@ The following grammar is supported:
     KEY_ABBREV = systemPowerDown | systemSleep | systemWakeUp
     KEY_ABBREV = mouseBtnLeft | mouseBtnRight | mouseBtnMiddle | mouseBtn4 | mouseBtn5 | mouseBtn6 | mouseBtn7 | mouseBtn8
     MACRONAME = <Case sensitive macro identifier as named in Agent. Identifier shall not contain spaces.>
+    ###################
+    #DEVELOPMENT TOOLS#
+    ###################
+    COMMAND = stopAllMacros
+    COMMAND = statsRuntime
+    COMMAND = statsLayerStack
+    COMMAND = statsPostponerStack
+    COMMAND = statsActiveKeys
+    COMMAND = statsActiveMacros
+    COMMAND = statsRegs
+    COMMAND = statsRecordKeyTiming
+    COMMAND = diagnose
+    COMMAND = {setStatus  | setStatusPart} <custom text>
+    COMMAND = clearStatus
+    COMMAND = set setEmergencyKey KEYID
     ############
     #DEPRECATED#
     ############

--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -71,6 +71,7 @@ The following grammar is supported:
     COMMAND = statsActiveKeys
     COMMAND = statsActiveMacros
     COMMAND = statsRegs
+    COMMAND = statsRecordKeyTiming
     COMMAND = resetTrackpoint
     COMMAND = diagnose
     COMMAND = printStatus
@@ -292,6 +293,7 @@ The following grammar is supported:
 - `statsActiveKeys` will output all active keys and their states (into the buffer).
 - `statsActiveMacros` will output all active macros (into the buffer).
 - `statsRegs` will output content of all registers (into the buffer).
+- `statsRecordKeyTiming` will write timing information of pressed and released keys into status buffer until invoked again.
 - `diagnose` will deactivate all keys and macros and print diagnostic information into the status buffer.
 - `set emergencyKey KEYID` will make the one key be ignored by postponing mechanisms. `diagnose` command on such key can be used to recover keyboard from conditions like infinite postponing loop...
 

--- a/right/src/macros.c
+++ b/right/src/macros.c
@@ -82,6 +82,8 @@ uint16_t DoubletapConditionTimeout = 400;
 uint16_t AutoRepeatInitialDelay = 500;
 uint16_t AutoRepeatDelayRate = 50;
 
+bool RecordKeyTiming = false;
+
 static void checkSchedulerHealth(const char* tag);
 static void wakeMacroInSlot(uint8_t slotIdx);
 static void scheduleSlot(uint8_t slotIdx);
@@ -1661,6 +1663,12 @@ static void processPostponeKeysCommand()
     s->as.modifierSuppressMods = true;
 }
 
+static macro_result_t processStatsRecordKeyTimingCommand()
+{
+    RecordKeyTiming = !RecordKeyTiming;
+    return MacroResult_Finished;
+}
+
 static macro_result_t processStatsRuntimeCommand()
 {
     int ms = Timer_GetElapsedTime(&s->ms.currentMacroStartTime);
@@ -2880,6 +2888,9 @@ static macro_result_t processCommand(const char* cmd, const char* cmdEnd)
             }
             else if (TokenMatches(cmd, cmdEnd, "statsRuntime")) {
                 return processStatsRuntimeCommand();
+            }
+            else if (TokenMatches(cmd, cmdEnd, "statsRecordKeyTiming")) {
+                return processStatsRecordKeyTimingCommand();
             }
             else if (TokenMatches(cmd, cmdEnd, "statsLayerStack")) {
                 return processStatsLayerStackCommand();

--- a/right/src/macros.h
+++ b/right/src/macros.h
@@ -237,6 +237,7 @@
     extern uint16_t AutoRepeatInitialDelay;
     extern uint16_t AutoRepeatDelayRate;
     extern bool Macros_ParserError;
+    extern bool RecordKeyTiming;
 
 // Functions:
 

--- a/right/src/postponer.c
+++ b/right/src/postponer.c
@@ -226,6 +226,7 @@ void PostponerCore_RunPostponedEvents(void)
     }
     // Process one event every two cycles. (Unless someone keeps Postponer active by touching cycles_until_activation.)
     if (bufferSize != 0 && (cyclesUntilActivation == 0 || bufferSize > POSTPONER_BUFFER_MAX_FILL)) {
+        CurrentPostponedTime = buffer[bufferPosition].time;
         applyEventAndConsume(&buffer[bufferPosition]);
     }
 }

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -23,6 +23,7 @@
 #include "layer_switcher.h"
 #include "layer_stack.h"
 #include "mouse_controller.h"
+#include "utils.h"
 #include "debug.h"
 
 bool TestUsbStack = false;
@@ -333,6 +334,14 @@ static void mergeReports(void)
 static void commitKeyState(key_state_t *keyState, bool active)
 {
     WATCH_TRIGGER(keyState);
+    if (RecordKeyTiming) {
+        Macros_SetStatusString( active ? "DOWN" : "UP", NULL);
+        Macros_SetStatusNum(Utils_KeyStateToKeyId(keyState));
+        Macros_SetStatusNum(CurrentTime);
+        Macros_SetStatusNum(CurrentPostponedTime);
+        Macros_SetStatusChar('\n');
+    }
+
     if (PostponerCore_IsActive()) {
         PostponerCore_TrackKeyEvent(keyState, active, 255);
     } else {


### PR DESCRIPTION
Reported in https://forum.ultimatehackingkeyboard.com/t/ifsecondary-config-to-match-deprecated-resolvesecondary/395/6 

Fixes the problem, and adds a debugging feature for similar scenarios.

Changelog line could be for instance: Fix behavior of the advanced secondary role strategy when rolling over multiple secondary role keys. Latter keys tended to produce false secondary role.