### PR TITLE
Make uart more robust - add start byte, add crc check.

### DIFF
--- a/boards/ugl/uhk-80/uhk-80-left.dts
+++ b/boards/ugl/uhk-80/uhk-80-left.dts
@@ -24,7 +24,7 @@
 &uart1 {
     compatible = "nordic,nrf-uarte";
     status = "okay";
-    current-speed = <115200>;
+    current-speed = <38400>;
     pinctrl-0 = <&uart1_default>;
     pinctrl-1 = <&uart1_sleep>;
     pinctrl-names = "default", "sleep";

--- a/boards/ugl/uhk-80/uhk-80-right.dts
+++ b/boards/ugl/uhk-80/uhk-80-right.dts
@@ -24,7 +24,7 @@
 &uart1 {
     compatible = "nordic,nrf-uarte";
     status = "okay";
-    current-speed = <115200>;
+    current-speed = <38400>;
     pinctrl-0 = <&uart1_default>;
     pinctrl-1 = <&uart1_sleep>;
     pinctrl-names = "default", "sleep";

--- a/device/src/CMakeLists.txt
+++ b/device/src/CMakeLists.txt
@@ -35,6 +35,7 @@ if(NOT CONFIG_BOARD_UHK_60_RIGHT)
         logger.c
         messenger_queue.c
         messenger.c
+        resend.c
         round_trip_test.c
         settings.c
         shell.c

--- a/device/src/CMakeLists.txt
+++ b/device/src/CMakeLists.txt
@@ -41,6 +41,7 @@ if(NOT CONFIG_BOARD_UHK_60_RIGHT)
         shell.c
         stack_trace.c
         state_sync.c
+        trace.c
     )
     if(CONFIG_BT_PERIPHERAL)
         target_sources(${PROJECT_NAME} PRIVATE

--- a/device/src/bt_conn.c
+++ b/device/src/bt_conn.c
@@ -695,7 +695,8 @@ uint8_t BtConn_UnusedPeripheralConnectionCount() {
     return count;
 }
 
-static void disconnectOldestHost() {
+// Unused in left half
+ATTR_UNUSED static void disconnectOldestHost() {
     uint32_t oldestSwitchover = UINT32_MAX;
     uint8_t oldestPeerId = PeerIdUnknown;
     for (uint8_t peerId = PeerIdFirstHost; peerId <= PeerIdLastHost; peerId++) {

--- a/device/src/connections.c
+++ b/device/src/connections.c
@@ -117,6 +117,13 @@ static void reportConnectionState(connection_id_t connectionId, const char* mess
     }
 }
 
+void Connections_ResetWatermarks(connection_id_t connectionId) {
+    connectionId = resolveAliases(connectionId);
+
+    Connections[connectionId].watermarks.txIdx = 0;
+    Connections[connectionId].watermarks.rxIdx = 255;
+}
+
 void Connections_ReportState(connection_id_t connectionId) {
     reportConnectionState(connectionId, "Conn state");
 }
@@ -133,10 +140,7 @@ void Connections_SetState(connection_id_t connectionId, connection_state_t state
         Connections[connectionId].state = state;
         reportConnectionState(connectionId, "Con state");
 
-        if (state == ConnectionState_Disconnected) {
-            Connections[connectionId].watermarks.txIdx = 0;
-            Connections[connectionId].watermarks.rxIdx = 0;
-        }
+        Connections_ResetWatermarks(connectionId);
 
         if (Connections_Target(connectionId) == ConnectionTarget_Host && DEVICE_IS_UHK80_RIGHT) {
             Connections_HandleSwitchover(connectionId, false);

--- a/device/src/connections.h
+++ b/device/src/connections.h
@@ -66,6 +66,10 @@
         uint8_t rxIdx;
         uint8_t txIdx;
         uint16_t missedCount;
+        bool needsResend;
+        uint8_t lastSentResendableWm;
+        uint8_t lastSentId1;
+        uint8_t lastSentId2;
     } ATTR_PACKED connection_watermarks_t;
 
     typedef struct {

--- a/device/src/keyboard/uart.c
+++ b/device/src/keyboard/uart.c
@@ -213,10 +213,16 @@ static void processIncomingByte(uint8_t byte) {
             wakeControlThread();
             break;
         case PING_BYTE:
+            // Always accept pings.
+            //
+            // Reestablishing connection is expensive, so in case of bad quality
+            // uart connection, once successful, we don't want to loose it just
+            // because of a broken packet frame.
+            lastPingTime = k_uptime_get();
+
             if (receivingMessage) {
                 goto msg_byte;
             }
-            lastPingTime = k_uptime_get();
             break;
         case END_BYTE:
             if (escaping) {

--- a/device/src/keyboard/uart.c
+++ b/device/src/keyboard/uart.c
@@ -23,6 +23,8 @@
 #define UART_RESEND_DELAY 100
 #define UART_RESEND_COUNT 3
 
+#define UART_RESET_DELAY 10
+
 static K_THREAD_STACK_DEFINE(stack_area, THREAD_STACK_SIZE);
 static struct k_thread thread_data;
 
@@ -103,7 +105,7 @@ static connection_id_t remoteConnectionId() {
 static void resetUart() {
     // This will probably not reset uart, but at least will give main thread some time to run
     uart_rx_disable(uart_dev);
-    EventScheduler_Schedule(k_uptime_get() + 100, EventSchedulerEvent_ReenableUart, "reenable uart");
+    EventScheduler_Schedule(k_uptime_get() + UART_RESET_DELAY, EventSchedulerEvent_ReenableUart, "reenable uart");
 }
 
 static void appendRxByte(uint8_t byte) {

--- a/device/src/keyboard/uart.c
+++ b/device/src/keyboard/uart.c
@@ -102,7 +102,7 @@ static void appendRxByte(uint8_t byte) {
     if (rxPosition < RX_BUF_SIZE) {
         rxBuffer[rxPosition++] = byte;
     } else {
-        LogU("Uart error: too long message in rx buffer, length: %i, begins with [%i, %i, ...]\n", rxPosition, rxBuffer[0], rxBuffer[1]);
+        LogU("Uart error: too long message [%i, %i, ... %i]\n", rxPosition, rxBuffer[0], rxBuffer[1], byte);
     }
 }
 
@@ -138,7 +138,9 @@ static void rxPacketReceived() {
         setRxState(UartRxState_Ack);
     } else {
         Uart_InvalidMessagesCounter++;
-        LogUO("Crc-invalid UART message received!");
+        const char *out1, *out2;
+        Messenger_GetMessageDescription(rxBuffer, CRC_LEN, &out1, &out2);
+        LogUO("Crc-invalid UART message received! %s %s ", out1, out2 == NULL ? "" : out2);
 
         for (uint16_t i = 0; i < rxPosition; i++) {
             LogU("%i ", rxBuffer[i]);

--- a/device/src/keyboard/uart.c
+++ b/device/src/keyboard/uart.c
@@ -19,12 +19,17 @@
 #define THREAD_STACK_SIZE 1000
 #define THREAD_PRIORITY 5
 
+#define UART_RESEND_DELAY 100
+
 static K_THREAD_STACK_DEFINE(stack_area, THREAD_STACK_SIZE);
 static struct k_thread thread_data;
 
-#define START_BYTE 0b1010100
-#define END_BYTE 0b1010101
-#define ESCAPE_BYTE 0b1010110
+#define START_BYTE 0b1010100 //84
+#define END_BYTE 0b1010101 //85
+#define ESCAPE_BYTE 0b1010110 //86
+#define ACK_BYTE 0b1010111 //87
+#define NACK_BYTE 0b1011000 //88
+#define PING_BYTE 0b1011001 //89
 
 // UART definitions
 
@@ -42,6 +47,8 @@ uint16_t txPosition = 0;
 
 #define UART_SLOTS 1
 K_SEM_DEFINE(txBufferBusy, UART_SLOTS, UART_SLOTS);
+K_SEM_DEFINE(txControlBusy, UART_SLOTS, UART_SLOTS);
+K_SEM_DEFINE(controlThreadSleeper, 1, 1);
 
 #define RX_BUF_SIZE UART_MAX_PACKET_LENGTH + CRC_LEN
 uint8_t* rxBuffer = NULL;
@@ -56,6 +63,24 @@ uint32_t lastPingTime = -2*UART_TIMEOUT;
 
 uint16_t Uart_InvalidMessagesCounter = 0;
 
+uint8_t resendTries = 0;
+
+typedef enum {
+    UartTxState_Idle,
+    UartTxState_WaitingForAck,
+    UartTxState_Resend,
+} uart_tx_state_t;
+
+typedef enum {
+    UartRxState_Idle,
+    UartRxState_Ack,
+    UartRxState_Nack,
+} uart_rx_state_t;
+
+static volatile uart_tx_state_t uartTxState = UartTxState_Idle;
+static volatile uart_rx_state_t uartRxState = UartRxState_Idle;
+static volatile uint32_t lastMessageSentTime = 0;
+
 /* UART message format:
  * [START_BYTE,crc16,escaped(messengerPacket), ENDBYTE]
  * crcMessage = 4 bytes = CRC16 in format [ESCAPE_BYTE,byte1,ESCAPE_BYTE,byte2]
@@ -64,6 +89,10 @@ uint16_t Uart_InvalidMessagesCounter = 0;
  *
  * We serialize both uart-level and messenger-level packets at the same place to avoid unnecessary copying.
  * */
+
+static void wakeControlThread() {
+    k_sem_give(&controlThreadSleeper);
+}
 
 static connection_id_t remoteConnectionId() {
     return DEVICE_IS_UHK80_LEFT ? ConnectionId_UartRight : ConnectionId_UartLeft;
@@ -104,71 +133,101 @@ static bool isCrcValid(uint8_t* buf, uint16_t len) {
     return failRandomly ^ CRC16_IsMessageValidExt(&msg);
 }
 
+static void setRxState(uart_rx_state_t state) {
+    uartRxState = state;
+    wakeControlThread();
+}
+
 static void rxPacketReceived() {
     uint16_t len = rxPosition;
 
     if (len >= CRC_LEN && isCrcValid(rxBuffer, len)) {
         lastPingTime = k_uptime_get();
         len -= CRC_LEN;
+        setRxState(UartRxState_Ack);
     } else {
         Uart_InvalidMessagesCounter++;
-        uint8_t invalidWatermark = Connections[remoteConnectionId()].watermarks.rxIdx;
-        LogU("Crc-invalid UART message received!\n");
-        device_id_t src = DEVICE_IS_UHK80_LEFT ? DeviceId_Uhk80_Right : DeviceId_Uhk80_Left;
-        connection_id_t connectionId = DEVICE_IS_UHK80_LEFT ? ConnectionId_UartRight : ConnectionId_UartLeft;
-        Resend_RequestResendAsync(src, connectionId, invalidWatermark);
+        LogUO("Crc-invalid UART message received!");
+
+        for (uint16_t i = 0; i < rxPosition; i++) {
+            LogU("%i ", rxBuffer[i]);
+        }
+        LogU("\n");
+
+        // uint8_t invalidWatermark = Connections[remoteConnectionId()].watermarks.rxIdx;
+        // device_id_t src = DEVICE_IS_UHK80_LEFT ? DeviceId_Uhk80_Right : DeviceId_Uhk80_Left;
+        // connection_id_t connectionId = DEVICE_IS_UHK80_LEFT ? ConnectionId_UartRight : ConnectionId_UartLeft;
+        // Resend_RequestResendAsync(src, connectionId, invalidWatermark);
+
+        setRxState(UartRxState_Nack);
 
         rxPosition = 0;
         return;
     }
 
-    if (len == 0) {
-        // ping
-        lastPingTime = k_uptime_get();
-    } else {
-        // message
-        uint8_t* oldPacket = rxBuffer;
+    // message
+    uint8_t* oldPacket = rxBuffer;
 
-        rxBuffer = MessengerQueue_AllocateMemory();
-        rxPosition = 0;
+    rxBuffer = MessengerQueue_AllocateMemory();
+    rxPosition = 0;
 
-        connection_id_t connectionId = DEVICE_IS_UHK80_LEFT ? ConnectionId_UartRight : ConnectionId_UartLeft;
+    connection_id_t connectionId = DEVICE_IS_UHK80_LEFT ? ConnectionId_UartRight : ConnectionId_UartLeft;
 
-        if (DEVICE_IS_UHK80_RIGHT) {
-            Messenger_Enqueue(connectionId, DeviceId_Uhk80_Left, oldPacket, len, CRC_LEN);
-        } else if (DEVICE_IS_UHK80_LEFT) {
-            Messenger_Enqueue(connectionId, DeviceId_Uhk80_Right, oldPacket, len, CRC_LEN);
-        }
+    if (DEVICE_IS_UHK80_RIGHT) {
+        Messenger_Enqueue(connectionId, DeviceId_Uhk80_Left, oldPacket, len, CRC_LEN);
+    } else if (DEVICE_IS_UHK80_LEFT) {
+        Messenger_Enqueue(connectionId, DeviceId_Uhk80_Right, oldPacket, len, CRC_LEN);
     }
 }
 
 static void processIncomingByte(uint8_t byte) {
     static bool escaping = false;
+    static bool receivingMessage = false;
+
     switch (byte) {
+        case ACK_BYTE:
+            if (receivingMessage) {
+                goto msg_byte;
+            }
+            resendTries = 0;
+            uartTxState = UartTxState_Idle;
+            k_sem_give(&txBufferBusy);
+            break;
+        case NACK_BYTE:
+            if (receivingMessage) {
+                goto msg_byte;
+            }
+            uartTxState = UartTxState_Resend;
+            wakeControlThread();
+            break;
+        case PING_BYTE:
+            if (receivingMessage) {
+                goto msg_byte;
+            }
+            lastPingTime = k_uptime_get();
+            break;
         case END_BYTE:
             if (escaping) {
-                appendRxByte(byte);
-                escaping = false;
-            } else {
-                rxPacketReceived();
+                goto msg_byte;
             }
+
+            receivingMessage = false;
+            rxPacketReceived();
             break;
         case ESCAPE_BYTE:
             if (escaping) {
-                appendRxByte(byte);
-                escaping = false;
-            } else {
-                escaping = true;
+                goto msg_byte;
             }
+            escaping = true;
             break;
         case START_BYTE:
             if (escaping) {
-                appendRxByte(byte);
-                escaping = false;
-            } else {
-                rxPosition = 0;
+                goto msg_byte;
             }
+            receivingMessage = true;
+            rxPosition = 0;
             break;
+msg_byte:
         default:
             escaping = false;
             appendRxByte(byte);
@@ -181,7 +240,7 @@ static void uart_callback(const struct device *dev, struct uart_event *evt, void
 
     switch (evt->type) {
     case UART_TX_DONE:
-        k_sem_give(&txBufferBusy);
+        k_sem_give(&txControlBusy);
         break;
 
     case UART_TX_ABORTED:
@@ -241,13 +300,14 @@ static void setEscapedTxByte(uint8_t idx, uint8_t byte) {
 
 static void processOutgoingByte(uint8_t byte) {
     switch (byte) {
+        case START_BYTE:
         case END_BYTE:
-            appendTxByte(ESCAPE_BYTE);
-            appendTxByte(END_BYTE);
-            break;
         case ESCAPE_BYTE:
+        case ACK_BYTE:
+        case NACK_BYTE:
+        case PING_BYTE:
             appendTxByte(ESCAPE_BYTE);
-            appendTxByte(ESCAPE_BYTE);
+            appendTxByte(byte);
             break;
         default:
             appendTxByte(byte);
@@ -268,35 +328,15 @@ static void finalizeCrc(crc16_data_t* crcState) {
     setEscapedTxByte(3, crc >> 8);
 }
 
-void Uart_SendPacket(const uint8_t* data, uint16_t len) {
-    SEM_TAKE(&txBufferBusy);
-
-    crc16_data_t crcState;
-    crc16_init(&crcState);
-
-    appendTxByte(START_BYTE);
-    txPosition = CRC_BUF_LEN+1;
-
-    if (len > 0) {
-        processOutgoingByteWithCrc(DEVICE_ID, &crcState);
-        processOutgoingByteWithCrc(DEVICE_ID == DeviceId_Uhk80_Right ? DeviceId_Uhk80_Left : DeviceId_Uhk80_Right, &crcState);
-        processOutgoingByteWithCrc(0, &crcState); //this will cause errors; send non-zero messages via SendMessage
-    }
-
-    for (uint16_t i = 0; i < len; i++) {
-        processOutgoingByte(data[i]);
-    }
-    crc16_update(&crcState, data, len);
-
-    appendTxByte(END_BYTE);
-
-    finalizeCrc(&crcState);
+void Uart_ControlMessage(const uint8_t* data, uint16_t len) {
+    SEM_TAKE(&txControlBusy);
 
     uart_tx(uart_dev, txBuffer, txPosition, UART_TIMEOUT);
 }
 
 void Uart_SendMessage(message_t* msg) {
     SEM_TAKE(&txBufferBusy);
+    SEM_TAKE(&txControlBusy);
 
     // Call this only after we have taken the semaphore.
     Resend_RegisterMessageAndUpdateWatermarks(msg);
@@ -325,10 +365,33 @@ void Uart_SendMessage(message_t* msg) {
     finalizeCrc(&crcState);
 
     uart_tx(uart_dev, txBuffer, txPosition, UART_TIMEOUT);
+
+    lastMessageSentTime = k_uptime_get();
+    uartTxState = UartTxState_WaitingForAck;
 }
 
-static void ping() {
-    Uart_SendPacket(NULL, 0);
+static void sendControl(uint8_t byte) {
+    SEM_TAKE(&txControlBusy);
+    uart_tx(uart_dev, &byte, 1, UART_TIMEOUT);
+}
+
+static void resend() {
+    if (resendTries++ > 5) {
+        LogU("Repeatedly failed to send a message! ");
+        for (uint16_t i = 0; i < txPosition; i++) {
+            LogU("%i ", txBuffer[i]);
+        }
+        LogU("\n");
+
+        resendTries = 0;
+        uartTxState = UartTxState_Idle;
+        k_sem_give(&txBufferBusy);
+    } else {
+        uartTxState = UartTxState_WaitingForAck;
+        SEM_TAKE(&txControlBusy);
+        k_sleep(K_MSEC(13));
+        uart_tx(uart_dev, txBuffer, txPosition, UART_TIMEOUT);
+    }
 }
 
 static void updateConnectionState() {
@@ -339,16 +402,62 @@ static void updateConnectionState() {
     if (oldIsConnected != newIsConnected) {
         Connections_SetState(connectionId, newIsConnected ? ConnectionState_Ready : ConnectionState_Disconnected);
         if (!newIsConnected) {
-            k_sem_init(&txBufferBusy, UART_SLOTS, UART_SLOTS);
+            k_sem_give(&txBufferBusy);
+            k_sem_give(&txControlBusy);
         }
     }
 }
 
 void testUart() {
+    uint32_t lastPingSentTime = 0;
+    uint32_t currentTime = 0;
     while (1) {
-        ping();
         updateConnectionState();
-        k_sleep(K_MSEC(UART_PING_DELAY));
+
+        if (currentTime >= lastPingSentTime + UART_PING_DELAY) {
+            sendControl(PING_BYTE);
+            lastPingSentTime = currentTime;
+        }
+
+        uint32_t wakeTime = lastPingSentTime + UART_PING_DELAY;
+
+        if (Connections_IsReady(remoteConnectionId())) {
+            switch (uartRxState) {
+                case UartRxState_Ack:
+                    sendControl(ACK_BYTE);
+                    uartRxState = UartRxState_Idle;
+                    break;
+                case UartRxState_Nack:
+                    sendControl(NACK_BYTE);
+                    uartRxState = UartRxState_Idle;
+                    break;
+                case UartRxState_Idle:
+                    break;
+            }
+
+            if (uartTxState == UartTxState_Resend) {
+                resend();
+            }
+
+            currentTime = k_uptime_get();
+            if (uartTxState == UartTxState_WaitingForAck) {
+                uint32_t resendTime = lastMessageSentTime + UART_RESEND_DELAY;
+                if (currentTime >= resendTime) {
+                    resend();
+                } else {
+                    wakeTime = MIN(wakeTime, resendTime);
+                }
+            }
+        } else {
+            uartTxState = UartTxState_Idle;
+            uartRxState = UartRxState_Idle;
+        }
+
+        currentTime = k_uptime_get();
+
+        if (wakeTime > currentTime) {
+            k_sem_take(&controlThreadSleeper, K_MSEC(wakeTime - currentTime));
+        }
     }
 }
 

--- a/device/src/keyboard/uart.h
+++ b/device/src/keyboard/uart.h
@@ -8,8 +8,8 @@
 
 // Macros:
 
-    #define UART_TIMEOUT 250
-    #define UART_PING_DELAY 100
+    #define UART_TIMEOUT 2000
+    #define UART_PING_DELAY 500
     #define UART_MAX_PACKET_LENGTH MAX_LINK_PACKET_LENGTH
 
 // Variables:
@@ -21,7 +21,7 @@
 
     bool Uart_IsConnected();
     void Uart_SendPacket(const uint8_t* data, uint16_t len);
-    void Uart_SendMessage(message_t msg);
+    void Uart_SendMessage(message_t* msg);
     bool Uart_Availability(messenger_availability_op_t total);
     void Uart_Enable();
     void InitUart(void);

--- a/device/src/keyboard/uart.h
+++ b/device/src/keyboard/uart.h
@@ -8,8 +8,8 @@
 
 // Macros:
 
-    #define UART_TIMEOUT 2000
-    #define UART_PING_DELAY 500
+    #define UART_TIMEOUT 500
+    #define UART_PING_DELAY 100
     #define UART_MAX_PACKET_LENGTH MAX_LINK_PACKET_LENGTH
 
 // Variables:

--- a/device/src/logger.c
+++ b/device/src/logger.c
@@ -57,6 +57,12 @@ void LogUO(const char *fmt, ...) {
     LogConstantTo(DEVICE_ID, LogTarget_Uart | LogTarget_Oled, buffer);
 }
 
+void LogO(const char *fmt, ...) {
+    EXPAND_STRING(buffer);
+
+    LogConstantTo(DEVICE_ID, LogTarget_Oled, buffer);
+}
+
 void LogUOS(const char *fmt, ...) {
     EXPAND_STRING(buffer);
 

--- a/device/src/logger.c
+++ b/device/src/logger.c
@@ -58,7 +58,7 @@ void LogUO(const char *fmt, ...) {
 void LogUOS(const char *fmt, ...) {
     EXPAND_STRING(buffer);
 
-    LogConstantTo(DeviceId_Uhk80_Right, LogTarget_Uart | LogTarget_Oled | LogTarget_ErrorBuffer, buffer);
+    LogConstantTo(DEVICE_ID, LogTarget_Uart | LogTarget_Oled | LogTarget_ErrorBuffer, buffer);
     MacroEvent_OnError();
 }
 
@@ -74,7 +74,11 @@ void LogConstantTo(device_id_t deviceId, log_target_t logMask, const char* buffe
             Macros_ReportPrintf(NULL, "%s", buffer);
         }
     } else {
-        Messenger_Send2(deviceId, MessageId_Log, logMask, buffer, strlen(buffer)+1);
+        if (arch_is_in_isr()) {
+            printk("Cannot send log from ISR:\n    %s\n", buffer);
+        } else {
+            Messenger_Send2(deviceId, MessageId_Log, logMask, buffer, strlen(buffer)+1);
+        }
     }
 }
 

--- a/device/src/logger.c
+++ b/device/src/logger.c
@@ -81,7 +81,7 @@ void LogUSDO(const char *fmt, ...) {
 
 void LogConstantTo(device_id_t deviceId, log_target_t logMask, const char* buffer) {
     if (DEVICE_ID == deviceId) {
-        if ((logMask & LogTarget_Oled) && DEBUG_MODE) {
+        if (logMask & LogTarget_Oled) {
             Oled_LogConstant(buffer);
         }
         if ((logMask & LogTarget_Uart) && DEBUG_LOG_UART) {

--- a/device/src/logger.h
+++ b/device/src/logger.h
@@ -27,6 +27,7 @@ typedef enum {
     // Log to UART and OLED and State buffer
     void LogU(const char *fmt, ...);
     void LogUO(const char *fmt, ...);
+    void LogO(const char *fmt, ...);
     void LogUOS(const char *fmt, ...);
     void LogUSDO(const char *fmt, ...);
 

--- a/device/src/logger.h
+++ b/device/src/logger.h
@@ -28,5 +28,6 @@ typedef enum {
     void LogU(const char *fmt, ...);
     void LogUO(const char *fmt, ...);
     void LogUOS(const char *fmt, ...);
+    void LogUSDO(const char *fmt, ...);
 
 #endif // __LOGGER_H__

--- a/device/src/main.c
+++ b/device/src/main.c
@@ -42,6 +42,7 @@
 #include <zephyr/drivers/gpio.h>
 #include "dongle_leds.h"
 #include "usb_protocol_handler.h"
+#include "trace.h"
 
 k_tid_t Main_ThreadId = 0;
 
@@ -73,6 +74,8 @@ static void scheduleNextRun() {
     CurrentTime = k_uptime_get();
     int32_t diff = nextEventTime - CurrentTime;
 
+    Trace('-');
+
     k_sem_take(&mainWakeupSemaphore, K_NO_WAIT);
     bool haveMoreWork = (EventScheduler_Vector & EventVector_UserLogicUpdateMask);
     if (haveMoreWork) {
@@ -91,6 +94,7 @@ static void scheduleNextRun() {
         k_sem_take(&mainWakeupSemaphore, K_FOREVER);
         // k_sleep(K_FOREVER);
     }
+    Trace('+');
 }
 
 //TODO: inline this
@@ -102,6 +106,8 @@ void Main_Wake() {
 int main(void) {
     Main_ThreadId = k_current_get();
     printk("----------\n" DEVICE_NAME " started\n");
+
+    Trace_Init();
 
     {
         flash_area_open(FLASH_AREA_ID(hardware_config_partition), &hardwareConfigArea);

--- a/device/src/main.c
+++ b/device/src/main.c
@@ -1,5 +1,6 @@
 #include "main.h"
 #include "bt_advertise.h"
+#include "messenger_queue.h"
 #include "nus_client.h"
 #include "nus_server.h"
 #include "bt_manager.h"

--- a/device/src/messenger.c
+++ b/device/src/messenger.c
@@ -325,6 +325,10 @@ ATTR_UNUSED static void getMessageDescription(uint8_t msgId1, uint8_t msgId2, co
     }
 }
 
+void Messenger_GetMessageDescription(uint8_t* data, uint8_t offset, const char** out1, const char** out2) {
+    getMessageDescription(data[offset+MessageOffset_MsgId1], data[offset+MessageOffset_MsgId1+1], out1, out2);
+}
+
 void processWatermarks(uint8_t srcConnectionId, uint8_t src, const uint8_t* data, uint16_t len, uint8_t offset) {
     if (data[offset+MessageOffset_MsgId1] == MessageId_ResendRequest) {
         return;

--- a/device/src/messenger.c
+++ b/device/src/messenger.c
@@ -338,7 +338,7 @@ void processWatermarks(uint8_t srcConnectionId, uint8_t src, const uint8_t* data
     desc1 = desc1 == NULL ? "" : desc1;
     desc2 = desc2 == NULL ? "" : desc2;
 
-    if (DEBUG_MODE) {
+    if (DEBUG_LOG_MESSAGES) {
         LogU("Rec %d    %d %s %s\n", srcConnectionId, wm, desc1, desc2);
     }
 
@@ -346,7 +346,7 @@ void processWatermarks(uint8_t srcConnectionId, uint8_t src, const uint8_t* data
         return;
     }
 
-    if (wm != expectedWm && DEBUG_MODE) {
+    if (false && wm != expectedWm && DEBUG_MODE) {
         if (wm != 0) {
             int8_t difference = wm - expectedWm;
             LogUSDO("Message index doesn't match by %i message(s) from connection %d (%s), wm %d / %d\n", difference, srcConnectionId, Connections_GetStaticName(srcConnectionId), wm, expectedWm);
@@ -458,7 +458,7 @@ void Messenger_SendMessage(message_t* message) {
     getMessageDescription(message->messageId[0], message->messageId[1], &desc1, &desc2);
     desc1 = desc1 == NULL ? "" : desc1;
     desc2 = desc2 == NULL ? "" : desc2;
-    if (DEBUG_MODE) {
+    if (DEBUG_LOG_MESSAGES) {
         LogU("Sen %d        %d %s %s\n", connectionId, message->wm, desc1, desc2);
     }
 

--- a/device/src/messenger.c
+++ b/device/src/messenger.c
@@ -349,7 +349,7 @@ void processWatermarks(uint8_t srcConnectionId, uint8_t src, const uint8_t* data
     if (wm != expectedWm && DEBUG_MODE) {
         if (wm != 0) {
             int8_t difference = wm - expectedWm;
-            LogUOS("Message index doesn't match by %i message(s) from connection %d (%s), wm %d / %d\n", difference, srcConnectionId, Connections_GetStaticName(srcConnectionId), wm, expectedWm);
+            LogUSDO("Message index doesn't match by %i message(s) from connection %d (%s), wm %d / %d\n", difference, srcConnectionId, Connections_GetStaticName(srcConnectionId), wm, expectedWm);
         } else {
             // they have resetted their connection; that is fine, just update our watermarks
         }

--- a/device/src/messenger.c
+++ b/device/src/messenger.c
@@ -23,6 +23,7 @@
 #include "connections.h"
 #include "resend.h"
 #include "debug.h"
+#include "trace.h"
 
 #if DEVICE_IS_KEYBOARD
 #include "keyboard/uart.h"
@@ -340,6 +341,7 @@ void logAllMessages(uint8_t srcConnectionId, uint8_t src, const uint8_t* data, u
     if (DEBUG_LOG_MESSAGES) {
         LogU("Rec %d    %d %s %s\n", srcConnectionId, wm, desc1, desc2);
     }
+    Trace_Printf("I%d", MessengerQueue_GetOccupiedCount());
 }
 
 
@@ -403,8 +405,10 @@ void Messenger_ProcessQueue() {
     EventVector_Unset(EventVector_NewMessage);
     messenger_queue_record_t rec = MessengerQueue_Take();
     while (rec.data != NULL) {
+        Trace('<');
         receive(rec.data+rec.offset, rec.len);
         MessengerQueue_FreeMemory(rec.data);
+        Trace('>');
 
         rec = MessengerQueue_Take();
     }
@@ -485,6 +489,8 @@ void Messenger_SendMessage(message_t* message) {
         LogU("Sen %d        %d %s %s\n", connectionId, message->wm, desc1, desc2);
     }
 
+    Trace('O');
+    Trace_Print();
 }
 
 void Messenger_Send(device_id_t dst, uint8_t messageId, const uint8_t* data, uint16_t len) {

--- a/device/src/messenger.h
+++ b/device/src/messenger.h
@@ -23,6 +23,7 @@
         MessageId_Log = 3,
         MessageId_Ping = 4,
         MessageId_RoundTripTest = 5,
+        MessageId_ResendRequest = 6,
     } message_id_t;
 
 typedef enum {
@@ -50,7 +51,7 @@ typedef enum {
 
     uint16_t Messenger_GetMissedMessages(device_id_t dst);
 
-    void Messenger_SendMessage(message_t message);
+    void Messenger_SendMessage(message_t* message);
     void Messenger_Send(device_id_t dst, uint8_t messageId, const uint8_t* data, uint16_t len);
     void Messenger_Send2(device_id_t dst, uint8_t messageId, uint8_t messageId2, const uint8_t* data, uint16_t len);
     void Messenger_Send2Via(device_id_t dst, connection_id_t connectionId, uint8_t messageId, uint8_t messageId2, const uint8_t* data, uint16_t len);

--- a/device/src/messenger.h
+++ b/device/src/messenger.h
@@ -59,6 +59,7 @@ typedef enum {
 
     void Messenger_Enqueue(uint8_t srcConnectionId, uint8_t src, const uint8_t* data, uint16_t len, uint8_t offset);
     void Messenger_ProcessQueue();
+    void Messenger_GetMessageDescription(uint8_t* data, uint8_t offset, const char** out1, const char** out2);
 
     void Messenger_Init();
 

--- a/device/src/messenger_queue.c
+++ b/device/src/messenger_queue.c
@@ -170,6 +170,16 @@ messenger_queue_record_t MessengerQueue_Take() {
     }
 }
 
+ATTR_UNUSED uint8_t MessengerQueue_GetOccupiedCount() {
+    uint8_t count = 0;
+    for (uint8_t i = 0; i < POOL_SIZE; i++) {
+        if (regionPool.segmentTaken[i]) {
+            count++;
+        }
+    }
+    return count;
+}
+
 void MessengerQueue_Init() {
     k_fifo_init(&messageQueue);
 }

--- a/device/src/messenger_queue.c
+++ b/device/src/messenger_queue.c
@@ -6,6 +6,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include "logger.h"
+#include "trace.h"
 
 uint16_t MessengerQueue_DroppedMessageCount = 0;
 
@@ -112,6 +113,7 @@ uint8_t* MessengerQueue_AllocateMemory() {
     for (uint8_t tries = 0; tries < POOL_SIZE; tries++) {
         POOL_ALLOCATE(regionPool, POOL_SIZE, POOL_REGION_SIZE);
     }
+    Trace_Print();
     LogUOS("Messanger message pool space ran out!\n");
     return blackholeBuffer;
 }

--- a/device/src/messenger_queue.h
+++ b/device/src/messenger_queue.h
@@ -32,4 +32,6 @@
     void MessengerQueue_Put(device_id_t src, const uint8_t* data, uint16_t len, uint8_t offset);
     messenger_queue_record_t MessengerQueue_Take();
 
+    uint8_t MessengerQueue_GetOccupiedCount();
+
 #endif // __MESSENGER_QUEUE_H__

--- a/device/src/nus_client.c
+++ b/device/src/nus_client.c
@@ -138,7 +138,10 @@ void NusClient_Connect(struct bt_conn *conn) {
 
 void NusClient_Disconnected() {
     // I argue that when bt is not connected, freeing the semaphore causes no trouble.
-    k_sem_init(&nusBusy, NUS_SLOTS, NUS_SLOTS);
+    for (uint8_t i = 0; i < NUS_SLOTS; i++) {
+        // calling init here would leave all the threads deadlocked
+        k_sem_give(&nusBusy);
+    }
 }
 
 void NusClient_Init(void) {

--- a/device/src/nus_client.c
+++ b/device/src/nus_client.c
@@ -22,6 +22,7 @@
 #include "debug.h"
 #include <zephyr/settings/settings.h>
 #include "resend.h"
+#include "trace.h"
 
 static struct bt_nus_client nus_client;
 
@@ -187,6 +188,7 @@ static void send_raw_buffer(const uint8_t *data, uint16_t len) {
 }
 
 void NusClient_SendMessage(message_t* msg) {
+    Trace_Printf("s2");
     SEM_TAKE(&nusBusy);
 
     // Call this only after we have taken the semaphore.

--- a/device/src/nus_client.h
+++ b/device/src/nus_client.h
@@ -11,7 +11,7 @@
     void NusClient_Init(void);
     void NusClient_Disconnected();
     void NusClient_Connect(struct bt_conn *conn);
-    void NusClient_SendMessage(message_t msg);
+    void NusClient_SendMessage(message_t* msg);
     bool NusClient_Availability(messenger_availability_op_t operation);
 
 #endif // __NUS_CLIENT_H__

--- a/device/src/nus_server.c
+++ b/device/src/nus_server.c
@@ -71,7 +71,10 @@ int NusServer_Init(void) {
 
 void NusServer_Disconnected() {
     // I argue that when bt is not connected, freeing the semaphore causes no trouble.
-    k_sem_init(&nusBusy, NUS_SLOTS, NUS_SLOTS);
+    for (uint8_t i = 0; i < NUS_SLOTS; i++) {
+        // calling init here would leave all the threads deadlocked
+        k_sem_give(&nusBusy);
+    }
 }
 
 static void send_raw_buffer(const uint8_t *data, uint16_t len, struct bt_conn* conn) {

--- a/device/src/nus_server.h
+++ b/device/src/nus_server.h
@@ -10,8 +10,8 @@
 
     extern int NusServer_Init(void);
     extern void NusServer_Disconnected();
-    extern void NusServer_SendMessage(message_t msg);
-    extern void NusServer_SendMessageTo(message_t msg, struct bt_conn* conn);
+    extern void NusServer_SendMessage(message_t* msg);
+    extern void NusServer_SendMessageTo(message_t* msg, struct bt_conn* conn);
     extern bool NusServer_Availability(messenger_availability_op_t operation);
 
 #endif // __NUS_SERVER_H__

--- a/device/src/resend.c
+++ b/device/src/resend.c
@@ -44,6 +44,7 @@ void Resend_RequestResendSync() {
 }
 
 static void resendSyncableProperty(syncable_property_id_t propId) {
+#if DEVICE_IS_KEYBOARD
     switch(propId) {
         case SyncablePropertyId_LeftHalfKeyStates:
             KeyScanner_ResendKeyStates = true;
@@ -54,6 +55,7 @@ static void resendSyncableProperty(syncable_property_id_t propId) {
         default:
             LogU("Resend request for %d received. This syncable property is unhandled?.", propId);
     }
+#endif
 }
 
 void Resend_ResendRequestReceived(device_id_t src, connection_id_t connectionId, const uint8_t* data, uint16_t len) {

--- a/device/src/resend.c
+++ b/device/src/resend.c
@@ -1,0 +1,100 @@
+#include "resend.h"
+#include "connections.h"
+#include "device.h"
+#include "event_scheduler.h"
+#include "link_protocol.h"
+#include "messenger.h"
+#include "state_sync.h"
+#include "keyboard/key_scanner.h"
+
+// TODO: throw out this file and write it anew. This will fail in a number of scenarios.
+
+struct {
+    bool needsResend;
+    connection_id_t connectionId;
+    device_id_t dst;
+    uint8_t messageWatermark;
+} resendRequest ;
+
+void Resend_RequestResendAsync(device_id_t dst, connection_id_t connectionId, uint8_t messageWatermark) {
+    if (!resendRequest.needsResend) {
+        resendRequest.needsResend = true;
+        resendRequest.connectionId = connectionId;
+        resendRequest.messageWatermark = messageWatermark;
+        resendRequest.dst = dst;
+        EventScheduler_Schedule(CurrentTime, EventSchedulerEvent_ResendMessage, "Messenger_ResendAsync");
+    } else {
+        // well, we would like to log this, but we don't want to do that from within uart callback
+    }
+
+}
+
+void Resend_RequestResendSync() {
+    if (resendRequest.needsResend) {
+        Messenger_Send2Via(
+                resendRequest.dst,
+                resendRequest.connectionId,
+                MessageId_ResendRequest,
+                0,
+                &resendRequest.messageWatermark,
+                1
+                );
+        resendRequest.needsResend = false;
+    }
+}
+
+static void resendSyncableProperty(syncable_property_id_t propId) {
+    switch(propId) {
+        case SyncablePropertyId_LeftHalfKeyStates:
+            KeyScanner_ResendKeyStates = true;
+            break;
+        case SyncablePropertyId_LeftModuleKeyStates:
+            UhkModuleDriver_ResendKeyStates = true;
+            break;
+        default:
+            LogU("Resend request for %d received. This syncable property is unhandled?.", propId);
+    }
+}
+
+void Resend_ResendRequestReceived(device_id_t src, connection_id_t connectionId, const uint8_t* data, uint16_t len) {
+    uint8_t ATTR_UNUSED messageId = *(data++);
+    uint8_t ATTR_UNUSED dummy = *(data++);
+    uint8_t requestedWatermark = *(data++);
+    uint8_t lastResendableWatermark = Connections[connectionId].watermarks.lastSentResendableWm;
+
+    if (requestedWatermark != lastResendableWatermark) {
+        LogU("Resend request for %d, but we have got %d\n", requestedWatermark, lastResendableWatermark);
+        return;
+    }
+
+    Connections[connectionId].watermarks.txIdx = Connections[connectionId].watermarks.lastSentResendableWm;
+    message_id_t msgId1 = Connections[connectionId].watermarks.lastSentId1;
+    message_id_t msgId2 = Connections[connectionId].watermarks.lastSentId2;
+
+    switch (msgId1) {
+        case MessageId_StateSync:
+            StateSync_UpdateProperty((state_sync_prop_id_t)msgId2, NULL);
+            break;
+        case MessageId_SyncableProperty:
+            resendSyncableProperty((syncable_property_id_t)msgId2);
+            break;
+        case MessageId_Log:
+        case MessageId_RoundTripTest:
+        case MessageId_Ping:
+            Log("Resend request for %d %d received. Ignoring as it is not vital.", msgId1, msgId2);
+            return;
+        default:
+            Log("Resend request for %d %d received. This message id is unhandled?.", msgId1, msgId2);
+            return;
+    }
+}
+
+void Resend_RegisterMessageAndUpdateWatermarks(message_t* msg) {
+    if (msg->messageId[0] != MessageId_ResendRequest) {
+        msg->wm = Connections[msg->connectionId].watermarks.txIdx++;
+        Connections[msg->connectionId].watermarks.lastSentResendableWm = msg->wm;
+        Connections[msg->connectionId].watermarks.lastSentId1 = msg->messageId[0];
+        Connections[msg->connectionId].watermarks.lastSentId2 = msg->messageId[1];
+    }
+}
+

--- a/device/src/resend.h
+++ b/device/src/resend.h
@@ -1,0 +1,28 @@
+#ifndef __RESEND_H__
+#define __RESEND_H__
+
+// Includes:
+
+    #include <stdbool.h>
+    #include <stdint.h>
+    #include "device.h"
+    #include "connections.h"
+    #include "messenger.h"
+
+// Macros:
+
+
+// Typedefs:
+
+
+// Variables:
+
+
+// Functions:
+
+    void Resend_ResendRequestReceived(device_id_t src, connection_id_t connectionId, const uint8_t* data, uint16_t len);
+    void Resend_RequestResendSync();
+    void Resend_RequestResendAsync(device_id_t dst, connection_id_t connectionId, uint8_t messageWatermark);
+    void Resend_RegisterMessageAndUpdateWatermarks(message_t* msg);
+
+#endif

--- a/device/src/round_trip_test.c
+++ b/device/src/round_trip_test.c
@@ -12,7 +12,7 @@ typedef struct {
 } ATTR_PACKED rtt_ping_t;
 
 void RoundTripTest_Init() {
-    if (DEVICE_IS_UHK80_RIGHT) {
+    if (DEVICE_IS_UHK80_RIGHT && DEBUG_TEST_RTT) {
         EventScheduler_Schedule(CurrentTime+10000, EventSchedulerEvent_RoundTripTest, "Event scheduler loop");
     }
 }

--- a/device/src/state_sync.c
+++ b/device/src/state_sync.c
@@ -34,7 +34,7 @@
 
 #define WAKE(TID) if (TID != 0) { k_wakeup(TID); }
 
-#define STATE_SYNC_SEND_DELAY 2
+#define STATE_SYNC_SEND_DELAY 1
 
 #define THREAD_STACK_SIZE 2000
 #define THREAD_PRIORITY 5

--- a/device/src/state_sync.c
+++ b/device/src/state_sync.c
@@ -59,7 +59,7 @@ static void wake(k_tid_t tid) {
     if (tid != 0) {
         k_wakeup(tid);
         if (DEBUG_MODE) {
-            printk("StateSync woke up %p\n", tid);
+            LogU("StateSync woke up %p\n", tid);
         }
     } else {
         printk("Skipping wake up, tid is 0");
@@ -647,6 +647,7 @@ static void prepareData(device_id_t dst, const uint8_t *propDataPtr, state_sync_
     case StateSyncPropertyId_KeyStatesDummy: {
 #if DEVICE_IS_KEYBOARD
         KeyScanner_ResendKeyStates = true;
+        UhkModuleDriver_ResendKeyStates = true;
 #endif
         return;
     }

--- a/device/src/state_sync.c
+++ b/device/src/state_sync.c
@@ -58,9 +58,9 @@ uint16_t StateSync_DongleResetCounter = 0;
 static void wake(k_tid_t tid) {
     if (tid != 0) {
         k_wakeup(tid);
-        if (DEBUG_MODE) {
-            LogU("StateSync woke up %p\n", tid);
-        }
+        // if (DEBUG_MODE) {
+        //     LogU("StateSync woke up %p\n", tid);
+        // }
     } else {
         printk("Skipping wake up, tid is 0");
     }

--- a/device/src/state_sync.c
+++ b/device/src/state_sync.c
@@ -308,11 +308,7 @@ void StateSync_CheckFirmwareVersions() {
 }
 
 static void checkDongleProtocolVersion() {
-    if (VERSIONS_EQUAL(DongleProtocolVersion, dongleProtocolVersion)) {
-        LogUOS("Dongle and right half run the same dongle protocol version %d.%d.%d\n",
-                DongleProtocolVersion.major, DongleProtocolVersion.minor, DongleProtocolVersion.patch
-        );
-    } else {
+    if (!VERSIONS_EQUAL(DongleProtocolVersion, dongleProtocolVersion)) {
         LogUOS("Dongle and right half run different dongle protocol versios (dongle: %d.%d.%d, right: %d.%d.%d), please upgrade!\n",
                 DongleProtocolVersion.major, DongleProtocolVersion.minor, DongleProtocolVersion.patch,
                 dongleProtocolVersion.major, dongleProtocolVersion.minor, dongleProtocolVersion.patch

--- a/device/src/state_sync.h
+++ b/device/src/state_sync.h
@@ -155,4 +155,6 @@
     void StateSync_ResetRightDongleLink(bool bidirectional);
     void StateSync_ResetConfig();
 
+    void StateSync_CheckFirmwareVersions();
+
 #endif

--- a/device/src/trace.c
+++ b/device/src/trace.c
@@ -1,0 +1,54 @@
+#include "trace.h"
+#include <stdio.h>
+
+#define TRACE_BUFFER_SIZE 64
+
+
+#define EXPAND_STRING(BUFFER, MAX_LOG_LENGTH)  \
+char BUFFER[MAX_LOG_LENGTH]; \
+{ \
+    va_list myargs; \
+    va_start(myargs, fmt); \
+    BUFFER[MAX_LOG_LENGTH-1] = '\0'; \
+    vsnprintf(BUFFER, MAX_LOG_LENGTH-1, fmt, myargs); \
+}
+
+
+char traceBuffer[TRACE_BUFFER_SIZE];
+uint8_t traceBufferPosition = 0;
+
+void Trace(char a) {
+    traceBuffer[traceBufferPosition] = a;
+    traceBufferPosition = (traceBufferPosition + 1) % TRACE_BUFFER_SIZE;
+}
+
+void Trace_Printf(const char *fmt, ...) {
+    EXPAND_STRING(buffer, TRACE_BUFFER_SIZE);
+
+    for (uint8_t i = 0; i < TRACE_BUFFER_SIZE; i++) {
+        if (buffer[i] == '\0') {
+            break;
+        }
+        if (buffer[i] == '\n') {
+            Trace(' ');
+        }
+        Trace(buffer[i]);
+    }
+}
+
+void Trace_Init(void) {
+    for (uint8_t i = 0; i < TRACE_BUFFER_SIZE; i++) {
+        traceBuffer[i] = ' ';
+    }
+    traceBufferPosition = 0;
+}
+
+void Trace_Print(void) {
+    printk("Trace: ");
+    uint8_t pos = traceBufferPosition;
+    for (uint8_t i = 0; i < TRACE_BUFFER_SIZE; i++) {
+        printk("%c", traceBuffer[(pos+i) % TRACE_BUFFER_SIZE]);
+    }
+    printk(" :ecarT\n");
+}
+

--- a/device/src/trace.h
+++ b/device/src/trace.h
@@ -1,0 +1,24 @@
+#ifndef __TRACE_H__
+#define __TRACE_H__
+
+// Includes:
+
+    #include <inttypes.h>
+    #include <stdbool.h>
+    #include "debug.h"
+
+// Macros:
+
+// Typedefs:
+
+// Variables:
+
+// Functions:
+
+    void Trace_Init(void);
+    void Trace(char a);
+    void Trace_Print(void);
+    void Trace_Printf(const char *fmt, ...);
+
+#endif
+

--- a/device/src/usb/keyboard_app.cpp
+++ b/device/src/usb/keyboard_app.cpp
@@ -3,6 +3,7 @@ extern "C" {
 #include "connections.h"
 #include "usb_compatibility.h"
 #include "zephyr/sys/printk.h"
+#include "trace.h"
 }
 
 keyboard_app &keyboard_app::usb_handle()
@@ -84,6 +85,7 @@ void keyboard_app::set_report_state(const keys_nkro_report_base<> &data)
     if (!active()) {
         return;
     }
+    Trace_Printf("s1");
     if (!sending_sem_.try_acquire_for(SEMAPHORE_RESET_TIMEOUT)) {
         //return;
     }

--- a/right/src/debug.h
+++ b/right/src/debug.h
@@ -10,7 +10,13 @@
 #define DEBUG_POSTPONER false
 #define WATCH_INTERVAL 500
 
-#define DEBUG_MODE false
+
+
+#define DEBUG_MODE true
+
+#define DEBUG_STRESS_UART false
+#define DEBUG_LOG_UART false
+#define DEBUG_TEST_RTT false
 
 #define DEBUG_ROLL_STATUS_BUFFER true
 

--- a/right/src/debug.h
+++ b/right/src/debug.h
@@ -10,10 +10,11 @@
 #define DEBUG_POSTPONER false
 #define WATCH_INTERVAL 500
 
-#define DEBUG_MODE false
+#define DEBUG_MODE true
 #define DEBUG_STRESS_UART false
-#define DEBUG_LOG_UART false
-#define DEBUG_TEST_RTT false
+#define DEBUG_TEST_RTT true
+#define DEBUG_LOG_UART true
+#define DEBUG_LOG_MESSAGES false
 
 #define DEBUG_ROLL_STATUS_BUFFER true
 

--- a/right/src/debug.h
+++ b/right/src/debug.h
@@ -10,10 +10,7 @@
 #define DEBUG_POSTPONER false
 #define WATCH_INTERVAL 500
 
-
-
-#define DEBUG_MODE true
-
+#define DEBUG_MODE false
 #define DEBUG_STRESS_UART false
 #define DEBUG_LOG_UART false
 #define DEBUG_TEST_RTT false

--- a/right/src/event_scheduler.c
+++ b/right/src/event_scheduler.c
@@ -129,6 +129,9 @@ static void processEvt(event_scheduler_event_t evt)
             RoundTripTest_Run();
             EventScheduler_Schedule(CurrentTime+10000, EventSchedulerEvent_RoundTripTest, "Event scheduler loop");
             break;
+        case EventSchedulerEvent_ResendMessage:
+            Resend_RequestResendSync();
+            break;
         default:
             return;
     }

--- a/right/src/event_scheduler.c
+++ b/right/src/event_scheduler.c
@@ -132,6 +132,9 @@ static void processEvt(event_scheduler_event_t evt)
         case EventSchedulerEvent_ResendMessage:
             Resend_RequestResendSync();
             break;
+        case EventSchedulerEvent_CheckFwChecksums:
+            StateSync_CheckFirmwareVersions();
+            break;
         default:
             return;
     }

--- a/right/src/event_scheduler.h
+++ b/right/src/event_scheduler.h
@@ -40,6 +40,7 @@
         EventSchedulerEvent_UpdateDebugOledLine,
         EventSchedulerEvent_RoundTripTest,
         EventSchedulerEvent_ResendMessage,
+        EventSchedulerEvent_CheckFwChecksums,
         EventSchedulerEvent_Count
     } event_scheduler_event_t;
 

--- a/right/src/event_scheduler.h
+++ b/right/src/event_scheduler.h
@@ -39,6 +39,7 @@
         EventSchedulerEvent_RedrawOled,
         EventSchedulerEvent_UpdateDebugOledLine,
         EventSchedulerEvent_RoundTripTest,
+        EventSchedulerEvent_ResendMessage,
         EventSchedulerEvent_Count
     } event_scheduler_event_t;
 

--- a/right/src/slave_drivers/uhk_module_driver.c
+++ b/right/src/slave_drivers/uhk_module_driver.c
@@ -33,6 +33,8 @@ module_connection_state_t ModuleConnectionStates[UHK_MODULE_MAX_SLOT_COUNT];
 
 static bool shouldResetTrackpoint = false;
 
+bool UhkModuleDriver_ResendKeyStates = false;
+
 uint8_t UhkModuleSlaveDriver_SlotIdToDriverId(uint8_t slotId)
 {
     return slotId-1;
@@ -186,9 +188,10 @@ static void forwardKeystates(uint8_t uhkModuleDriverId, uhk_module_state_t* uhkM
     pointer_delta_t *pointerDelta = (pointer_delta_t*)(rxMessage->data + keyStatesLength);
     bool thisDeltasAreZero = pointerDelta->x == 0 && pointerDelta->y == 0;
 
-    if (stateChanged || !lastDeltasWereZero || !thisDeltasAreZero) {
+    if (UhkModuleDriver_ResendKeyStates || stateChanged || !lastDeltasWereZero || !thisDeltasAreZero) {
         Messenger_Send2(DeviceId_Uhk80_Right, MessageId_SyncableProperty, SyncablePropertyId_LeftModuleKeyStates, rxMessage->data, rxMessage->length);
         lastDeltasWereZero = thisDeltasAreZero;
+        UhkModuleDriver_ResendKeyStates = false;
     }
 #endif
 }

--- a/right/src/slave_drivers/uhk_module_driver.h
+++ b/right/src/slave_drivers/uhk_module_driver.h
@@ -123,6 +123,7 @@
 
 // Variables:
 
+    extern bool UhkModuleDriver_ResendKeyStates;
     extern uhk_module_state_t UhkModuleStates[UHK_MODULE_MAX_SLOT_COUNT];
     extern module_connection_state_t ModuleConnectionStates[UHK_MODULE_MAX_SLOT_COUNT];
 

--- a/right/src/stubs.c
+++ b/right/src/stubs.c
@@ -32,3 +32,4 @@
     ATTRS void RoundTripTest_Run() {};
     ATTRS void Resend_RequestResendSync() {};
     ATTRS void PairingScreen_Feedback(bool success) {};
+    ATTRS void StateSync_CheckFirmwareVersions() {};

--- a/right/src/stubs.c
+++ b/right/src/stubs.c
@@ -36,4 +36,5 @@
     ATTRS void BtConn_UpdateHostConnectionPeerAllocations() {};
     ATTRS void Oled_RequestRedraw() {};
     ATTRS void RoundTripTest_Run() {};
+    ATTRS void Resend_RequestResendSync() {};
 

--- a/right/src/stubs.h
+++ b/right/src/stubs.h
@@ -50,6 +50,7 @@
     extern void BtConn_UpdateHostConnectionPeerAllocations();
     extern void Oled_RequestRedraw();
     extern void RoundTripTest_Run();
+    extern void Resend_RequestResendSync();
 
 #if DEVICE_HAS_OLED
 #define WIDGET_REFRESH(W) Widget_Refresh(W)

--- a/right/src/stubs.h
+++ b/right/src/stubs.h
@@ -52,6 +52,7 @@
     extern void RoundTripTest_Run();
     extern void Resend_RequestResendSync();
     extern void PairingScreen_Feedback(bool success);
+    extern void StateSync_CheckFirmwareVersions();
 
 #if DEVICE_HAS_OLED
 #define WIDGET_REFRESH(W) Widget_Refresh(W)

--- a/right/src/user_logic.c
+++ b/right/src/user_logic.c
@@ -67,7 +67,7 @@ void RunUhk80LeftHalfLogic() {
     LOG_SCHEDULE(
         EventVector_ReportMask("=== ", EventScheduler_Vector)
     );
-    if (EventScheduler_Vector & EventVector_UserLogicUpdateMask) {
+    if (EventScheduler_Vector & EventVector_UserLogicUpdateMask & (~EventVector_NewMessage)) {
         EventVector_ReportMask("Warning: following event hasn't been unset: ", EventScheduler_Vector & EventVector_UserLogicUpdateMask);
     }
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -21,7 +21,7 @@
   "firmwareVersion": "12.3.1",
   "deviceProtocolVersion": "4.14.1",
   "moduleProtocolVersion": "4.3.0",
-  "dongleProtocolVersion": "1.0.0",
+  "dongleProtocolVersion": "1.0.1",
   "userConfigVersion": "8.3.0",
   "hardwareConfigVersion": "1.0.0",
   "smartMacrosVersion": "3.1.0",


### PR DESCRIPTION
Changes:
- decrease uart timeouts, but at the same time forgive one missed ping
- check consistency of uart messages
- start message frames explicitly, thus reducing issues with interference where a single spike can shift the entire message by a byte.
- reset the link protocol when an inconsistent uart message is received

This PR should solve:
- lags when the bridge cable is connected
- some of the key chatter and stucking

(Reseting the entire link is hardly ideal, and later should be replaced by a more robust solution.)