### PR TITLE
Get proper device number when number of digits is mixed

### DIFF
--- a/doc-dev/user-guide.md
+++ b/doc-dev/user-guide.md
@@ -837,7 +837,7 @@ Or, in linux, you can put the following script into your path... and then use it
 
 ```
 #!/bin/bash
-hidraw=`grep 'UHK 60' /sys/class/hidraw/hidraw*/device/uevent | LC_ALL=C sort -rh | head -n 1 | grep -o 'hidraw[0-9][0-9]*'`
+hidraw="hidraw`grep 'UHK 60' /sys/class/hidraw/hidraw*/device/uevent | sed -nE 's/.*hidraw([0-9]+)\/.*/\1/p' | sort -rn | head -n 1`"
 echo -e "\x14$*" > "/dev/$hidraw"
 ```
 


### PR DESCRIPTION
The hidraw numbers on my machine span 7-11. With the alphabetical sorting in the old docs, hidraw9 was being used instead of 11. This commit changes the sorting to be numerical.