### PR TITLE
Fix comments in string literals.

### DIFF
--- a/right/src/macros_string_reader.c
+++ b/right/src/macros_string_reader.c
@@ -216,7 +216,9 @@ char Macros_ConsumeCharOfString(parser_context_t* ctx, uint16_t* stringOffset, u
                 goto normalChar;
             } else {
                 parser_context_t ctx2 = { .macroState = ctx->macroState, .begin = ctx->begin, .at = a, .end = aEnd };
+                ConsumeCommentsAsWhite(false);
                 char res = consumeExpressionChar(&ctx2, subIndex);
+                ConsumeCommentsAsWhite(true);
                 if (*subIndex == 0) {
                     *index += ctx2.at - a;
                 }

--- a/right/src/str_utils.c
+++ b/right/src/str_utils.c
@@ -7,6 +7,7 @@
 #include "module.h"
 #include "slave_protocol.h"
 
+static bool consumeCommentsAsWhite = true;
 
 static bool isIdentifierChar(char c);
 
@@ -81,6 +82,17 @@ static void consumeWhite(parser_context_t* ctx)
     while (*ctx->at <= 32 && ctx->at < ctx->end) {
         ctx->at++;
     }
+    if (ctx->at[0] == '/' && ctx->at[1] == '/' && consumeCommentsAsWhite) {
+        while (*ctx->at != '\n' && *ctx->at != '\r' && ctx->at < ctx->end) {
+            ctx->at++;
+        }
+    }
+}
+
+
+void ConsumeCommentsAsWhite(bool consume)
+{
+    consumeCommentsAsWhite = consume;
 }
 
 void ConsumeWhite(parser_context_t* ctx)
@@ -321,7 +333,7 @@ const char* NextCmd(const char* cmd, const char *cmdEnd)
 
 const char* CmdEnd(const char* cmd, const char *cmdEnd)
 {
-    while(*cmd != '\n' && *cmd != '\r' && (cmd[0] != '/' || cmd[1] != '/') && cmd < cmdEnd)    {
+    while(*cmd != '\n' && *cmd != '\r' && cmd < cmdEnd)    {
         cmd++;
     }
     return cmd;

--- a/right/src/str_utils.h
+++ b/right/src/str_utils.h
@@ -33,6 +33,7 @@
     bool StrEqual(const char* a, const char* aEnd, const char* b, const char* bEnd);
     const char* FindChar(char c, const char* str, const char* strEnd);
     bool ConsumeToken(parser_context_t* ctx, const char *b);
+    void ConsumeCommentsAsWhite(bool consume);
     bool ConsumeTokenByRef(parser_context_t* ctx, string_ref_t ref);
     bool ConsumeIdentifierByRef(parser_context_t* ctx, string_ref_t ref);
     void ConsumeAnyIdentifier(parser_context_t* ctx);


### PR DESCRIPTION
One more problem with #687:

Given `write "abc // def"`, it discards the `// def` part as a comment. 

Here is a fix.