### PR TITLE
High-res scrolling support for trackball

### DIFF
--- a/right/src/mouse_controller.c
+++ b/right/src/mouse_controller.c
@@ -24,6 +24,8 @@ typedef struct {
     float x;
     float y;
     float speed;
+    float scaleX;
+    float scaleY;
     int16_t yInversion;
     int16_t xInversion;
     float speedDivisor;
@@ -362,6 +364,8 @@ static void processAxisLocking(
     float x = args.x;
     float y = args.y;
     float speed = args.speed;
+    float scaleX = args.scaleX;
+    float scaleY = args.scaleY;
     int16_t yInversion = args.yInversion;
     int16_t xInversion = args.xInversion;
     float speedDivisor = args.speedDivisor;
@@ -424,11 +428,15 @@ static void processAxisLocking(
 
         float* axisFractionRemainders [CaretAxis_Count] = {&ks->xFractionRemainder, &ks->yFractionRemainder};
         float axisIntegerParts [CaretAxis_Count] = { 0, 0 };
+        float maxScale = MAX(scaleX, scaleY);
+        float axisScales [CaretAxis_Count] = {scaleX, scaleY};
 
         // determine integer parts
-
-        modff(ks->xFractionRemainder, &axisIntegerParts[CaretAxis_Horizontal]);
-        modff(ks->yFractionRemainder, &axisIntegerParts[CaretAxis_Vertical]);
+        // use maxScale so that the subsequent axis-picking is done on an evenly
+        // scaled basis and to avoid having to potentially re-compute the values
+        // for *both* axes afterwards
+        modff(ks->xFractionRemainder * maxScale, &axisIntegerParts[CaretAxis_Horizontal]);
+        modff(ks->yFractionRemainder * maxScale, &axisIntegerParts[CaretAxis_Vertical]);
 
         // pick axis to apply action on, if possible - check previously active axis first
         if ( axisIntegerParts[axisCandidate] != 0 ) {
@@ -439,12 +447,27 @@ static void processAxisLocking(
             axisCandidate = CaretAxis_None;
         }
 
+        // re-scale and re-check picked axis if needed
+        if (axisCandidate < CaretAxis_Count && axisScales[axisCandidate] != maxScale) {
+            modff(*axisFractionRemainders[axisCandidate] * axisScales[axisCandidate], &axisIntegerParts[axisCandidate]);
+            if (axisIntegerParts[axisCandidate] == 0) {
+                axisCandidate = CaretAxis_None;
+            }
+        }
+
         // handle the action
         if ( axisCandidate < CaretAxis_Count ) {
             float sgn = axisIntegerParts[axisCandidate] > 0 ? 1 : -1;
             int8_t currentAxisInversion = axisCandidate == CaretAxis_Vertical ? yInversion : xInversion;
-            float consumedAmount = continuous ? axisIntegerParts[axisCandidate] : sgn;
-            *axisFractionRemainders[axisCandidate] -= consumedAmount;
+            float consumedAmount;
+            if (continuous) {
+                consumedAmount = axisIntegerParts[axisCandidate];
+                *axisFractionRemainders[axisCandidate] -= consumedAmount / axisScales[axisCandidate];
+            }
+            else {
+                consumedAmount = sgn;
+                *axisFractionRemainders[axisCandidate] -= consumedAmount;
+            }
 
             //always zero primary axis - experimental
             // TODO: this slows down maximum rate, as right half processing is much faster than module refresh rate.
@@ -510,6 +533,8 @@ static void processModuleKineticState(
                     .x = x,
                     .y = y,
                     .speed = speed,
+                    .scaleX = 1.0f,
+                    .scaleY = 1.0f,
                     .yInversion = yInversion,
                     .xInversion = xInversion,
                     .speedDivisor = 1.0,
@@ -523,15 +548,21 @@ static void processModuleKineticState(
             break;
         }
         case NavigationMode_Scroll:  {
-            if (UsbMouse_HighResMode) {
-                speed *= USB_MOUSE_REPORT_DESCRIPTOR_MAX_RESOLUTION_MULTIPLIER_PHYSICAL_VALUE;
-            }
+            float scaleX = UsbMouseHighResModeX ? USB_MOUSE_REPORT_DESCRIPTOR_MAX_RESOLUTION_MULTIPLIER_PHYSICAL_VALUE : 1.0f;
+            float scaleY = UsbMouseHighResModeY ? USB_MOUSE_REPORT_DESCRIPTOR_MAX_RESOLUTION_MULTIPLIER_PHYSICAL_VALUE : 1.0f;
+
             if (!moduleConfiguration->scrollAxisLock) {
                 float xIntegerPart;
                 float yIntegerPart;
 
-                ks->xFractionRemainder = modff(ks->xFractionRemainder + x * speed / moduleConfiguration->scrollSpeedDivisor, &xIntegerPart);
-                ks->yFractionRemainder = modff(ks->yFractionRemainder + y * speed / moduleConfiguration->scrollSpeedDivisor, &yIntegerPart);
+                // since the kinetic state is shared among navigation modes, and
+                // since axis locking needs the stored x and y values to have
+                // the same scale, make sure the kinetic state values stay
+                // unscaled
+                ks->xFractionRemainder += x * speed / moduleConfiguration->scrollSpeedDivisor;
+                ks->yFractionRemainder += y * speed / moduleConfiguration->scrollSpeedDivisor;
+                ks->xFractionRemainder = modff(ks->xFractionRemainder * scaleX, &xIntegerPart) / scaleX;
+                ks->yFractionRemainder = modff(ks->yFractionRemainder * scaleY, &yIntegerPart) / scaleY;
 
                 ActiveUsbMouseReport->wheelX += xInversion*xIntegerPart;
                 ActiveUsbMouseReport->wheelY += yInversion*yIntegerPart;
@@ -541,6 +572,8 @@ static void processModuleKineticState(
                     .x = x,
                     .y = y,
                     .speed = speed,
+                    .scaleX = scaleX,
+                    .scaleY = scaleY,
                     .yInversion = yInversion,
                     .xInversion = xInversion,
                     .speedDivisor = moduleConfiguration->scrollSpeedDivisor,
@@ -566,6 +599,8 @@ static void processModuleKineticState(
                 .x = x,
                 .y = y,
                 .speed = speed,
+                .scaleX = 1.0f,
+                .scaleY = 1.0f,
                 .yInversion = yInversion,
                 .xInversion = xInversion,
                 .speedDivisor = speedDivisor,

--- a/right/src/mouse_controller.c
+++ b/right/src/mouse_controller.c
@@ -2,7 +2,6 @@
 #include "key_action.h"
 #include "layer.h"
 #include "slave_protocol.h"
-#include "usb_descriptors/usb_descriptor_mouse_report.h"
 #include "usb_interfaces/usb_interface_mouse.h"
 #include "slave_drivers/uhk_module_driver.h"
 #include "timer.h"
@@ -523,7 +522,7 @@ static void processModuleKineticState(
             break;
         }
         case NavigationMode_Scroll:  {
-            speed *= UsbMouseHighResMode ? USB_MOUSE_REPORT_DESCRIPTOR_MAX_RESOLUTION_MULTIPLIER_PHYSICAL_VALUE : USB_MOUSE_REPORT_DESCRIPTOR_MIN_RESOLUTION_MULTIPLIER_PHYSICAL_VALUE;
+            speed *= UsbMouseScrollMultiplier;
             if (!moduleConfiguration->scrollAxisLock) {
                 float xIntegerPart;
                 float yIntegerPart;

--- a/right/src/mouse_controller.c
+++ b/right/src/mouse_controller.c
@@ -2,6 +2,7 @@
 #include "key_action.h"
 #include "layer.h"
 #include "slave_protocol.h"
+#include "usb_descriptors/usb_descriptor_mouse_report.h"
 #include "usb_interfaces/usb_interface_mouse.h"
 #include "slave_drivers/uhk_module_driver.h"
 #include "timer.h"
@@ -522,6 +523,9 @@ static void processModuleKineticState(
             break;
         }
         case NavigationMode_Scroll:  {
+            if (UsbMouse_HighResMode) {
+                speed *= USB_MOUSE_REPORT_DESCRIPTOR_MAX_RESOLUTION_MULTIPLIER_PHYSICAL_VALUE;
+            }
             if (!moduleConfiguration->scrollAxisLock) {
                 float xIntegerPart;
                 float yIntegerPart;

--- a/right/src/mouse_keys.c
+++ b/right/src/mouse_keys.c
@@ -80,11 +80,11 @@ void MouseKeys_ActivateDirectionSigns(uint8_t state) {
 
 static void processMouseKineticState(mouse_kinetic_state_t *kineticState)
 {
-    float initialSpeed = kineticState->intMultiplier * kineticState->initialSpeed;
-    float acceleration = kineticState->intMultiplier * kineticState->acceleration;
-    float deceleratedSpeed = kineticState->intMultiplier * kineticState->deceleratedSpeed;
-    float baseSpeed = kineticState->intMultiplier * kineticState->baseSpeed;
-    float acceleratedSpeed = kineticState->intMultiplier * kineticState->acceleratedSpeed;
+    float initialSpeed = UsbMouseScrollMultiplier * kineticState->intMultiplier * kineticState->initialSpeed;
+    float acceleration = UsbMouseScrollMultiplier * kineticState->intMultiplier * kineticState->acceleration;
+    float deceleratedSpeed = UsbMouseScrollMultiplier * kineticState->intMultiplier * kineticState->deceleratedSpeed;
+    float baseSpeed = UsbMouseScrollMultiplier * kineticState->intMultiplier * kineticState->baseSpeed;
+    float acceleratedSpeed = UsbMouseScrollMultiplier * kineticState->intMultiplier * kineticState->acceleratedSpeed;
 
     if (!kineticState->wasMoveAction && !ActiveMouseStates[SerializedMouseAction_Decelerate]) {
         kineticState->currentSpeed = initialSpeed;

--- a/right/src/mouse_keys.c
+++ b/right/src/mouse_keys.c
@@ -80,11 +80,12 @@ void MouseKeys_ActivateDirectionSigns(uint8_t state) {
 
 static void processMouseKineticState(mouse_kinetic_state_t *kineticState)
 {
-    float initialSpeed = UsbMouseScrollMultiplier * kineticState->intMultiplier * kineticState->initialSpeed;
-    float acceleration = UsbMouseScrollMultiplier * kineticState->intMultiplier * kineticState->acceleration;
-    float deceleratedSpeed = UsbMouseScrollMultiplier * kineticState->intMultiplier * kineticState->deceleratedSpeed;
-    float baseSpeed = UsbMouseScrollMultiplier * kineticState->intMultiplier * kineticState->baseSpeed;
-    float acceleratedSpeed = UsbMouseScrollMultiplier * kineticState->intMultiplier * kineticState->acceleratedSpeed;
+    int16_t scrollMultiplier = kineticState->isScroll ? UsbMouseScrollMultiplier : 1;
+    float initialSpeed = scrollMultiplier * kineticState->intMultiplier * kineticState->initialSpeed;
+    float acceleration = scrollMultiplier * kineticState->intMultiplier * kineticState->acceleration;
+    float deceleratedSpeed = scrollMultiplier * kineticState->intMultiplier * kineticState->deceleratedSpeed;
+    float baseSpeed = scrollMultiplier * kineticState->intMultiplier * kineticState->baseSpeed;
+    float acceleratedSpeed = scrollMultiplier * kineticState->intMultiplier * kineticState->acceleratedSpeed;
 
     if (!kineticState->wasMoveAction && !ActiveMouseStates[SerializedMouseAction_Decelerate]) {
         kineticState->currentSpeed = initialSpeed;

--- a/right/src/usb_descriptors/usb_descriptor_mouse_report.h
+++ b/right/src/usb_descriptors/usb_descriptor_mouse_report.h
@@ -60,8 +60,15 @@
 
                 HID_RI_COLLECTION(8, HID_RI_COLLECTION_LOGICAL),
 
-                    // Vertical wheel
-                    // Resolution multiplier
+                    // Scroll wheels
+
+                    // Resolution multiplier for high-res scroll support
+                    // To have a multiplier apply to a wheel, it must be in the
+                    // same logical collection as the wheel, or else there must
+                    // be no logical collections (according to the USB HID spec);
+                    // so to have a single multiplier apply to the two wheels,
+                    // they must be in the same logical collection (or there
+                    // must be no logical collection at all)
                     HID_RI_USAGE(8, HID_RI_USAGE_GENERIC_DESKTOP_RESOLUTION_MULTIPLIER),
                     HID_RI_LOGICAL_MINIMUM(8, 0),
                     HID_RI_LOGICAL_MAXIMUM(8, 1),
@@ -69,10 +76,9 @@
                     HID_RI_PHYSICAL_MAXIMUM(8, USB_MOUSE_REPORT_DESCRIPTOR_MAX_RESOLUTION_MULTIPLIER_PHYSICAL_VALUE),
                     HID_RI_REPORT_COUNT(8, 1),
                     HID_RI_REPORT_SIZE(8, 8),
-                    HID_RI_PUSH(0),
                     HID_RI_FEATURE(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
 
-                    // Wheel itself
+                    // Vertical wheel
                     HID_RI_USAGE(8, HID_RI_USAGE_GENERIC_DESKTOP_WHEEL),
                     HID_RI_LOGICAL_MINIMUM(16, -32767),
                     HID_RI_LOGICAL_MAXIMUM(16, 32767),
@@ -82,17 +88,7 @@
                     HID_RI_REPORT_SIZE(8, 16),
                     HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
 
-                HID_RI_END_COLLECTION(0),
-
-                HID_RI_COLLECTION(8, HID_RI_COLLECTION_LOGICAL),
-
                     // Horizontal wheel
-                    // Resolution multiplier
-                    HID_RI_POP(0),
-                    HID_RI_USAGE(8, HID_RI_USAGE_GENERIC_DESKTOP_RESOLUTION_MULTIPLIER),
-                    HID_RI_FEATURE(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
-
-                    // Wheel itself
                     HID_RI_USAGE_PAGE(8, HID_RI_USAGE_PAGE_CONSUMER),
                     HID_RI_USAGE(16, HID_RI_USAGE_CONSUMER_AC_PAN),
                     HID_RI_LOGICAL_MINIMUM(16, -32767),

--- a/right/src/usb_descriptors/usb_descriptor_mouse_report.h
+++ b/right/src/usb_descriptors/usb_descriptor_mouse_report.h
@@ -15,6 +15,9 @@
     #define USB_MOUSE_REPORT_DESCRIPTOR_MAX_AXIS_PHYSICAL_VALUE 4096
     #define USB_MOUSE_REPORT_DESCRIPTOR_BUTTONS 20
 
+    #define USB_MOUSE_REPORT_DESCRIPTOR_MIN_RESOLUTION_MULTIPLIER_PHYSICAL_VALUE 1
+    #define USB_MOUSE_REPORT_DESCRIPTOR_MAX_RESOLUTION_MULTIPLIER_PHYSICAL_VALUE 120
+
     #define USB_MOUSE_REPORT_DESCRIPTOR_BUTTONS_PADDING ((USB_MOUSE_REPORT_DESCRIPTOR_BUTTONS % 8) \
                 ? (8 - (USB_MOUSE_REPORT_DESCRIPTOR_BUTTONS % 8)) \
                 : 0)
@@ -58,13 +61,25 @@
                 HID_RI_COLLECTION(8, HID_RI_COLLECTION_LOGICAL),
 
                     // Vertical wheel
-                    HID_RI_USAGE(8, HID_RI_USAGE_GENERIC_DESKTOP_WHEEL),
-                    HID_RI_LOGICAL_MINIMUM(8, -127),
-                    HID_RI_LOGICAL_MAXIMUM(8, 127),
-                    HID_RI_PHYSICAL_MINIMUM(16, -127),
-                    HID_RI_PHYSICAL_MAXIMUM(16, 127),
+                    // Resolution multiplier
+                    HID_RI_USAGE(8, HID_RI_USAGE_GENERIC_DESKTOP_RESOLUTION_MULTIPLIER),
+                    HID_RI_LOGICAL_MINIMUM(8, 0),
+                    HID_RI_LOGICAL_MAXIMUM(8, 1),
+                    HID_RI_PHYSICAL_MINIMUM(8, USB_MOUSE_REPORT_DESCRIPTOR_MIN_RESOLUTION_MULTIPLIER_PHYSICAL_VALUE),
+                    HID_RI_PHYSICAL_MAXIMUM(8, USB_MOUSE_REPORT_DESCRIPTOR_MAX_RESOLUTION_MULTIPLIER_PHYSICAL_VALUE),
                     HID_RI_REPORT_COUNT(8, 1),
                     HID_RI_REPORT_SIZE(8, 8),
+                    HID_RI_PUSH(0),
+                    HID_RI_FEATURE(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
+
+                    // Wheel itself
+                    HID_RI_USAGE(8, HID_RI_USAGE_GENERIC_DESKTOP_WHEEL),
+                    HID_RI_LOGICAL_MINIMUM(16, -32767),
+                    HID_RI_LOGICAL_MAXIMUM(16, 32767),
+                    HID_RI_PHYSICAL_MINIMUM(16, -32767),
+                    HID_RI_PHYSICAL_MAXIMUM(16, 32767),
+                    HID_RI_REPORT_COUNT(8, 1),
+                    HID_RI_REPORT_SIZE(8, 16),
                     HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
 
                 HID_RI_END_COLLECTION(0),
@@ -72,14 +87,20 @@
                 HID_RI_COLLECTION(8, HID_RI_COLLECTION_LOGICAL),
 
                     // Horizontal wheel
+                    // Resolution multiplier
+                    HID_RI_POP(0),
+                    HID_RI_USAGE(8, HID_RI_USAGE_GENERIC_DESKTOP_RESOLUTION_MULTIPLIER),
+                    HID_RI_FEATURE(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
+
+                    // Wheel itself
                     HID_RI_USAGE_PAGE(8, HID_RI_USAGE_PAGE_CONSUMER),
                     HID_RI_USAGE(16, HID_RI_USAGE_CONSUMER_AC_PAN),
-                    HID_RI_LOGICAL_MINIMUM(8, -127),
-                    HID_RI_LOGICAL_MAXIMUM(8, 127),
-                    HID_RI_PHYSICAL_MINIMUM(16, -127),
-                    HID_RI_PHYSICAL_MAXIMUM(16, 127),
+                    HID_RI_LOGICAL_MINIMUM(16, -32767),
+                    HID_RI_LOGICAL_MAXIMUM(16, 32767),
+                    HID_RI_PHYSICAL_MINIMUM(16, -32767),
+                    HID_RI_PHYSICAL_MAXIMUM(16, 32767),
                     HID_RI_REPORT_COUNT(8, 1),
-                    HID_RI_REPORT_SIZE(8, 8),
+                    HID_RI_REPORT_SIZE(8, 16),
                     HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_RELATIVE),
 
                 HID_RI_END_COLLECTION(0),

--- a/right/src/usb_interfaces/usb_interface_mouse.h
+++ b/right/src/usb_interfaces/usb_interface_mouse.h
@@ -38,7 +38,8 @@
 
 // Variables:
 
-    extern bool UsbMouse_HighResMode;
+    extern bool UsbMouseHighResModeY;
+    extern bool UsbMouseHighResModeX;
     extern uint32_t UsbMouseActionCounter;
     extern usb_mouse_report_t* ActiveUsbMouseReport;
 

--- a/right/src/usb_interfaces/usb_interface_mouse.h
+++ b/right/src/usb_interfaces/usb_interface_mouse.h
@@ -38,7 +38,7 @@
 
 // Variables:
 
-    extern bool UsbMouseHighResMode;
+    extern int16_t UsbMouseScrollMultiplier;
     extern uint32_t UsbMouseActionCounter;
     extern usb_mouse_report_t* ActiveUsbMouseReport;
 

--- a/right/src/usb_interfaces/usb_interface_mouse.h
+++ b/right/src/usb_interfaces/usb_interface_mouse.h
@@ -18,7 +18,7 @@
     #define USB_MOUSE_INTERRUPT_IN_INTERVAL 1
 
     #define USB_MOUSE_REPORT_LENGTH (sizeof(usb_mouse_report_t))
-    #define USB_MOUSE_FEAT_REPORT_LENGTH 2
+    #define USB_MOUSE_FEAT_REPORT_LENGTH 1
 
 // Typedefs:
 
@@ -38,8 +38,7 @@
 
 // Variables:
 
-    extern bool UsbMouseHighResModeY;
-    extern bool UsbMouseHighResModeX;
+    extern bool UsbMouseHighResMode;
     extern uint32_t UsbMouseActionCounter;
     extern usb_mouse_report_t* ActiveUsbMouseReport;
 

--- a/right/src/usb_interfaces/usb_interface_mouse.h
+++ b/right/src/usb_interfaces/usb_interface_mouse.h
@@ -18,6 +18,7 @@
     #define USB_MOUSE_INTERRUPT_IN_INTERVAL 1
 
     #define USB_MOUSE_REPORT_LENGTH (sizeof(usb_mouse_report_t))
+    #define USB_MOUSE_FEAT_REPORT_LENGTH 2
 
 // Typedefs:
 
@@ -31,12 +32,13 @@
         uint32_t buttons : 24;
         int16_t x;
         int16_t y;
-        int8_t wheelY;
-        int8_t wheelX;
+        int16_t wheelY;
+        int16_t wheelX;
     } ATTR_PACKED usb_mouse_report_t;
 
 // Variables:
 
+    extern bool UsbMouse_HighResMode;
     extern uint32_t UsbMouseActionCounter;
     extern usb_mouse_report_t* ActiveUsbMouseReport;
 


### PR DESCRIPTION
This PR is for HID-compliant high-resolution scrolling support for the trackball. Closes #741. See [this comment](https://github.com/UltimateHackingKeyboard/firmware/issues/741#issuecomment-2247465574) for notes on testing this on Linux.

## TODO

- [x] Actually handle values in `SetReport` request (will require separating X and Y high-res modes)
- [x] Add exception(s) for Linux's broken (?) `SetReport` requests
- [x] Test on Windows
- [x] Use a single multiplier for both axes (try just making the multiplier global in the report, but if that doesn't work, the logical collections will have to be removed)
- [x] Fix [mouse scroll keys](https://github.com/UltimateHackingKeyboard/firmware/issues/741#issuecomment-2267976306) not working in high res mode