### PR TITLE
Fix && macro command.

### DIFF
--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -701,7 +701,7 @@ static macro_variable_t consumeAndExpression(parser_context_t* ctx)
     while (true) {
         parser_context_t opCtx = *ctx;
         if (ConsumeToken(ctx, "&&")) {
-            op = Operator_Or;
+            op = Operator_And;
         } else {
             return accumulator;
         }


### PR DESCRIPTION
Typo fix...

- `write "$(1 && 0)"`
- observe 1 being produced whereas 0 is correct

Closes #706 