### PR TITLE
chore: remove unused `commander` npm package

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,7 +13,6 @@
     "url": "https://github.com/UltimateHackingKeyboard/firmware/issues"
   },
   "dependencies": {
-    "commander": "^2.11.0",
     "md5": "2.3.0",
     "shelljs": "^0.8.4"
   },


### PR DESCRIPTION
I did not find any usage of the `commander` package. It also really outdated because the latest version is `12.1.0`