### PR TITLE
Key timing hunt rebased

### DIFF
--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -114,7 +114,9 @@ The following grammar is supported:
     COMMAND = set secondaryRole.advanced.timeout <ms, 0-500 (INT)>
     COMMAND = set secondaryRole.advanced.timeoutAction { primary | secondary }
     COMMAND = set secondaryRole.advanced.safetyMargin <ms, -50 - 50 (INT)>
+    COMMAND = set secondaryRole.advanced.triggerByPress BOOL
     COMMAND = set secondaryRole.advanced.triggerByRelease BOOL
+    COMMAND = set secondaryRole.advanced.triggerByMouse BOOL
     COMMAND = set secondaryRole.advanced.doubletapToPrimary BOOL
     COMMAND = set secondaryRole.advanced.doubletapTime <ms, 0 - 500 (INT)>
     COMMAND = set mouseKeys.{move|scroll}.initialSpeed <px/s, -100/20 (INT)>
@@ -580,8 +582,10 @@ Internally, values are saved in one of the following types, and types are automa
     - advanced strategy may trigger secondary role depending on timeout, or depending on key release order.
       - `set secondaryRole.advanced.timeout <timeout in ms, 350 (INT)>` if this timeout is reached, `timeoutAction` (secondary by default) role is activated.
       - `set secondaryRole.advanced.timeoutAction { primary | secondary }` defines whether the primary action or the secondary role should be activated when timeout is reached
-      - `set secondaryRole.advanced.triggerByRelease BOOL` if enabled, secondary role is chosen depending on the release order of the keys (`press-A, press-B, release-B, release-A` leads to secondary action; `press-A, press-B, release-A, release-B` leads to primary action).
-      - `set secondaryRole.advanced.safetyMargin <ms, -50 - 50 (INT)>` finetunes sensitivity of the trigger-by-release behaviour by adding the value to the dual-role-key release time. I.e., if both keys are released simultaneously (i.e., at most `safetyMargin` ms from each other), then positive values favor the primary action, and negative values the secondary role.
+      - `set secondaryRole.advanced.triggerByRelease BOOL` if enabled, secondary role is chosen depending on the release order of the keys (`press-A, press-B, release-B, release-A` leads to secondary action; `press-A, press-B, release-A, release-B` leads to primary action). This is further modified by safetyMargin.
+      - `set secondaryRole.advanced.triggerByPress BOOL` if enabled, secondary role is triggered when there is another press, simiarly to the simple strategy. Unlike simple strategy, this allows setting timeout behaviors, and also is modified by safetyMargin.
+      - `set secondaryRole.advanced.triggerByMouse BOOL` if enabled, any mouse (module) activity triggers secondary role immediately.
+      - `set secondaryRole.advanced.safetyMargin <ms, -50 - 50 (INT)>` finetunes sensitivity of the trigger-by-release and trigger-by-press behaviours, so that positive values favor primary role, while negative values favor secondary role. This works by adding the value to the action key (or subtracting from the dual role key). E.g., suppose trigger by release is active, and safetyMargin equal 50. Furthermore assume that dual-role key is released 30ms after the action key. Due to safety margin 50 being greater than 30, the dual-role key is still considered to be released first, and so primary role is activated.
       - `set secondaryRole.advanced.doubletapToPrimary BOOL` allows initiating hold of primary action by doubletap. (Useful if you want a dual key on space.)
       - `set secondaryRole.advanced.doubletapTime <ms, 200 (INT)>` configures the above timeout (measured press-to-press).
 

--- a/doc-dev/user-guide.md
+++ b/doc-dev/user-guide.md
@@ -444,6 +444,33 @@ set secondaryRole.advanced.doubletapToPrimary 1
 set secondaryRole.advanced.doubletapTime 200
 ```
 
+Simple strategy behavior, but via advanced strategy and with timeout on 500ms:
+
+```
+set secondaryRole.defaultStrategy advanced
+set secondaryRole.advanced.timeout 500
+set secondaryRole.advanced.timeoutAction secondary
+set secondaryRole.advanced.safetyMargin 0
+set secondaryRole.advanced.triggerByRelease 0
+set secondaryRole.advanced.triggerByPress 1
+set secondaryRole.advanced.doubletapToPrimary 1
+set secondaryRole.advanced.doubletapTime 200
+```
+
+Full set of advanced strategy config values follows (for copy-paste convenience):
+
+```
+set secondaryRole.defaultStrategy advanced
+set secondaryRole.advanced.timeout 500
+set secondaryRole.advanced.timeoutAction secondary
+set secondaryRole.advanced.safetyMargin 0
+set secondaryRole.advanced.triggerByRelease 0
+set secondaryRole.advanced.triggerByPress 0
+set secondaryRole.advanced.triggerByMouse 0
+set secondaryRole.advanced.doubletapToPrimary 1
+set secondaryRole.advanced.doubletapTime 200
+```
+
 The above configuration will trigger the secondary role whenever the dual-role key is pressed for more than 200ms, i.e., just a very slightly prolonged activation will trigger the secondary role.
 
 Furthermore, this configuration allows you to activate the primary role by double-tap-and-hold. You may want this on your space key, or other primary key that is often used to produce a row of characters.

--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -57,8 +57,6 @@ uint16_t DoubletapConditionTimeout = 400;
 uint16_t AutoRepeatInitialDelay = 500;
 uint16_t AutoRepeatDelayRate = 50;
 
-bool RecordKeyTiming = false;
-
 static void checkSchedulerHealth(const char* tag);
 static void wakeMacroInSlot(uint8_t slotIdx);
 static void scheduleSlot(uint8_t slotIdx);

--- a/right/src/macros/core.h
+++ b/right/src/macros/core.h
@@ -248,7 +248,6 @@
     extern uint16_t AutoRepeatInitialDelay;
     extern uint16_t AutoRepeatDelayRate;
     extern bool Macros_ParserError;
-    extern bool RecordKeyTiming;
     extern bool Macros_DryRun;
     extern bool Macros_ValidationInProgress;
 

--- a/right/src/macros/debug_commands.c
+++ b/right/src/macros/debug_commands.c
@@ -1,6 +1,7 @@
 #include "macros/core.h"
 #include "macros/status_buffer.h"
 #include "macros/debug_commands.h"
+#include "macros/key_timing.h"
 #include "utils.h"
 #include "layer_stack.h"
 #include "postponer.h"

--- a/right/src/macros/key_timing.c
+++ b/right/src/macros/key_timing.c
@@ -1,0 +1,37 @@
+#include "macros/key_timing.h"
+#include "key_states.h"
+#include "macros/status_buffer.h"
+#include "utils.h"
+#include "timer.h"
+
+bool RecordKeyTiming = false;
+
+void KeyTiming_RecordKeystroke(key_state_t *keyState, bool active, uint32_t pressTime, uint32_t activationTime)
+{
+    const char* keyAbbreviation = Utils_KeyAbbreviation(keyState);
+    Macros_SetStatusString( active ? "DOWN" : "UP", NULL);
+    Macros_SetStatusChar(' ');
+    Macros_SetStatusString(keyAbbreviation, NULL);
+    Macros_SetStatusNum(pressTime);
+    Macros_SetStatusNum(activationTime);
+    Macros_SetStatusChar('\n');
+}
+
+void KeyTiming_RecordReport(usb_basic_keyboard_report_t* report)
+{
+    Macros_SetStatusNumSpaced(CurrentTime, false);
+    Utils_PrintReport(" OUT", ActiveUsbBasicKeyboardReport);
+}
+
+void KeyTiming_RecordComment(key_state_t* keyState, const char* comment)
+{
+    const char* keyAbbreviation = Utils_KeyAbbreviation(keyState);
+
+    Macros_SetStatusNumSpaced(CurrentTime, false);
+    Macros_SetStatusChar(' ');
+    Macros_SetStatusString(keyAbbreviation, NULL);
+    Macros_SetStatusChar(' ');
+    Macros_SetStatusString(comment, NULL);
+    Macros_SetStatusChar('\n');
+}
+

--- a/right/src/macros/key_timing.h
+++ b/right/src/macros/key_timing.h
@@ -1,0 +1,28 @@
+#ifndef __KEY_TIMING_H__
+#define __KEY_TIMING_H__
+
+// Includes:
+
+#include "key_states.h"
+#include "usb_interfaces/usb_interface_basic_keyboard.h"
+
+// Macros:
+
+#define KEY_TIMING(code) if (RecordKeyTiming) { code; }
+
+#define KEY_TIMING2(condition, code) if (RecordKeyTiming && condition) { code; }
+
+// Typedefs:
+
+
+// Variables:
+
+    extern bool RecordKeyTiming;
+
+// Functions:
+
+void KeyTiming_RecordKeystroke(key_state_t *keyState, bool active, uint32_t pressTime, uint32_t activationTime);
+void KeyTiming_RecordReport(usb_basic_keyboard_report_t* report);
+void KeyTiming_RecordComment(key_state_t* keyState, const char* comment);
+
+#endif

--- a/right/src/macros/keyid_parser.c
+++ b/right/src/macros/keyid_parser.c
@@ -147,3 +147,13 @@ uint8_t MacroKeyIdParser_TryConsumeKeyId(parser_context_t* ctx)
 
     return record->keyId;
 }
+
+const char* MacroKeyIdParser_KeyIdToAbbreviation(uint8_t keyId)
+{
+    for (uint8_t i = 0; i < lookup_size - 1; i++) {
+        if (lookup_table[i].keyId == keyId) {
+            return lookup_table[i].id;
+        }
+    }
+    return "?";
+}

--- a/right/src/macros/keyid_parser.h
+++ b/right/src/macros/keyid_parser.h
@@ -15,6 +15,7 @@
 
     void KeyIdParser_initialize();
     uint8_t MacroKeyIdParser_TryConsumeKeyId(parser_context_t* ctx);
+    const char* MacroKeyIdParser_KeyIdToAbbreviation(uint8_t keyId) ;
 
 
 #endif

--- a/right/src/macros/set_command.c
+++ b/right/src/macros/set_command.c
@@ -283,6 +283,12 @@ static macro_variable_t secondaryRoleAdvanced(parser_context_t* ctx, set_command
     else if (ConsumeToken(ctx, "triggerByRelease")) {
         ASSIGN_BOOL(SecondaryRoles_AdvancedStrategyTriggerByRelease);
     }
+    else if (ConsumeToken(ctx, "triggerByPress")) {
+        ASSIGN_BOOL(SecondaryRoles_AdvancedStrategyTriggerByPress);
+    }
+    else if (ConsumeToken(ctx, "triggerByMouse")) {
+        ASSIGN_BOOL(SecondaryRoles_AdvancedStrategyTriggerByMouse);
+    }
     else if (ConsumeToken(ctx, "doubletapToPrimary")) {
         ASSIGN_BOOL(SecondaryRoles_AdvancedStrategyDoubletapToPrimary);
     }

--- a/right/src/macros/shortcut_parser.c
+++ b/right/src/macros/shortcut_parser.c
@@ -23,13 +23,14 @@ typedef struct {
 
 static const lookup_record_t* lookup(uint8_t begin, uint8_t end, const char* str, const char* strEnd);
 
+
 char MacroShortcutParser_ScancodeToCharacter(uint16_t scancode)
 {
     switch (scancode) {
         case HID_KEYBOARD_SC_A ... HID_KEYBOARD_SC_Z:
             return scancode - HID_KEYBOARD_SC_A + 'a';
         default:
-            return ' ';
+            return DEFAULT_SCANCODE_ABBREVIATION;
     }
 }
 

--- a/right/src/macros/shortcut_parser.h
+++ b/right/src/macros/shortcut_parser.h
@@ -8,9 +8,14 @@
     #include <stdbool.h>
     #include "macros/core.h"
 
+
+// Macros:
+
+    #define DEFAULT_SCANCODE_ABBREVIATION '?'
+
 // Typedefs:
 
-    // Functions:
+// Functions:
 
     void ShortcutParser_initialize();
 

--- a/right/src/macros/status_buffer.c
+++ b/right/src/macros/status_buffer.c
@@ -72,6 +72,11 @@ static void setStatusChar(char n)
         return;
     }
 
+    if (n && statusBufferLen == STATUS_BUFFER_MAX_LENGTH) {
+        memcpy(statusBuffer, &statusBuffer[STATUS_BUFFER_MAX_LENGTH/2], STATUS_BUFFER_MAX_LENGTH/2);
+        statusBufferLen = STATUS_BUFFER_MAX_LENGTH/2;
+    }
+
     if (n && statusBufferLen < STATUS_BUFFER_MAX_LENGTH) {
         statusBuffer[statusBufferLen] = n;
         statusBufferLen++;
@@ -274,7 +279,7 @@ void Macros_ReportErrorPrintf(const char* pos, const char *fmt, ...)
     va_list myargs;
     va_start(myargs, fmt);
     char buffer[256];
-    vsprintf(buffer, fmt, myargs);
+    sprintf(buffer, fmt, myargs);
     Macros_ReportError(buffer, pos, pos);
 
 }

--- a/right/src/postponer.c
+++ b/right/src/postponer.c
@@ -1,5 +1,6 @@
 #include "postponer.h"
 #include "key_states.h"
+#include "macros/key_timing.h"
 #include "usb_report_updater.h"
 #include "macros/core.h"
 #include "macros/status_buffer.h"
@@ -71,6 +72,7 @@ static void applyEventAndConsume(postponer_buffer_record_type_t* rec) {
     switch (rec->event.type) {
         case PostponerEventType_PressKey:
         case PostponerEventType_ReleaseKey:
+            KEY_TIMING(KeyTiming_RecordKeystroke(rec->event.key.keyState, rec->event.key.active, rec->time, CurrentTime));
             rec->event.key.keyState->current = rec->event.key.active;
             Postponer_LastKeyLayer = rec->event.key.layer;
             Postponer_LastKeyMods = rec->event.key.modifiers;

--- a/right/src/secondary_role_driver.h
+++ b/right/src/secondary_role_driver.h
@@ -79,6 +79,8 @@
     extern uint16_t SecondaryRoles_AdvancedStrategyTimeout;
     extern int16_t SecondaryRoles_AdvancedStrategySafetyMargin;
     extern bool SecondaryRoles_AdvancedStrategyTriggerByRelease;
+    extern bool SecondaryRoles_AdvancedStrategyTriggerByPress;
+    extern bool SecondaryRoles_AdvancedStrategyTriggerByMouse;
     extern bool SecondaryRoles_AdvancedStrategyDoubletapToPrimary;
     extern secondary_role_state_t SecondaryRoles_AdvancedStrategyTimeoutAction;
 

--- a/right/src/usb_report_updater.h
+++ b/right/src/usb_report_updater.h
@@ -42,4 +42,6 @@
     void ActivateStickyMods(key_state_t *keyState, uint8_t mods);
     void ApplyKeyAction(key_state_t *keyState, key_action_cached_t *cachedAction, key_action_t *actionBase);
 
+    void RecordKeyTiming_ReportKeystroke(key_state_t *keyState, bool active, uint32_t pressTime, uint32_t activationTime);
+
 #endif

--- a/right/src/utils.c
+++ b/right/src/utils.c
@@ -115,36 +115,7 @@ void Utils_SafeStrCopy(char* target, const char* src, uint8_t max) {
 
 const char* Utils_KeyAbbreviation(key_state_t* keyState)
 {
-    if (true) {
-        //static enUs mapping
-        uint8_t keyId = Utils_KeyStateToKeyId(keyState);
-        return MacroKeyIdParser_KeyIdToAbbreviation(keyId);
-    } else {
-        //action based mapping
-        static char buffer[4];
-
-        uint8_t keyId = Utils_KeyStateToKeyId(keyState);
-
-        MacroKeyIdParser_KeyIdToAbbreviation(keyId);
-
-        key_coordinates_t coordinates = Utils_KeyIdToKeyCoordinates(keyId);
-        key_action_t* action = &CurrentKeymap[LayerId_Base][coordinates.slotId][coordinates.inSlotId];
-
-        char maybeAbbreviation = DEFAULT_SCANCODE_ABBREVIATION;
-        if (action->type == KeyActionType_Keystroke && action->keystroke.keystrokeType == KeystrokeType_Basic && action->keystroke.modifiers == 0) {
-            maybeAbbreviation = MacroShortcutParser_ScancodeToCharacter(action->keystroke.scancode);
-        }
-
-        if (maybeAbbreviation == DEFAULT_SCANCODE_ABBREVIATION) {
-            snprintf(buffer, sizeof(buffer)-1, "%d", keyId);
-            buffer[sizeof(buffer)-1] = '\0';
-        } else {
-            buffer[0] = maybeAbbreviation;
-            buffer[1] = '\n';
-        }
-
-        return buffer;
-    }
-
-
+    //maps according to static enUs mapping
+    uint8_t keyId = Utils_KeyStateToKeyId(keyState);
+    return MacroKeyIdParser_KeyIdToAbbreviation(keyId);
 }

--- a/right/src/utils.c
+++ b/right/src/utils.c
@@ -1,6 +1,10 @@
 #include "utils.h"
+#include "key_action.h"
 #include "key_states.h"
+#include "keymap.h"
+#include "layer.h"
 #include "macros/core.h"
+#include "macros/keyid_parser.h"
 #include "macros/status_buffer.h"
 #include "macros/shortcut_parser.h"
 #include "led_display.h"
@@ -27,6 +31,11 @@ uint16_t Utils_KeyStateToKeyId(key_state_t* key)
 key_state_t* Utils_KeyIdToKeyState(uint16_t keyid)
 {
     return &(((key_state_t*)KeyStates)[recodeId(keyid, 64, MAX_KEY_COUNT_PER_MODULE)]);
+}
+
+key_coordinates_t Utils_KeyIdToKeyCoordinates(uint16_t keyId)
+{
+    return (key_coordinates_t) { .slotId = keyId / 64, .inSlotId = keyId % 64, };
 }
 
 //TODO: Should probably be realized by the above KeyStateToKeyId
@@ -102,4 +111,40 @@ void Utils_SafeStrCopy(char* target, const char* src, uint8_t max) {
     uint8_t stringlength = MIN(strlen(src)+1, (max));
     memcpy(target, src, stringlength);
     target[stringlength-1] = '\0';
+}
+
+const char* Utils_KeyAbbreviation(key_state_t* keyState)
+{
+    if (true) {
+        //static enUs mapping
+        uint8_t keyId = Utils_KeyStateToKeyId(keyState);
+        return MacroKeyIdParser_KeyIdToAbbreviation(keyId);
+    } else {
+        //action based mapping
+        static char buffer[4];
+
+        uint8_t keyId = Utils_KeyStateToKeyId(keyState);
+
+        MacroKeyIdParser_KeyIdToAbbreviation(keyId);
+
+        key_coordinates_t coordinates = Utils_KeyIdToKeyCoordinates(keyId);
+        key_action_t* action = &CurrentKeymap[LayerId_Base][coordinates.slotId][coordinates.inSlotId];
+
+        char maybeAbbreviation = DEFAULT_SCANCODE_ABBREVIATION;
+        if (action->type == KeyActionType_Keystroke && action->keystroke.keystrokeType == KeystrokeType_Basic && action->keystroke.modifiers == 0) {
+            maybeAbbreviation = MacroShortcutParser_ScancodeToCharacter(action->keystroke.scancode);
+        }
+
+        if (maybeAbbreviation == DEFAULT_SCANCODE_ABBREVIATION) {
+            snprintf(buffer, sizeof(buffer)-1, "%d", keyId);
+            buffer[sizeof(buffer)-1] = '\0';
+        } else {
+            buffer[0] = maybeAbbreviation;
+            buffer[1] = '\n';
+        }
+
+        return buffer;
+    }
+
+
 }

--- a/right/src/utils.h
+++ b/right/src/utils.h
@@ -20,6 +20,13 @@ if (reentrancyGuard_active) {                    \
 #include "key_states.h"
 #include <stdint.h>
 
+// Typedefs:
+
+    typedef struct {
+        uint8_t slotId;
+        uint8_t inSlotId;
+    } key_coordinates_t;
+
 // Functions:
 
     void Utils_SafeStrCopy(char* target, const char* src, uint8_t max);
@@ -27,6 +34,8 @@ if (reentrancyGuard_active) {                    \
     uint16_t Utils_KeyStateToKeyId(key_state_t* key);
     void Utils_DecodeId(uint16_t keyid, uint8_t* outSlotId, uint8_t* outSlotIdx);
     void Utils_PrintReport(const char* prefix, usb_basic_keyboard_report_t* report);
+    key_coordinates_t Utils_KeyIdToKeyCoordinates(uint16_t keyId);
+    const char* Utils_KeyAbbreviation(key_state_t* keyState);
 
 
 #endif /* SRC_UTILS_H_ */

--- a/scripts/timingGraph
+++ b/scripts/timingGraph
@@ -1,0 +1,233 @@
+#!/bin/bash
+
+VIEWER=eog
+OUTFILE=
+TEMPFILE=`mktemp`
+IMG=$TEMPFILE
+
+function help() {
+    echo "usage: timingGraph [ -o <output file> ] <input file>"
+}
+
+while getopts "o:h" opt
+do
+  case "$opt" in
+    o)
+        OUTFILE=$OPTARG
+        IMG=$OPTARG
+      ;;
+    *)
+        help
+      ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+INFILE=$1
+
+cat $INFILE | sed 's/OUT//g' | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g" | awk '
+BEGIN {
+    print("<svg width=\"WIDTH\" height=\"HEIGHT\" xmlns=\"http://www.w3.org/2000/svg\">");
+    print(" \
+      <defs \
+         id=\"defs2\"> \
+        <marker \
+           style=\"overflow:visible\" \
+           id=\"Stop\" \
+           refX=\"0\" \
+           refY=\"0\" \
+           orient=\"auto\" \
+           stockid=\"Stop\" \
+           markerWidth=\"2\" \
+           markerHeight=\"2\" \
+           viewBox=\"0 0 1 2\" \
+           isstock=\"true\" \
+           collect=\"always\" \
+           preserveAspectRatio=\"xMidYMid\"> \
+          <path \
+             style=\"fill:none;stroke:context-stroke;stroke-width:1\" \
+             d=\"M 0,2 V -2\" \
+             id=\"path171\" /> \
+        </marker> \
+      </defs> \
+      ");
+    print("<rect width=\"100%\" height=\"100%\" fill=\"white\"/>");
+
+    textOffset = 5;
+    fontSize = 12;
+    lineHeight = 16;
+    leftMargin = 100;
+    topMargin = 30;
+    lastY = topMargin + lineHeight;
+}
+
+
+func initTime(time) {
+    if (zeroTime == "") {
+        zeroTime = time - leftMargin; 
+        endTime = zeroTime;
+    }
+    if (time + 2*leftMargin > endTime) {
+        endTime = time + 2*leftMargin;
+    }
+}
+
+func getY() {
+    lastY += lineHeight;
+    return lastY;
+}
+
+func timeToCoordinates(time) {
+    if(time == "") {
+        return 0;
+    } else {
+        return (time-zeroTime);
+    }
+}
+
+func sanitize(coordinates) {
+    if (coordinates == "") {
+        return getY();
+    } else {
+        return coordinates;
+    }
+}
+
+func drawTextLeft(x, y, text) {
+    print "<text x=\"" x - textOffset "\" y=\"" y + 3 "\" dominant-baseline=\"middle\" text-anchor=\"end\" fill=\"black\" font-size=\"" fontSize "\">" text "</text>"
+}
+
+func drawTextRight(x, y, text) {
+    print "<text x=\"" x + textOffset "\" y=\"" y + 3 "\" dominant-baseline=\"middle\" text-anchor=\"start\" fill=\"black\" font-size=\"" fontSize "\">" text "</text>"
+}
+
+func drawTextAbove(x, y, text) {
+    print "<text x=\"" x "\" y=\"" y - 4 "\" dominant-baseline=\"middle\" text-anchor=\"middle\" fill=\"black\" font-size=\"" fontSize "\">" text "</text>"
+}
+
+func drawTextBelow(x, y, text) {
+    print "<text x=\"" x "\" y=\"" y -4 + lineHeight "\" dominant-baseline=\"middle\" text-anchor=\"middle\" fill=\"black\" font-size=\"" fontSize "\">" text "</text>"
+}
+
+func drawLine(x1, y1, x2, y2) {
+    lineConstants="stroke-width=\"2\" marker-start=\"url(#Stop)\" marker-end=\"url(#Stop)\"";
+    print(" <line x1=\"" x1 "\" y1=\"" y1 "\" x2=\"" x2 "\" y2=\"" y2 "\" stroke=\"black\" " lineConstants " />");
+}
+
+func drawPoint(x, y) {
+    print("<circle cx=\"" x "\" cy=\"" y "\" r=\"2\" fill=\"black\" />");
+}
+
+func drawTimeLine(x) {
+    lineConstants="stroke-width=\"0.5\"";
+    print(" <line x1=\"" x "\" y1=\"" lineHeight "\" x2=\"" x "\" y2=\"100%\" stroke=\"gray\" " lineConstants " />");
+}
+
+func drawKeystroke(label, y, start, postponedStart, end, postponedEnd) {
+    drawLine(start, y-1.5, end, y-1.5);
+    drawLine(postponedStart, y+1.5, postponedEnd, y+1.5);
+    drawTextLeft(start, y, label);
+}
+
+func drawComment(label, x, y) {
+    drawPoint(x, y);
+    drawTextRight(x, y, label);
+}
+
+func recordTimePoint(time) {
+    if (timePointCount == "") {
+        timePointCount = 0;
+    }
+    timePoints[timePointCount] = time;
+    timePointCount++;
+}
+
+func drawTimePoint(lastTimePoint, time) {
+    if (lastTimePoint != time) {
+        if (lastTimePoint != "") {
+            diff = time - lastTimePoint;
+            drawTextBelow(timeToCoordinates((time+lastTimePoint)/2), lineHeight, time-lastTimePoint);
+        }
+        drawTextAbove(timeToCoordinates(time), lineHeight, time-zeroTime);
+
+        drawTimeLine(timeToCoordinates(time));
+    }
+}
+
+func drawTimePoints() {
+    n = asort(timePoints, sortedTimePoints);
+    drawTimePoint("", sortedTimePoints[1]);
+    for (i = 1; i <= n; i++) {
+        drawTimePoint(sortedTimePoints[i-1], sortedTimePoints[i]);
+    }
+}
+
+function abs(v) {return v < 0 ? -v : v}
+
+/DOWN/ {
+    id = $2;
+    initTime($3);
+    keyY[id] = getY();
+    keyStart[id] = $3;
+    keyPostponedStart[id] = $4;
+}
+/UP/ {
+    id = $2;
+    initTime($3);
+    keyEnd[id] = $3;
+    keyPostponedEnd[id] = $4;
+    drawKeystroke( id, sanitize(keyY[id]), timeToCoordinates(keyStart[id]), timeToCoordinates(keyPostponedStart[id]), timeToCoordinates(keyEnd[id]), timeToCoordinates(keyPostponedEnd[id]) );
+
+    end = keyEnd[id];
+    start = keyStart[id];
+    postponedEnd = keyPostponedEnd[id];
+    postponedStart = keyPostponedStart[id];
+
+    realTime = end - start;
+    postponedTime = postponedEnd - postponedStart;
+    startDiff = postponedStart - start;
+    endDiff = postponedEnd - end;
+
+    if (abs(postponedTime-realTime) < 5 && startDiff < 5 && endDiff < 5) {
+        timeLabel = realTime;
+    } else if (postponedStart < end) {
+        timeLabel = realTime " (" startDiff ":" (end - postponedStart) ":" endDiff ")";
+    } else {
+        timeLabel = realTime " (" realTime " " (postponedStart - end) " " postponedTime ")";
+    }
+
+    recordTimePoint(start);
+    recordTimePoint(end);
+    recordTimePoint(postponedStart);
+    recordTimePoint(postponedEnd);
+    drawTextAbove(timeToCoordinates((start + postponedEnd)/2), keyY[id], timeLabel);
+}
+/^[0-9].*/ {
+    initTime($1);
+    time = $1;
+    $1 = "";
+    text = $0;
+    /*y = lastY + lineHeight;*/
+    y = getY();
+    recordTimePoint(time);
+    drawComment(text, timeToCoordinates(time), y);
+}
+
+END {
+drawTimePoints();
+print("</svg>");
+print("DIMENSIONS " timeToCoordinates(endTime) " " lastY + topMargin);
+}
+' > $IMG
+
+DIMENSIONS=`grep DIMENSIONS $IMG`
+WIDTH=`echo "$DIMENSIONS" | awk '// { print($2)}'`
+HEIGHT=`echo "$DIMENSIONS" | awk '// { print($3)}'`
+sed 's/DIMENSIONS.*//g;s/WIDTH/'"$WIDTH"'/g;s/HEIGHT/'"$HEIGHT"'/g' -i $IMG
+
+
+$VIEWER $IMG
+rm $TEMPFILE
+
+


### PR DESCRIPTION
Changelog:
- advanced strategy revised: safety-margin-related behavior might have changed
- added `secondaryRole.advanced.triggerByMouse` config value. Advanced secondary roles are now not triggered by mouse movement by default.
- added `secondaryRole.advanced.triggerByPress` config value.

Closes #746 .
Implements https://github.com/UltimateHackingKeyboard/agent/issues/792 .