### PR TITLE
Keyid parser fixes.

### DIFF
--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1392,17 +1392,18 @@ static bool processIfKeyPendingAtCommand(parser_context_t* ctx, bool negate)
 static bool processIfKeyActiveCommand(parser_context_t* ctx, bool negate)
 {
     uint16_t keyid = Macros_TryConsumeKeyId(ctx);
-    key_state_t* key = Utils_KeyIdToKeyState(keyid);
 
-    if (key == 255) {
+    if (keyid == 255) {
         Macros_ReportError("Failed to decode keyId.", ctx->at, ctx->at);
         return false;
     }
 
-
     if (Macros_DryRun) {
         return true;
     }
+
+    key_state_t* key = Utils_KeyIdToKeyState(keyid);
+
     return KeyState_Active(key) != negate;
 }
 

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1375,7 +1375,12 @@ static macro_result_t processOverlayLayerCommand(parser_context_t* ctx)
 static bool processIfKeyPendingAtCommand(parser_context_t* ctx, bool negate)
 {
     uint16_t idx = Macros_ConsumeInt(ctx);
-    uint16_t key = Macros_ConsumeInt(ctx);
+    uint16_t key = Macros_TryConsumeKeyId(ctx);
+
+    if (key == 255) {
+        Macros_ReportError("Failed to decode keyId.", ctx->at, ctx->at);
+        return false;
+    }
 
     if (Macros_DryRun) {
         return true;
@@ -1386,8 +1391,15 @@ static bool processIfKeyPendingAtCommand(parser_context_t* ctx, bool negate)
 
 static bool processIfKeyActiveCommand(parser_context_t* ctx, bool negate)
 {
-    uint16_t keyid = Macros_ConsumeInt(ctx);
+    uint16_t keyid = Macros_TryConsumeKeyId(ctx);
     key_state_t* key = Utils_KeyIdToKeyState(keyid);
+
+    if (key == 255) {
+        Macros_ReportError("Failed to decode keyId.", ctx->at, ctx->at);
+        return false;
+    }
+
+
     if (Macros_DryRun) {
         return true;
     }
@@ -1405,7 +1417,13 @@ static bool processIfPendingKeyReleasedCommand(parser_context_t* ctx, bool negat
 
 static bool processIfKeyDefinedCommand(parser_context_t* ctx, bool negate)
 {
-    uint16_t keyid = Macros_ConsumeInt(ctx);
+    uint16_t keyid = Macros_TryConsumeKeyId(ctx);
+
+    if (keyid == 255) {
+        Macros_ReportError("Failed to decode keyId.", ctx->at, ctx->at);
+        return false;
+    }
+
     if (Macros_DryRun) {
         return true;
     }
@@ -1455,8 +1473,13 @@ static macro_result_t processActivateKeyPostponedCommand(parser_context_t* ctx)
         }
     }
 
-    uint16_t keyid = Macros_ConsumeInt(ctx);
+    uint16_t keyid = Macros_TryConsumeKeyId(ctx);
     key_state_t* key = Utils_KeyIdToKeyState(keyid);
+
+    if (keyid == 255) {
+        Macros_ReportError("Failed to decode keyId.", ctx->at, ctx->at);
+        return MacroResult_Finished;
+    }
 
     if (Macros_ParserError) {
         return MacroResult_Finished;

--- a/right/src/macros/keyid_parser.c
+++ b/right/src/macros/keyid_parser.c
@@ -137,7 +137,17 @@ static const lookup_record_t* lookup(uint8_t begin, uint8_t end, const char* str
 
 uint8_t MacroKeyIdParser_TryConsumeKeyId(parser_context_t* ctx)
 {
-    const lookup_record_t* record = lookup(0, lookup_size-1, ctx->at, IdentifierEnd(ctx));
+    // this gets identifier till the next dot only
+    const char* end1 = IdentifierEnd(ctx);
+    const lookup_record_t* record = lookup(0, lookup_size-1, ctx->at, end1);
+
+    // if failed, try consume with dot
+    if (record == NULL && *end1 == '.' && end1+1 < ctx->end) {
+        parser_context_t ctx2 = *ctx;
+        ctx2.at = end1 + 1;
+        const char* end2 = IdentifierEnd(&ctx2);
+        record = lookup(0, lookup_size-1, ctx->at, end2);
+    }
 
     if (record == NULL) {
         return 255;

--- a/right/src/macros/set_command.c
+++ b/right/src/macros/set_command.c
@@ -457,7 +457,12 @@ static macro_variable_t keyRgb(parser_context_t* ctx, set_command_action_t actio
 
     ConsumeUntilDot(ctx);
 
-    uint8_t keyId = Macros_ConsumeInt(ctx);
+    uint16_t keyId = Macros_TryConsumeKeyId(ctx);
+
+    if (keyId == 255) {
+        Macros_ReportError("Failed to decode keyid!", ctx->at, ctx->at);
+        return noneVar();
+    }
 
     if (action == SetCommandAction_Read) {
         Macros_ReportError("Reading RGB values not supported!", ConsumedToken(ctx), ConsumedToken(ctx));


### PR DESCRIPTION
Try:

```
set backlight.keyRgb.base.leftModule.key1 0 0 0
set backlight.keyRgb.base.leftModule.key2 0 0 0
set backlight.keyRgb.base.leftModule.key3 0 0 0
```

Reported at https://forum.ultimatehackingkeyboard.com/t/right-click-killing-the-board/704/18