### PR TITLE
TEST: use 6KRO mode by default

### DIFF
--- a/device/src/usb/keyboard_app.hpp
+++ b/device/src/usb/keyboard_app.hpp
@@ -134,7 +134,7 @@ class keyboard_app : public app_base {
 
     C2USB_USB_TRANSFER_ALIGN(leds_report, leds_buffer_) {};
     hid::protocol prot_{};
-    rollover rollover_{};
+    rollover rollover_{rollover::SIX_KEY};
     rollover rollover_override_{};
     union keys_reports {
         keys_nkro_report nkro{};


### PR DESCRIPTION
Use the generated firmware for evaluating #1143 