### PR TITLE
Fix Usb Switch Keymap getting reverted on first macro layer switch.

### DIFF
--- a/right/src/usb_commands/usb_command_switch_keymap.c
+++ b/right/src/usb_commands/usb_command_switch_keymap.c
@@ -1,6 +1,7 @@
 #include "usb_protocol_handler.h"
 #include "usb_commands/usb_command_switch_keymap.h"
 #include "keymap.h"
+#include "layer_stack.h"
 
 void UsbCommand_SwitchKeymap(void)
 {
@@ -11,7 +12,10 @@ void UsbCommand_SwitchKeymap(void)
         SetUsbTxBufferUint8(0, UsbStatusCode_SwitchKeymap_InvalidAbbreviationLength);
     }
 
-    if (!SwitchKeymapByAbbreviation(keymapLength, keymapAbbrev)) {
+    uint8_t res = SwitchKeymapByAbbreviation(keymapLength, keymapAbbrev);
+    LayerStack_Reset();
+
+    if (!res) {
         SetUsbTxBufferUint8(0, UsbStatusCode_SwitchKeymap_InvalidAbbreviation);
     }
 }


### PR DESCRIPTION
Fixes https://forum.ultimatehackingkeyboard.com/t/changing-layer-reverts-keymap-to-default/909

Steps to reproduce:
- use the `./switch-keymap.ts QTY` script
- now use a `holdLayer mod` macro
- observe that upon release, keymap gets switched back to previous keymap