### PR TITLE
Fix press modmask modifier.

### DIFF
--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -328,7 +328,7 @@ COMMAND = setEmergencyKey KEYID
     - `{S|C|A|G}` - Shift Control Alt Gui. (Windows, Super, and Gui are the same thing.)
     - `[L|R]` - Left Right (which hand side modifier should be used) E.g. `holdKey RA-c` (right alt + c).
     - `{s|i|o}` - modifiers (ctrl, alt, shift, gui) exist in three composition modes within UHK - sticky, input, output:
-        - **sticky modifiers** are modifiers of composite shortcuts. These are applied only until the next key press. In certain contexts, they will take effect even after their activation key is released (e.g., to support alt + tab on non-base layers, you can do `holdKey sLA-tab`).
+        - **sticky modifiers** are modifiers of composite shortcuts. These are applied only until the next (physical) key press. In certain contexts, they will take effect even after their activation key is released (e.g., to support alt + tab on non-base layers, you can do `holdKey sLA-tab`).
         - **input modifiers** are queried by `ifMod` conditions, and can be suppressed by `suppressMods`. E.g. `holdKey iLS`.
         - **output modifiers** are ignored by `ifMod` conditions, and are not suppressed by `suppressMods`.
 

--- a/right/src/macros/shortcut_parser.c
+++ b/right/src/macros/shortcut_parser.c
@@ -647,15 +647,17 @@ bool MacroShortcutParser_Parse(const char* str, const char* strEnd, macro_sub_ac
     bool success = false;
 
     if (FindChar('-', str, strEnd) == strEnd || str+1 == strEnd) {
-        //"-" notation not used
+        // input is either just "<modmask>" or just a "<key>"
         success = success || parseAbbrev(str, strEnd, outMacroAction, outKeyAction);
-        success = success || parseMods(str, strEnd, outMacroAction, outKeyAction);
 
         if (outMacroAction != NULL) {
             outMacroAction->key.action = type;
         }
+
+        success = success || parseMods(str, strEnd, outMacroAction, outKeyAction);
     }
     else {
+        // input is of form "<modmask>-<scancode>"
         const char* delim = FindChar('-', str, strEnd);
         success = success || parseAbbrev(delim+1, strEnd, outMacroAction, outKeyAction);
 


### PR DESCRIPTION
Noticed when untangling https://forum.ultimatehackingkeyboard.com/t/emoji-support-for-a-different-layer/223/7

Steps to reproduce:
- set `set keystrokeDelay 150`
- create macro `tapKeySeq pLS a b c`
- navigate https://keyboardchecker.com/
- use the tapKeySeq macro

expected behavior:
- (according to keyboardchecker) shift is pressed, a is tapped, b is tapped, c is tapped, shift is released

actual behavior:
- (according to keyboardchecker) shift is tapped, a is tapped, b is tapped, c is tapped