### PR TITLE
Try fix warning.

### DIFF
--- a/right/src/buspal/bm_usb/usb_descriptor.c
+++ b/right/src/buspal/bm_usb/usb_descriptor.c
@@ -57,7 +57,7 @@ usb_device_interfaces_struct_t g_hid_generic_interfaces[USB_HID_GENERIC_INTERFAC
     USB_HID_GENERIC_PROTOCOL,        /* HID generic protocol code */
     USB_HID_GENERIC_INTERFACE_INDEX, /* The interface number of the HID generic */
     g_hid_generic_interface,         /* Interfaces handle */
-    sizeof(g_hid_generic_interface) / sizeof(usb_device_interfaces_struct_t),
+    sizeof(g_hid_generic_interface) / sizeof(usb_device_interface_struct_t)
 } };
 
 usb_device_interface_list_t g_hid_generic_interface_list[USB_CONFIGURE_COUNT] = {


### PR DESCRIPTION
Compiler throws:

```
/opt/firmware/right/src/buspal/bm_usb/usb_descriptor.c:60:37: warning: expression does not compute the number of elements in this array; element type is 'usb_device_interface_struct_t' {aka 'struct _usb_device_interface_struct'}, not 'usb_device_interfaces_struct_t' {aka 'struct _usb_device_interfaces_struct'}
[-Wsizeof-array-div]
   60 |     sizeof(g_hid_generic_interface) / sizeof(usb_device_interfaces_struct_t),
      |                                     ^
/opt/firmware/right/src/buspal/bm_usb/usb_descriptor.c:60:37: note: add parentheses around the second 'sizeof' to silence this warning
/opt/firmware/right/src/buspal/bm_usb/usb_descriptor.c:45:31: note: array 'g_hid_generic_interface' declared here
   45 | usb_device_interface_struct_t g_hid_generic_interface[] = { {
      |                               ^~~~~~~~~~~~~~~~~~~~~~~
```

Following fix seems to makes sense. UHK seems to work fine like this, but to tell the truth I am not entirely sure that the fix is correct, as I don't see much into the usb machinery.