### PR TITLE
Make oneShot wait for actual usb report change.

### DIFF
--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1247,7 +1247,7 @@ static macro_result_t processOneShotCommand(parser_context_t* ctx) {
      * Also, we need to prevent the command to go sleeping after this because
      * we would not be woken up.
      * */
-    if (!S->ms.macroInterrupted) {
+    if (!S->ms.macroInterrupted || !S->ms.oneShotUsbChangeDetected) {
         S->ms.oneShotState = 1;
     } else if (S->ms.oneShotState < 3) {
         S->ms.oneShotState++;

--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -79,6 +79,15 @@ void Macros_SignalInterrupt()
     }
 }
 
+void Macros_SignalUsbReportsChange()
+{
+    for (uint8_t i = 0; i < MACRO_STATE_POOL_SIZE; i++) {
+        if (MacroState[i].ms.macroPlaying && MacroState[i].ms.macroInterrupted) {
+            MacroState[i].ms.oneShotUsbChangeDetected = true;
+        }
+    }
+}
+
 macro_result_t Macros_GoToAddress(uint8_t address)
 {
     if(address == S->ls->ms.commandAddress) {

--- a/right/src/macros/core.h
+++ b/right/src/macros/core.h
@@ -151,6 +151,7 @@
             uint8_t postponeNextNCommands;
             uint8_t nextSlot;
             uint8_t oneShotState : 2;
+            bool oneShotUsbChangeDetected : 1;
             bool macroInterrupted : 1;
             bool macroSleeping : 1;
             bool macroBroken : 1;
@@ -280,6 +281,7 @@
     void Macros_Initialize();
     void Macros_ResetBasicKeyboardReports();
     void Macros_SignalInterrupt(void);
+    void Macros_SignalUsbReportsChange();
     void Macros_ValidateAllMacros();
 
 #define WAKE_MACROS_ON_KEYSTATE_CHANGE()  if (Macros_WakeMeOnKeystateChange) { \

--- a/right/src/usb_interfaces/usb_interface_mouse.c
+++ b/right/src/usb_interfaces/usb_interface_mouse.c
@@ -51,13 +51,17 @@ usb_status_t UsbMouseCheckIdleElapsed()
     return kStatus_USB_Busy;
 }
 
-usb_status_t UsbMouseCheckReportReady()
+usb_status_t UsbMouseCheckReportReady(bool* buttonsChanged)
 {
     // Send out the mouse position and wheel values continuously if the report is not zeros, but only send the mouse button states when they change.
     if ((memcmp(ActiveUsbMouseReport, GetInactiveUsbMouseReport(), sizeof(usb_mouse_report_t)) != 0) ||
             ActiveUsbMouseReport->x || ActiveUsbMouseReport->y ||
-            ActiveUsbMouseReport->wheelX || ActiveUsbMouseReport->wheelY)
+            ActiveUsbMouseReport->wheelX || ActiveUsbMouseReport->wheelY) {
+        if (buttonsChanged != NULL) {
+            *buttonsChanged = ActiveUsbMouseReport->buttons != GetInactiveUsbMouseReport()->buttons;
+        }
         return kStatus_USB_Success;
+    }
 
     return UsbMouseCheckIdleElapsed();
 }

--- a/right/src/usb_interfaces/usb_interface_mouse.h
+++ b/right/src/usb_interfaces/usb_interface_mouse.h
@@ -48,6 +48,6 @@
     void UsbMouseResetActiveReport(void);
     usb_status_t UsbMouseAction(void);
     usb_status_t UsbMouseCheckIdleElapsed();
-    usb_status_t UsbMouseCheckReportReady();
+    usb_status_t UsbMouseCheckReportReady(bool* buttonsChanged);
 
 #endif


### PR DESCRIPTION
Closes #735.

Steps to reproduce:
- set `set oneShotTimeout 10000`
- use `oneShot holdKey LS`
- use a scancode action bound in layer, or on a secondary role key
- observe shift not being applied to the action. (Desired behavior: shift is applied to the action.)