### PR TITLE
Rewrite if doubletap.

### DIFF
--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1512,10 +1512,10 @@ static macro_result_t processFinalCommand(parser_context_t* ctx)
     macro_result_t res = processCommand(ctx);
 
     if (Macros_DryRun) {
-        return MacroResult_Finished;
+        return res;
     }
 
-    if (res & MacroResult_InProgressFlag) {
+    if (res & MacroResult_InProgressFlag || res & MacroResult_DoneFlag) {
         return res;
     } else {
         S->ms.macroBroken = true;

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -493,10 +493,13 @@ static bool processIfDoubletapCommand(bool negate)
     }
     bool doubletapFound = false;
 
-    for (uint8_t i = 0; i < MACRO_STATE_POOL_SIZE; i++) {
-        if (S->ms.currentMacroStartTime - MacroState[i].ps.previousMacroStartTime <= DoubletapConditionTimeout && S->ms.currentMacroIndex == MacroState[i].ps.previousMacroIndex) {
+    for (uint8_t i = 0; i < MACRO_HISTORY_POOL_SIZE; i++) {
+        if (S->ms.currentMacroStartTime - MacroHistory[i].macroStartTime <= DoubletapConditionTimeout && S->ms.currentMacroIndex == MacroHistory[i].macroIndex) {
             doubletapFound = true;
         }
+    }
+
+    for (uint8_t i = 0; i < MACRO_STATE_POOL_SIZE; i++) {
         if (
             MacroState[i].ms.macroPlaying &&
             MacroState[i].ms.currentMacroStartTime < S->ms.currentMacroStartTime &&

--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -49,6 +49,10 @@ macro_scope_state_t MacroScopeState[MACRO_SCOPE_STATE_POOL_SIZE];
 macro_state_t MacroState[MACRO_STATE_POOL_SIZE];
 macro_state_t *S = NULL;
 
+
+macro_history_t MacroHistory[MACRO_HISTORY_POOL_SIZE];
+uint8_t MacroHistoryPosition = 0;
+
 uint16_t DoubletapConditionTimeout = 400;
 uint16_t AutoRepeatInitialDelay = 500;
 uint16_t AutoRepeatDelayRate = 50;
@@ -258,8 +262,9 @@ static macro_result_t endMacro(void)
     S->ms.macroSleeping = false;
     S->ms.macroPlaying = false;
     S->ms.macroBroken = false;
-    S->ps.previousMacroIndex = S->ms.currentMacroIndex;
-    S->ps.previousMacroStartTime = S->ms.currentMacroStartTime;
+    MacroHistoryPosition = (MacroHistoryPosition + 1) % MACRO_HISTORY_POOL_SIZE;
+    MacroHistory[MacroHistoryPosition].macroIndex = S->ms.currentMacroIndex;
+    MacroHistory[MacroHistoryPosition].macroStartTime = S->ms.currentMacroStartTime;
     unscheduleCurrentSlot();
     if (S->ms.parentMacroSlot != 255) {
         //resume our calee, if this macro was called by another macro

--- a/right/src/macros/core.h
+++ b/right/src/macros/core.h
@@ -18,6 +18,7 @@
     #define MAX_MACRO_NUM 255
     #define STATUS_BUFFER_MAX_LENGTH 2000
     #define MACRO_STATE_POOL_SIZE 16
+    #define MACRO_HISTORY_POOL_SIZE 16
     #define MACRO_SCOPE_STATE_POOL_SIZE (MACRO_STATE_POOL_SIZE*2)
     #define MAX_REG_COUNT 32
 
@@ -128,16 +129,14 @@
 
     typedef struct macro_state_t macro_state_t;
 
+    typedef struct {
+        uint32_t macroStartTime;
+        uint8_t macroIndex;
+    } macro_history_t;
+
     struct macro_state_t {
         // local scope data
         macro_scope_state_t *ls;
-
-        // persistent scope data
-        // these need to live in between macro calls
-        struct {
-            uint32_t previousMacroStartTime;
-            uint8_t previousMacroIndex;
-        } ps;
 
         // macro scope data
         // these can be destroyed at the end of macro runtime, and probably should be re-initialized with each macro start
@@ -233,6 +232,7 @@
     extern macro_reference_t AllMacros[MacroIndex_MaxCount];
     extern uint8_t AllMacrosCount;
     extern macro_state_t MacroState[MACRO_STATE_POOL_SIZE];
+    extern macro_history_t MacroHistory[MACRO_HISTORY_POOL_SIZE];
     extern macro_scope_state_t MacroScopeState[MACRO_SCOPE_STATE_POOL_SIZE];
     extern macro_state_t *S;
     extern bool MacroPlaying;


### PR DESCRIPTION
This fixes two bugs:

# 1 

- Run:
```
final {
    write abc
}
```
- Observe "abc" not being written

# 2 

- flash UserConfig from https://forum.ultimatehackingkeyboard.com/t/macro-key-modifier/633/7
- (optionally, increase led brightness so you can read out results)
- doubletap left mod
  - expected behavior: mouse layer gets toggled
  - actual behavior: nothing, except brief activation of fn4 accompanied with TXT on led display