### PR TITLE
bt: use correct zephyr callbacks for passkey entry (#1051)

### DIFF
--- a/device/src/bt_conn.c
+++ b/device/src/bt_conn.c
@@ -28,6 +28,7 @@
 #include "config_manager.h"
 #include "zephyr/kernel.h"
 #include <zephyr/bluetooth/gatt.h>
+#include "stubs.h"
 
 bool Bt_NewPairedDevice = false;
 

--- a/device/src/bt_conn.c
+++ b/device/src/bt_conn.c
@@ -613,12 +613,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 
 // Auth callbacks
 
-static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
-{
-    printk("Passkey for %s: %06u\n", GetPeerStringByConn(conn), passkey);
-}
-
-static void auth_passkey_confirm(struct bt_conn *conn, unsigned int passkey) {
+static void auth_passkey_entry(struct bt_conn *conn) {
     if (auth_conn) {
         bt_conn_disconnect(auth_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
         bt_conn_unref(auth_conn);
@@ -644,11 +639,10 @@ static void auth_passkey_confirm(struct bt_conn *conn, unsigned int passkey) {
     }
 
 #if DEVICE_HAS_OLED
-    PairingScreen_AskForPassword(passkey);
+    PairingScreen_AskForPassword();
 #endif
 
-    printk("Passkey for %s: %06u\n", GetPeerStringByConn(conn), passkey);
-    printk("Type `uhk btacc 1/0` to accept/reject\n");
+    printk("Type `uhk passkey xxxxxx` to pair, or `uhk passkey -1` to reject\n");
 }
 
 static void auth_cancel(struct bt_conn *conn) {
@@ -685,8 +679,7 @@ static void auth_oob_data_request(struct bt_conn *conn, struct bt_conn_oob_info 
 }
 
 static struct bt_conn_auth_cb conn_auth_callbacks = {
-    .passkey_display = auth_passkey_display,
-    .passkey_confirm = auth_passkey_confirm,
+    .passkey_entry = auth_passkey_entry,
     .oob_data_request = auth_oob_data_request,
     .cancel = auth_cancel,
 };
@@ -722,6 +715,7 @@ static void pairing_complete(struct bt_conn *conn, bool bonded) {
     if (auth_conn) {
         bt_conn_unref(auth_conn);
         auth_conn = NULL;
+        PairingScreen_Feedback(true);
     }
 
     BtManager_StartScanningAndAdvertisingAsync();
@@ -745,6 +739,7 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason) {
         bt_conn_unref(auth_conn);
         printk("Pairing of auth conn failed because of %d\n", reason);
         auth_conn = NULL;
+        PairingScreen_Feedback(false);
     }
 
     printk("Pairing failed: %s, reason %d\n", GetPeerStringByConn(conn), reason);
@@ -777,7 +772,7 @@ void BtConn_Init(void) {
     }
 }
 
-void num_comp_reply(uint8_t accept) {
+void num_comp_reply(int passkey) {
     struct bt_conn *conn;
 
 #if DEVICE_HAS_OLED
@@ -790,12 +785,12 @@ void num_comp_reply(uint8_t accept) {
 
     conn = auth_conn;
 
-    if (accept) {
-        bt_conn_auth_passkey_confirm(conn);
-        printk("Numeric Match, conn %p\n", conn);
+    if (passkey >= 0) {
+        bt_conn_auth_passkey_entry(conn, passkey);
+        printk("Sending passkey to conn %p\n", conn);
     } else {
         bt_conn_auth_cancel(conn);
-        printk("Numeric Reject, conn %p\n", conn);
+        printk("Reject pairing to conn %p\n", conn);
         bt_conn_unref(auth_conn);
         auth_conn = NULL;
     }

--- a/device/src/bt_conn.h
+++ b/device/src/bt_conn.h
@@ -59,7 +59,7 @@ typedef enum {
     char *GetPeerStringByAddr(const bt_addr_le_t *addr);
     char *GetPeerStringByConn(const struct bt_conn *conn);
     char* GetAddrString(const bt_addr_le_t *addr);
-    extern void num_comp_reply(uint8_t accept);
+    void num_comp_reply(int passkey);
 
     void BtConn_Init(void);
     void BtConn_DisconnectAll();

--- a/device/src/keyboard/oled/screens/pairing_screen.c
+++ b/device/src/keyboard/oled/screens/pairing_screen.c
@@ -23,9 +23,8 @@ widget_t* PairingFailedScreen;
 static uint8_t passwordCharCount = 0;
 static uint8_t password[PASSWORD_LENGTH];
 static char passwordTextBuffer[2*PASSWORD_LENGTH] = { ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', '\0'};
-static unsigned int correctPassword;
 
-static void updatePasswordText()
+static void updatePasswordText(void)
 {
     for (uint8_t i = 0; i < PASSWORD_LENGTH; i++) {
         if (i < passwordCharCount) {
@@ -39,7 +38,7 @@ static void updatePasswordText()
     Oled_RequestRedraw();
 }
 
-unsigned int computePassword()
+unsigned int computePassword(void)
 {
     unsigned int res = 0;
     for (uint8_t i = 0; i < PASSWORD_LENGTH; i++) {
@@ -57,14 +56,13 @@ static void registerPasswordDigit(uint8_t digit)
     updatePasswordText();
 
     if (passwordCharCount == PASSWORD_LENGTH) {
-        if (computePassword() == correctPassword) {
-            num_comp_reply(1);
-            ScreenManager_ActivateScreen(ScreenId_PairingSucceeded);
-        } else {
-            num_comp_reply(0);
-            ScreenManager_ActivateScreen(ScreenId_PairingFailed);
-        }
+        num_comp_reply(computePassword());
     }
+}
+
+void PairingScreen_Feedback(bool success)
+{
+    ScreenManager_ActivateScreen(success ? ScreenId_PairingSucceeded : ScreenId_PairingFailed);
 }
 
 const rgb_t* PairingScreen_ActionColor(key_action_t* action) {
@@ -102,8 +100,7 @@ void PairingScreen_RegisterScancode(uint8_t scancode)
     switch (scancode)
     {
         case HID_KEYBOARD_SC_ESCAPE:
-            num_comp_reply(0);
-            ScreenManager_ActivateScreen(ScreenId_PairingFailed);
+            num_comp_reply(-1);
             break;
         case HID_KEYBOARD_SC_DELETE:
         case HID_KEYBOARD_SC_BACKSPACE:
@@ -125,15 +122,14 @@ void PairingScreen_RegisterScancode(uint8_t scancode)
     }
 }
 
-void PairingScreen_AskForPassword(unsigned int pass)
+void PairingScreen_AskForPassword(void)
 {
-    correctPassword = pass;
     passwordCharCount = 0;
     updatePasswordText();
     ScreenManager_ActivateScreen(ScreenId_Pairing);
 }
 
-void PairingScreen_Init()
+void PairingScreen_Init(void)
 {
     questionLine = TextWidget_Build(&JetBrainsMono16, "Pairing code:");
     answerLine = TextWidget_Build(&JetBrainsMono16, passwordTextBuffer);

--- a/device/src/keyboard/oled/screens/pairing_screen.h
+++ b/device/src/keyboard/oled/screens/pairing_screen.h
@@ -22,9 +22,10 @@
 
 // Functions:
 
-    void PairingScreen_Init();
+    void PairingScreen_Init(void);
     void PairingScreen_RegisterScancode(uint8_t scancode);
-    void PairingScreen_AskForPassword(unsigned int pass);
+    void PairingScreen_AskForPassword(void);
+    void PairingScreen_Feedback(bool success);
     const rgb_t* PairingScreen_ActionColor(key_action_t* action);
 
 #endif

--- a/device/src/legacy/usb_descriptors/usb_descriptor_mouse_report.h
+++ b/device/src/legacy/usb_descriptors/usb_descriptor_mouse_report.h
@@ -1,1 +1,0 @@
-../../../../right/src/usb_descriptors/usb_descriptor_mouse_report.h

--- a/device/src/shell.c
+++ b/device/src/shell.c
@@ -140,9 +140,15 @@ static int cmd_uhk_gamepad(const struct shell *shell, size_t argc, char *argv[])
     return 0;
 }
 
-static int cmd_uhk_btacc(const struct shell *shell, size_t argc, char *argv[])
+static int cmd_uhk_passkey(const struct shell *shell, size_t argc, char *argv[])
 {
-    num_comp_reply(argv[1][0]);
+    int err = 0;
+    int passkey = shell_strtol(argv[1], 10, &err);
+    if (err) {
+        shell_error(shell, "Invalid passkey format (%d)\n", err);
+    } else {
+        num_comp_reply(passkey);
+    }
     return 0;
 }
 
@@ -184,7 +190,7 @@ void InitShell(void)
         SHELL_CMD_ARG(
             rollover, NULL, "get/set keyboard rollover mode (n/6)", cmd_uhk_rollover, 1, 1),
         SHELL_CMD_ARG(gamepad, NULL, "switch gamepad on/off", cmd_uhk_gamepad, 1, 1),
-        SHELL_CMD_ARG(btacc, NULL, "accept bluetooth pairing", cmd_uhk_btacc, 1, 1),
+        SHELL_CMD_ARG(passkey, NULL, "send passkey for bluetooth pairing", cmd_uhk_passkey, 2, 0),
         SHELL_CMD_ARG(btunpair, NULL, "unpair bluetooth devices", cmd_uhk_btunpair, 1, 1),
         [10]=SHELL_CMD_ARG(connections, NULL, "list BLE connections", cmd_uhk_connections, 1, 0),
         SHELL_SUBCMD_SET_END);

--- a/right/src/stubs.c
+++ b/right/src/stubs.c
@@ -1,11 +1,5 @@
 #include "stubs.h"
 
-#ifdef __ZEPHYR__
-#include "device.h"
-#else
-#include "device.h"
-#endif
-
 #define ATTRS __attribute__((weak))
 
     ATTRS bool SegmentDisplay_NeedsUpdate = false;
@@ -34,3 +28,4 @@
     ATTRS int BtScan_Start(void) { return 0; };
     ATTRS void BtManager_StartScanningAndAdvertising() {};
     ATTRS void BtConn_UpdateHostConnectionPeerAllocations() {};
+    ATTRS void PairingScreen_Feedback(bool success) {};

--- a/right/src/stubs.h
+++ b/right/src/stubs.h
@@ -48,6 +48,7 @@
     extern int BtScan_Start(void);
     extern void BtManager_StartScanningAndAdvertising();
     extern void BtConn_UpdateHostConnectionPeerAllocations();
+    extern void PairingScreen_Feedback(bool success);
 
 #if DEVICE_HAS_OLED
 #define WIDGET_REFRESH(W) Widget_Refresh(W)


### PR DESCRIPTION
This is a draft so far, I couldn't even test it as for some reason the right half didn't advertise itself. The point here is using the `passkey_entry` callback instead of `passkey_display` and `passkey_confirm`, so the BT IO capabilities are reported to the other side differently. Pairing will simply complete by successfully entering the challenge passkey (that is actually not known to the keyboard), therefore the Pair/Connect confirmation on the other end is removed. @kareltucek please review the code, especially the interactions between the BT side and the screen.