### PR TITLE
Fix composite shortcuts in caret mode.

### DIFF
--- a/right/src/mouse_controller.c
+++ b/right/src/mouse_controller.c
@@ -654,8 +654,11 @@ static void processModuleActions(
     processModuleKineticState(x, y, moduleConfiguration, ks, forcedNavigationMode);
 }
 
-bool canWeRun()
+bool canWeRun(module_kinetic_state_t* ks)
 {
+    if (caretModeActionIsRunning(ks)) {
+        return false;
+    }
     if (StickyModifiers) {
         StickyModifiers = 0;
         StickyModifiersNegative = 0;
@@ -679,7 +682,7 @@ void MouseController_ProcessMouseActions()
         }
 
         bool eventsIsNonzero = memcmp(&TouchpadEvents, &ZeroTouchpadEvents, sizeof TouchpadEvents) != 0;
-        if (!eventsIsNonzero || (eventsIsNonzero && canWeRun())) {
+        if (!eventsIsNonzero || (eventsIsNonzero && canWeRun(ks))) {
             //eventsIsNonzero is needed for touchpad action state automaton timer
             __disable_irq();
             touchpad_events_t events = TouchpadEvents;
@@ -714,7 +717,7 @@ void MouseController_ProcessMouseActions()
 
 
         bool eventsIsNonzero = moduleState->pointerDelta.x || moduleState->pointerDelta.y;
-        if (eventsIsNonzero && canWeRun()) {
+        if (eventsIsNonzero && canWeRun(ks)) {
             __disable_irq();
             // Gcc compiles those int16_t assignments as sequences of
             // single-byte instructions, therefore we need to make the


### PR DESCRIPTION
Closes #730.

Steps to reproduce:
- Add the following into your `$onInit`:
```
set navigationModeAction.caret.left none
set navigationModeAction.caret.right none
set navigationModeAction.caret.up keystroke LS-U
set navigationModeAction.caret.down keystroke LS-D
set keystrokeDelay 10
```
- Now press fn and swipe with your right hand module. 
- Observe output like `uuuuuuuuuUddddddddduuuuuddddduuDDDDdddDuuuuu`.
- Apply this fix.
- Observe output like `UUUUDDDDDDDDDDUUUUUUUUUDDDDDDDDUUUUDDDDDDDDUUUU`