### PR TITLE
Implement touchpad hold continuation timeout.

### DIFF
--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -109,6 +109,7 @@ The following grammar is supported:
     COMMAND = set module.MODULEID.invertScrollDirectionY BOOL
     COMMAND = set module.touchpad.pinchZoomDivisor <1-100 (FLOAT)>
     COMMAND = set module.touchpad.pinchZoomMode NAVIGATION_MODE
+    COMMAND = set module.touchpad.holdContinuationTimeout <0-65535 (INT)>
     COMMAND = set secondaryRole.defaultStrategy { simple | advanced }
     COMMAND = set secondaryRole.advanced.timeout <ms, 0-500 (INT)>
     COMMAND = set secondaryRole.advanced.timeoutAction { primary | secondary }
@@ -564,6 +565,8 @@ Internally, values are saved in one of the following types, and types are automa
   - `cursorAxisLock BOOL` - turns axis locking on for cursor mode. Not recommended, but possible.
   - `scrollAxisLock BOOL` - turns axis locking on for scroll mode. Default for keycluster trackball.
   - `caretAxisLock BOOL` - turns axis locking on for all discrete modes.
+
+- `set module.touchpad.holdContinuationTimeout <0-65535 (INT)>` If non-zero, touchpad allows you to release your finger for the specified amount of time during drag-and-drop (without the left click getting released).
 
 - Remapping keys:
   - `set navigationModeAction.{caret|media}.{DIRECTION|none} ACTION` can be used to customize the caret or media mode behaviour by binding directions to macros. This action is global and reversible only by powercycling.

--- a/right/src/macros/set_command.c
+++ b/right/src/macros/set_command.c
@@ -252,9 +252,14 @@ static macro_variable_t module(parser_context_t* ctx, set_command_action_t actio
         ConsumeUntilDot(ctx);
         return moduleNavigationMode(ctx, action, module);
     }
+    else if (ConsumeToken(ctx, "holdContinuationTimeout") && moduleId == ModuleId_TouchpadRight) {
+        DEFINE_INT_LIMITS(0, 65535);
+        ASSIGN_INT(HoldContinuationTimeout);
+    }
     else {
         return moduleSpeed(ctx, action, module, moduleId);
     }
+    return noneVar();
 }
 
 static macro_variable_t secondaryRoleAdvanced(parser_context_t* ctx, set_command_action_t action)

--- a/right/src/mouse_controller.h
+++ b/right/src/mouse_controller.h
@@ -29,6 +29,7 @@
 
 // Variables:
 
+    extern uint16_t HoldContinuationTimeout;
 
 // Functions:
     void MouseController_ProcessMouseActions();


### PR DESCRIPTION
As discussed in https://forum.ultimatehackingkeyboard.com/t/touchpad-double-click-to-drag-continuation/595/4

`set module.touchpad.holdContinuationTimeout 200`

Should it be enabled by default?