### PR TITLE
Fix errors caused by repeatFor

### DIFF
--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -89,6 +89,15 @@ static macro_variable_t consumeNumericValue(parser_context_t* ctx)
 
 macro_variable_t* Macros_ConsumeExistingWritableVariable(parser_context_t* ctx)
 {
+    if (Macros_DryRun) {
+        if (!IsIdentifierChar(*ctx->at)) {
+            Macros_ReportError("Identifier expected here:", ctx->at, ctx->at);
+            return NULL;
+        }
+        ConsumeAnyIdentifier(ctx);
+        return NULL;
+    }
+
     //TODO: optimize this!
     for (uint8_t i = 0; i < macroVariableCount; i++) {
         if (ConsumeIdentifierByRef(ctx, macroVariables[i].name)) {


### PR DESCRIPTION
Closes #717 

- Create macro and save the config:
```
setVar count 6
startloop:
setLedTxt 200 "`-'"
setLedTxt 200 "---"
repeatFor count startloop 
```
- observe validation error
- run the macro
- observe another error