### PR TITLE
Parse keyid abbreviaitons in set keymapAction.

### DIFF
--- a/right/src/macros/set_command.c
+++ b/right/src/macros/set_command.c
@@ -648,7 +648,12 @@ static macro_variable_t keymapAction(parser_context_t* ctx, set_command_action_t
 
     ConsumeUntilDot(ctx);
 
-    uint16_t keyId = Macros_ConsumeInt(ctx);
+    uint16_t keyId = Macros_TryConsumeKeyId(ctx);
+
+    if (keyId == 255) {
+        Macros_ReportError("Failed to decode keyid!", ctx->at, ctx->at);
+        return noneVar();
+    }
 
     if (action == SetCommandAction_Read) {
         Macros_ReportError("Reading actions is not supported!", ctx->at, ctx->at);


### PR DESCRIPTION
Reported in https://forum.ultimatehackingkeyboard.com/t/temporarily-change-d-to-delete-with-alt-tab-sequence-without-affecting-alt-d/942/3

Steps to reproduce:
- use `set keymapAction.base.d keystroke delete`
- observe error