### PR TITLE
Fix ifGesture hang when an old-fashioned # register is entered.

### DIFF
--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -602,7 +602,6 @@ static bool processIfLayerCommand(parser_context_t* ctx, bool negate)
     return (queryLayerIdx == ActiveLayer) != negate;
 }
 
-
 static bool processIfLayerToggledCommand(parser_context_t* ctx, bool negate)
 {
     if (Macros_DryRun) {
@@ -610,7 +609,6 @@ static bool processIfLayerToggledCommand(parser_context_t* ctx, bool negate)
     }
     return (LayerStack_IsLayerToggled()) != negate;
 }
-
 
 static bool processIfCommand(parser_context_t* ctx)
 {
@@ -1180,7 +1178,12 @@ uint8_t Macros_TryConsumeKeyId(parser_context_t* ctx)
     uint8_t keyId = MacroKeyIdParser_TryConsumeKeyId(ctx);
 
     if (keyId == 255 && isNUM(ctx)) {
-        return Macros_ConsumeInt(ctx);
+        uint8_t num = Macros_ConsumeInt(ctx);
+        if (Macros_ParserError) {
+            return 255;
+        } else {
+            return num;
+        }
     } else {
         return keyId;
     }


### PR DESCRIPTION
Closes https://github.com/UltimateHackingKeyboard/agent/issues/2219.

Steps to reproduce:
- Flash 11.x firmware
- create macro `ifGesture #key final holdKey escape`
- save the config
- observe unresponsive UHK