### PR TITLE
Switch error logs to line numbers and fix trailing newlines.

### DIFF
--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -10,7 +10,11 @@ This file contains (semi)formal documentation of all features of the extended en
 
 Whenever a garbled command is encountered, `ERR` will light up on the display, and details are appended to the error buffer. You can retrieve it by running a `printStatus` macro command over a focused text editor.
 
-Logs are prefixed with macro name, action index and command address.
+Errors have following format:
+
+```
+{Error|Warning} at <macro name> <action index>/<line>: <message>: <failed command>
+```
 
 ## Macro events
 

--- a/right/src/caret_config.c
+++ b/right/src/caret_config.c
@@ -63,7 +63,7 @@ caret_configuration_t* GetNavigationModeConfiguration(navigation_mode_t mode) {
     if (NavigationMode_RemappableFirst <= mode && mode <= NavigationMode_RemappableLast) {
         return &remappableModes[mode - NavigationMode_RemappableFirst];
     } else {
-            Macros_ReportErrorNum("Mode referenced in invalid context. Only remappable modes are supported here.", mode);
+            Macros_ReportErrorNum("Mode referenced in invalid context. Only remappable modes are supported here:", mode, NULL);
             return NULL;
     }
 }

--- a/right/src/macro_recorder.c
+++ b/right/src/macro_recorder.c
@@ -185,7 +185,7 @@ static void playReport(usb_basic_keyboard_report_t *report)
         }
         break;
     default:
-        Macros_ReportErrorNum("PlayReport decode failed at ", type);
+        Macros_ReportErrorNum("PlayReport decode failed at:", type, NULL);
     }
 }
 

--- a/right/src/macro_set_command.c
+++ b/right/src/macro_set_command.c
@@ -94,7 +94,7 @@ static void moduleSpeed(const char* arg1, const char *textEnd, module_configurat
         module->swapAxes = Macros_ParseBoolean(arg2, textEnd);
     }
     else if (TokenMatches(arg1, textEnd, "invertScrollDirection")) {
-        Macros_ReportWarn("Command deprecated. Please, replace invertScrollDirection by invertScrollDirectionY.", NULL, NULL);
+        Macros_ReportWarn("Command deprecated. Please, replace invertScrollDirection by invertScrollDirectionY.", arg1, textEnd);
         module->invertScrollDirectionY = Macros_ParseBoolean(arg2, textEnd);
     }
     else if (TokenMatches(arg1, textEnd, "invertScrollDirectionY")) {

--- a/right/src/macro_set_command.c
+++ b/right/src/macro_set_command.c
@@ -28,7 +28,7 @@ static const char* proceedByDot(const char* cmd, const char *cmdEnd)
         cmd++;
     }
     if (*cmd != '.') {
-        Macros_ReportError("'.' expected", NULL, NULL);
+        Macros_ReportError("'.' expected", cmd, cmd);
     }
     return cmd+1;
 }
@@ -39,7 +39,7 @@ static void moduleNavigationMode(const char* arg1, const char *textEnd, module_c
     navigation_mode_t modeId = ParseNavigationModeId(NextTok(arg1, textEnd), textEnd);
 
     if (IS_MODIFIER_LAYER(layerId)) {
-        Macros_ReportError("Navigation mode cannot be changed for modifier layers!", NULL, NULL);
+        Macros_ReportError("Navigation mode cannot be changed for modifier layers!", arg1, arg1);
         return;
     }
 
@@ -94,7 +94,7 @@ static void moduleSpeed(const char* arg1, const char *textEnd, module_configurat
         module->swapAxes = Macros_ParseBoolean(arg2, textEnd);
     }
     else if (TokenMatches(arg1, textEnd, "invertScrollDirection")) {
-        Macros_ReportWarn("Command deprecated. Please, replace invertScrollDirection by invertScrollDirectionY.", arg1, textEnd);
+        Macros_ReportWarn("Command deprecated. Please, replace invertScrollDirection by invertScrollDirectionY.", arg1, arg1);
         module->invertScrollDirectionY = Macros_ParseBoolean(arg2, textEnd);
     }
     else if (TokenMatches(arg1, textEnd, "invertScrollDirectionY")) {
@@ -104,7 +104,7 @@ static void moduleSpeed(const char* arg1, const char *textEnd, module_configurat
         module->invertScrollDirectionX = Macros_ParseBoolean(arg2, textEnd);
     }
     else {
-        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+        Macros_ReportError("Parameter not recognized:", arg1, textEnd);
     }
 }
 
@@ -143,7 +143,7 @@ static void secondaryRoleAdvanced(const char* arg1, const char *textEnd)
             SecondaryRoles_AdvancedStrategyTimeoutAction = SecondaryRoleState_Secondary;
         }
         else {
-            Macros_ReportError("parameter not recognized:", arg2, textEnd);
+            Macros_ReportError("Parameter not recognized:", arg2, textEnd);
         }
     }
     else if (TokenMatches(arg1, textEnd, "safetyMargin")) {
@@ -159,7 +159,7 @@ static void secondaryRoleAdvanced(const char* arg1, const char *textEnd)
         SecondaryRoles_AdvancedStrategyDoubletapTime = Macros_ParseInt(arg2, textEnd, NULL);
     }
     else {
-        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+        Macros_ReportError("Parameter not recognized:", arg1, textEnd);
     }
 }
 
@@ -174,14 +174,14 @@ static void secondaryRoles(const char* arg1, const char *textEnd)
             SecondaryRoles_Strategy = SecondaryRoleStrategy_Advanced;
         }
         else {
-            Macros_ReportError("parameter not recognized:", arg2, textEnd);
+            Macros_ReportError("Parameter not recognized:", arg2, textEnd);
         }
     }
     else if (TokenMatches(arg1, textEnd, "advanced")) {
         secondaryRoleAdvanced(proceedByDot(arg1, textEnd), textEnd);
     }
     else {
-        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+        Macros_ReportError("Parameter not recognized:", arg1, textEnd);
     }
 }
 
@@ -194,7 +194,7 @@ static void mouseKeys(const char* arg1, const char *textEnd)
     } else if (TokenMatches(arg1, textEnd, "scroll")) {
         state = &MouseScrollState;
     } else {
-        Macros_ReportError("scroll or move expected", NULL, NULL);
+        Macros_ReportError("Scroll or move expected", arg1, arg1);
     }
 
     const char* arg2 = proceedByDot(arg1, textEnd);
@@ -219,7 +219,7 @@ static void mouseKeys(const char* arg1, const char *textEnd)
         state->axisSkew = ParseFloat(arg3, textEnd);
     }
     else {
-        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+        Macros_ReportError("Parameter not recognized:", arg1, textEnd);
     }
 }
 
@@ -235,7 +235,7 @@ static void stickyModifiers(const char* arg1, const char *textEnd)
         StickyModifierStrategy = Stick_Always;
     }
     else {
-        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+        Macros_ReportError("Parameter not recognized:", arg1, textEnd);
     }
 }
 
@@ -248,7 +248,7 @@ static void macroEngineScheduler(const char* arg1, const char *textEnd)
         Macros_Scheduler = Scheduler_Blocking;
     }
     else {
-        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+        Macros_ReportError("Parameter not recognized:", arg1, textEnd);
     }
 }
 
@@ -264,7 +264,7 @@ static void macroEngine(const char* arg1, const char *textEnd)
         /* this option was removed -> accept the command & do nothing */
     }
     else {
-        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+        Macros_ReportError("Parameter not recognized:", arg1, textEnd);
     }
 }
 
@@ -283,11 +283,11 @@ static void backlightStrategy(const char* arg1, const char *textEnd)
             Ledmap_SetLedBacklightingMode(BacklightingMode_PerKeyRgb);
             Ledmap_UpdateBacklightLeds();
         } else {
-            Macros_ReportError("Cannot set perKeyRgb mode when perKeyRgb maps are not available. Please, consult Agent's led section...", NULL, NULL);
+            Macros_ReportError("Cannot set perKeyRgb mode when perKeyRgb maps are not available. Please, consult Agent's led section...", arg1, arg1);
         }
     }
     else {
-        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+        Macros_ReportError("Parameter not recognized:", arg1, textEnd);
     }
 }
 
@@ -332,7 +332,7 @@ static void constantRgb(const char* arg1, const char *textEnd)
         Ledmap_UpdateBacklightLeds();
     }
     else {
-        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+        Macros_ReportError("Parameter not recognized:", arg1, textEnd);
     }
 }
 
@@ -346,7 +346,7 @@ static void leds(const char* arg1, const char *textEnd)
     } else if (TokenMatches(arg1, textEnd, "enabled")) {
         LedsEnabled = Macros_ParseBoolean(value, textEnd);
     } else {
-        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+        Macros_ReportError("Parameter not recognized:", arg1, textEnd);
     }
 
     LedSlaveDriver_UpdateLeds();
@@ -364,7 +364,7 @@ static void backlight(const char* arg1, const char *textEnd)
         keyRgb(proceedByDot(arg1, textEnd), textEnd);
     }
     else {
-        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+        Macros_ReportError("Parameter not recognized:", arg1, textEnd);
     }
 }
 
@@ -386,7 +386,7 @@ static key_action_t parseKeyAction(const char* arg1, const char *textEnd) {
         action.type = KeyActionType_None;
     }
     else {
-        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+        Macros_ReportError("Parameter not recognized:", arg1, textEnd);
     }
 
     return action;
@@ -405,7 +405,7 @@ static void navigationModeAction(const char* arg1, const char *textEnd)
     navigationMode = ParseNavigationModeId(arg1, textEnd);
 
     if(navigationMode < NavigationMode_RemappableFirst || navigationMode > NavigationMode_RemappableLast) {
-        Macros_ReportError("Invalid or non-remapable navigation mode", arg1, textEnd);
+        Macros_ReportError("Invalid or non-remapable navigation mode:", arg1, textEnd);
     }
 
     if (Macros_ParserError) {
@@ -429,7 +429,7 @@ static void navigationModeAction(const char* arg1, const char *textEnd)
         positive = false;
     }
     else {
-        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+        Macros_ReportError("Parameter not recognized:", arg1, textEnd);
     }
 
     key_action_t action = parseKeyAction(arg3, textEnd);
@@ -455,7 +455,7 @@ static void keymapAction(const char* arg1, const char *textEnd)
     uint8_t inSlotIdx = keyId%64;
 
     if(slotIdx > SLOT_COUNT || inSlotIdx > MAX_KEY_COUNT_PER_MODULE) {
-        Macros_ReportError("invalid key id:", arg2, textEnd);
+        Macros_ReportError("Invalid key id:", arg2, textEnd);
     }
 
     if (Macros_ParserError) {
@@ -492,7 +492,7 @@ static void modLayerTriggers(const char* arg1, const char *textEnd)
         right = HID_KEYBOARD_MODIFIER_RIGHTGUI ;
         break;
     default:
-        Macros_ReportError("This layer does not allow modifier triggers.", arg1, specifier);
+        Macros_ReportError("This layer does not allow modifier triggers:", arg1, specifier);
         return;
     }
 
@@ -510,7 +510,7 @@ static void modLayerTriggers(const char* arg1, const char *textEnd)
         LayerConfig[layerId].modifierLayerMask = left | right;
     }
     else {
-        Macros_ReportError("Specifier not recognized", specifier, textEnd);
+        Macros_ReportError("Specifier not recognized:", specifier, textEnd);
     }
 }
 
@@ -591,7 +591,7 @@ macro_result_t MacroSetCommand(const char* arg1, const char *textEnd)
         EmergencyKey = Utils_KeyIdToKeyState(key);
     }
     else {
-        Macros_ReportError("parameter not recognized:", arg1, textEnd);
+        Macros_ReportError("Parameter not recognized:", arg1, textEnd);
     }
     return MacroResult_Finished;
 }

--- a/right/src/macro_shortcut_parser.c
+++ b/right/src/macro_shortcut_parser.c
@@ -499,7 +499,7 @@ static serialized_mouse_action_t mouseBtnToSerializedMouseAction(mouse_button_t 
         case MouseButton_8:
             return SerializedMouseAction_Button_8;
         default:
-            Macros_ReportErrorNum("Unknown button encountered:", btn);
+            Macros_ReportErrorNum("Unknown button encountered:", btn, NULL);
             return 0;
     }
 }

--- a/right/src/macros.c
+++ b/right/src/macros.c
@@ -572,22 +572,27 @@ static void reportErrorHeader(const char* status)
     }
 }
 
-static void reportCommandLocation(uint16_t line, uint16_t pos, const char* begin, const char* end)
+static void reportCommandLocation(uint16_t line, uint16_t pos, const char* begin, const char* end, bool reportPosition)
 {
+    Macros_SetStatusString("> ", NULL);
     uint16_t l = statusBufferLen;
     Macros_SetStatusNumSpaced(line, false);
     l = statusBufferLen - l;
     Macros_SetStatusString(" | ", NULL);
     Macros_SetStatusString(begin, end);
     Macros_SetStatusString("\n", NULL);
-    for (uint8_t i = 0; i < l; i++) {
-        Macros_SetStatusString(" ", NULL);
+    if (reportPosition) {
+        Macros_SetStatusString("> ", NULL);
+        for (uint8_t i = 0; i < l; i++) {
+            Macros_SetStatusString(" ", NULL);
+        }
+        Macros_SetStatusString(" | ", NULL);
+        for (uint8_t i = 0; i < pos; i++) {
+            Macros_SetStatusString(" ", NULL);
+        }
+        Macros_SetStatusString("^", NULL);
+        Macros_SetStatusString("\n", NULL);
     }
-    Macros_SetStatusString(" | ", NULL);
-    for (uint8_t i = 0; i < pos; i++) {
-        Macros_SetStatusString(" ", NULL);
-    }
-    Macros_SetStatusString("^", NULL);
 }
 
 void reportStringArg(const char* arg, const char *argEnd)
@@ -599,10 +604,19 @@ void reportStringArg(const char* arg, const char *argEnd)
             Macros_SetStatusString("\n", NULL);
             const char* startOfLine = s->ms.currentMacroAction.cmd.text + s->ms.commandBegin;
             uint16_t line = findCurrentCommandLine();
-            reportCommandLocation(line, arg-startOfLine, startOfLine, argEnd);
-            Macros_SetStatusString("\n", NULL);
+            reportCommandLocation(line, arg-startOfLine, startOfLine, argEnd, true);
         } else {
             Macros_SetStatusString(arg, argEnd);
+            Macros_SetStatusString("\n", NULL);
+        }
+    } else {
+        if (s != NULL) {
+            Macros_SetStatusString("\n", NULL);
+            const char* startOfLine = s->ms.currentMacroAction.cmd.text + s->ms.commandBegin;
+            const char* endOfLine = s->ms.currentMacroAction.cmd.text + s->ms.commandEnd;
+            uint16_t line = findCurrentCommandLine();
+            reportCommandLocation(line, 0, startOfLine, endOfLine, false);
+        } else {
             Macros_SetStatusString("\n", NULL);
         }
     }

--- a/right/src/macros.h
+++ b/right/src/macros.h
@@ -246,9 +246,9 @@
     void Macros_SignalInterrupt(void);
     bool Macros_ClaimReports(void);
     void Macros_ReportError(const char* err, const char* arg, const char *argEnd);
-    void Macros_ReportErrorPrintf(const char *fmt, ...);
-    void Macros_ReportErrorNum(const char* err, int32_t num);
-    void Macros_ReportErrorFloat(const char* err, float num);
+    void Macros_ReportErrorPrintf(const char* pos, const char *fmt, ...);
+    void Macros_ReportErrorNum(const char* err, int32_t num, const char* pos);
+    void Macros_ReportErrorFloat(const char* err, float num, const char* pos);
     void Macros_ReportWarn(const char* err, const char* arg, const char *argEnd);
     void Macros_SetStatusString(const char* text, const char *textEnd);
     void Macros_SetStatusStringInterpolated(const char* text, const char *textEnd);

--- a/right/src/str_utils.c
+++ b/right/src/str_utils.c
@@ -201,6 +201,23 @@ const char* NextCmd(const char* cmd, const char *cmdEnd)
     return cmd;
 }
 
+
+const char* CmdEnd(const char* cmd, const char *cmdEnd)
+{
+    while(*cmd != '\n' && *cmd != '\r' && cmd < cmdEnd)    {
+        cmd++;
+    }
+    return cmd;
+}
+
+const char* SkipWhite(const char* cmd, const char *cmdEnd)
+{
+    while(*cmd <= 32 && cmd < cmdEnd) {
+        cmd++;
+    }
+    return cmd;
+}
+
 module_id_t ParseModuleId(const char* arg1, const char* cmdEnd)
 {
     if (TokenMatches(arg1, cmdEnd, "keycluster")) {

--- a/right/src/str_utils.h
+++ b/right/src/str_utils.h
@@ -22,6 +22,8 @@
     uint8_t TokLen(const char *a, const char *aEnd);
     const char* NextTok(const char* cmd, const char *cmdEnd);
     const char* NextCmd(const char* cmd, const char *cmdEnd);
+    const char* CmdEnd(const char* cmd, const char *cmdEnd);
+    const char* SkipWhite(const char* cmd, const char *cmdEnd);
     uint8_t CountCommands(const char* text, uint16_t textLen);
     const char* TokEnd(const char* cmd, const char *cmdEnd);
     module_id_t ParseModuleId(const char* arg1, const char* cmdEnd);


### PR DESCRIPTION
- Switches position to actionIndex/lineNumber
- If error is in the middle of a command, it will now print entire line, with error place marked:
```
Error at tstErr 1/3: unrecognized command: autoRepeat HERE->asdf
```
- Also should fix troubles with unwanted extra newlines in error logs.

Closes #662 