### PR TITLE
Don't throw "unprocessed input" error as consequence of another error.

### DIFF
--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -2427,7 +2427,7 @@ macro_result_t Macros_ProcessCommandAction(void)
 
     if (*ctx.at == '#') {
         Macros_ReportWarn("# comments are deprecated, please switch to //", ctx.at, ctx.at);
-    } else if (ctx.at != ctx.end) {
+    } else if (ctx.at != ctx.end && !Macros_ParserError) {
         Macros_ReportWarn("Unprocessed input encountered.", ctx.at, ctx.at);
     }
 


### PR DESCRIPTION
Steps to reproduce:

- Make some errors in your macros and save config.
- Observe that every error is followed by a redundant "unprocessed input" error.

E.g.:

```
Warning at Emoji 2/1: `@` notation is now deprecated. Please, replace it with $currentAddress. E.g., `@3` with `$($currentAddress + 3)`.
> 1 | ifGesture transitive 21 74 17 10 goTo @2
>   |                                       ^
Warning at Rgb 1/11: Unprocessed input encountered.
> 11 | ifGesture transitive g final set backlight.constantRgb.rgb 192 255 0  /green
>    |                                                                       ^
Error at tstErr 1/4: Unrecognized command: invalid
> 4 | invalid 1
>   | ^
Warning at tstErr 1/4: Unprocessed input encountered.
> 4 | invalid 1
>   | ^
Error at tstErr 1/5: Unrecognized command: abcdefg
> 5 | ifShortcut abcdefg
>   |            ^
Warning at tstErr 1/5: Unprocessed input encountered.
> 5 | ifShortcut abcdefg
>   |            ^
Error at tstErr 1/6: Unrecognized command: defg
> 6 | ifGesture defg
>   |           ^
Warning at tstErr 1/6: Unprocessed input encountered.
> 6 | ifGesture defg
>   |           ^
```

Correct output:

```
Warning at Emoji 2/1: `@` notation is now deprecated. Please, replace it with $currentAddress. E.g., `@3` with `$($currentAddress + 3)`.
> 1 | ifGesture transitive 21 74 17 10 goTo @2
>   |                                       ^
Warning at Rgb 1/11: Unprocessed input encountered.
> 11 | ifGesture transitive g final set backlight.constantRgb.rgb 192 255 0  /green
>    |                                                                       ^
Error at tstErr 1/4: Unrecognized command: invalid
> 4 | invalid 1
>   | ^
Error at tstErr 1/5: Unrecognized command: abcdefg
> 5 | ifShortcut abcdefg
>   |            ^
Error at tstErr 1/6: Unrecognized command: defg
> 6 | ifGesture defg
>   |           ^

```
