### PR TITLE
Fix redundant "unprocessed input" warning after `if BOOLEAN` condition.

### DIFF
--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -769,7 +769,13 @@ static bool processIfLayerCommand(parser_context_t* ctx, bool negate)
 
 static bool processIfCommand(parser_context_t* ctx)
 {
-    return Macros_ConsumeBool(ctx);
+    bool res = Macros_ConsumeBool(ctx);
+
+    if (Macros_DryRun) {
+        return true;
+    }
+
+    return res;
 }
 
 static macro_result_t processBreakCommand()


### PR DESCRIPTION
Reported in https://forum.ultimatehackingkeyboard.com/t/replay-macro-n-times/311/19?u=kareltucek

- Create this macro:
```
if(false) setVar repeatCount 1
```
- Save your config
- Observe following warning:
```
Warning at tstErr 1/2: Unprocessed input encountered.
> 2 | if(false) setVar repeatCount 1
>   |           ^
```