### PR TITLE
Fix Agent led, caused by forgotten event scheduler Init.

### DIFF
--- a/device/src/main.c
+++ b/device/src/main.c
@@ -181,6 +181,8 @@ int main(void) {
         InitCharger(); // has to be after usb initialization
     }
 
+    EventVector_Init();
+
     Messenger_Init();
 
     StateSync_Init();

--- a/right/src/event_scheduler.h
+++ b/right/src/event_scheduler.h
@@ -108,6 +108,7 @@
     uint32_t EventScheduler_Process();
 
     void EventVector_ReportMask(const char* prefix, uint32_t mask);
+    void EventVector_Init();
 
     static inline void EventVector_Set(event_vector_event_t evt) {
         DISABLE_IRQ();

--- a/right/src/led_manager.c
+++ b/right/src/led_manager.c
@@ -83,7 +83,7 @@ void LedManager_RecalculateLedBrightness()
 
 void LedManager_UpdateAgentLed()
 {
-#ifndef __ZEPHYR
+#ifndef __ZEPHYR__
     const uint32_t updatePeriod = 1000;
     if (!TestSwitches) {
        LedDisplay_SetIcon(LedDisplayIcon_Agent, CurrentTime - LastUsbGetKeyboardStateRequestTimestamp < 1000);

--- a/right/src/main.c
+++ b/right/src/main.c
@@ -31,6 +31,7 @@
 #include "layouts/key_layout_60_to_universal.h"
 #include "power_mode.h"
 #include "usb_protocol_handler.h"
+#include "event_scheduler.h"
 
 static bool IsEepromInitialized = false;
 static bool IsConfigInitialized = false;
@@ -63,6 +64,7 @@ static void initConfig()
             ShortcutParser_initialize();
             KeyIdParser_initialize();
             Macros_Initialize();
+            EventVector_Init();
             IsConfigInitialized = true;
         } else {
             __WFI();

--- a/right/src/usb_commands/usb_command_get_device_state.c
+++ b/right/src/usb_commands/usb_command_get_device_state.c
@@ -49,5 +49,6 @@ void UsbCommand_GetKeyboardState(const uint8_t *GenericHidOutBuffer, uint8_t *Ge
     SetUsbTxBufferUint8(6, ActiveLayer | (ActiveLayer != LayerId_Base && !ActiveLayerHeld ? (1 << 7) : 0) ); // Active layer + most significant bit if layer is toggled
     SetUsbTxBufferUint8(7, Macros_ConsumeStatusCharDirtyFlag);
     SetUsbTxBufferUint8(8, CurrentKeymapIndex);
+
     LastUsbGetKeyboardStateRequestTimestamp = CurrentTime;
 }


### PR DESCRIPTION
Closes #1072.

(I have also noticed some issues with uhk80 led display timeout. This might be fixing that too.)