### PR TITLE
Fix ifLayer command to work with native layer switching.

### DIFF
--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -599,7 +599,7 @@ static bool processIfLayerCommand(parser_context_t* ctx, bool negate)
     if (Macros_DryRun) {
         return true;
     }
-    return (queryLayerIdx == LayerStack_ActiveLayer) != negate;
+    return (queryLayerIdx == ActiveLayer) != negate;
 }
 
 


### PR DESCRIPTION
Reported in https://forum.ultimatehackingkeyboard.com/t/cant-seem-to-get-iflayer-to-work/827.

Steps to reproduce:
- bind `ifLayer mod setLedTxt 1000 mod` in your mod layer.
- use the macro
- observe mod not getting shown on the display