### PR TITLE
Backport a numlock state fix.

### DIFF
--- a/right/src/usb_interfaces/usb_interface_basic_keyboard.c
+++ b/right/src/usb_interfaces/usb_interface_basic_keyboard.c
@@ -134,7 +134,7 @@ usb_status_t UsbBasicKeyboardCallback(class_handle_t handle, uint32_t event, voi
 
         case kUSB_DeviceHidEventSetReport: {
             usb_device_hid_report_struct_t *report = (usb_device_hid_report_struct_t*)param;
-            if (report->reportType == USB_DEVICE_HID_REQUEST_GET_REPORT_TYPE_OUPUT && report->reportId == 0 && report->reportLength == sizeof(usbBasicKeyboardOutBuffer)) {
+            if (report->reportType == USB_DEVICE_HID_REQUEST_GET_REPORT_TYPE_OUPUT && report->reportId == 0 && report->reportLength <= sizeof(usbBasicKeyboardOutBuffer)) {
                 LedDisplay_SetIcon(LedDisplayIcon_CapsLock, report->reportBuffer[0] & HID_KEYBOARD_LED_CAPSLOCK);
 
                 processStateChange(&UsbBasicKeyboard_CapsLockOn,   report->reportBuffer[0] & HID_KEYBOARD_LED_CAPSLOCK,   &MacroEvent_CapsLockStateChanged  );

--- a/right/src/usb_interfaces/usb_interface_basic_keyboard.h
+++ b/right/src/usb_interfaces/usb_interface_basic_keyboard.h
@@ -24,7 +24,9 @@
         #error USB_BASIC_KEYBOARD_REPORT_LENGTH greater than max usb report length (64)
     #endif
 
-    #define USB_BASIC_KEYBOARD_OUT_REPORT_LENGTH 1
+    // Technically should be one, but the stack for some reason always writes 4,
+    // so we need to dedicate 4 bytes in order to avoid overwriting other data.
+    #define USB_BASIC_KEYBOARD_OUT_REPORT_LENGTH 4
 
     #define USB_BOOT_KEYBOARD_REPORT_LENGTH (2 + USB_BOOT_KEYBOARD_MAX_KEYS)
     #define USB_BOOT_KEYBOARD_MAX_KEYS 6


### PR DESCRIPTION
This is a backport of the issue 186 from the private repository.

It deals with a num-lock conditions, although I am not sure how, or if at all this is reproducible (after all, compilation is an unstable process), but some users on the forum reported the problem being present with the old firmware.