### PR TITLE
use full keyboard code range in NKRO report

### DIFF
--- a/device/Kconfig
+++ b/device/Kconfig
@@ -16,12 +16,12 @@ config UHK_BATTERY_DEVICE
 
 config KEYBOARD_MAX_SCANCODE
     hex "highest keyboard scancode"
-    default 0x86
+    default 0xDD
     range 0x66 0xDD
     help
         The highest keyboard scancode value influences the overall length of the HID record sent to the host.
-        The default is set so Android devices (which don't exchange the MTU from the default 23)
-        still receive the "NKRO" report layout. If a higher scancode is used, the report size will exceed this size,
+        The value 0x86 is the maximum for Android devices (which don't exchange the MTU from the default 23)
+        to still receive the "NKRO" report layout. If a higher scancode is used, the report size will exceed this size,
         causing a fallback to 6KRO report layout on Android.
 
 # by using the same Kconfig symbol names as mcuboot, the board Kconfig files can contain the values


### PR DESCRIPTION
Closes #1092

This is the simple solution, that extends the NKRO to include all existing scancodes - but it makes Android fall back to 6KRO mode. The more elegant, but lot more complicated solution would be to add a user configuration option, that selects between Android NKRO with reduced scancode range and 6KRO with full range.