### PR TITLE
Fix macro name corruption caused by buffer shifts (when new cfg is saved).

### DIFF
--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -276,6 +276,7 @@ COMMAND = statsPostponerStack
 COMMAND = statsActiveKeys
 COMMAND = statsActiveMacros
 COMMAND = statsRecordKeyTiming
+COMMAND = statsVariables
 COMMAND = diagnose
 COMMAND = setStatus STRING
 COMMAND = clearStatus

--- a/right/src/config_parser/parse_config.c
+++ b/right/src/config_parser/parse_config.c
@@ -26,6 +26,7 @@
 #include "error_reporting.h"
 #include "versioning.h"
 #include "stubs.h"
+#include "macros/vars.h"
 
 #if DEVICE_HAS_OLED
 #include "keyboard/oled/widgets/widgets.h"
@@ -346,6 +347,7 @@ parser_error_t parseConfig(config_buffer_t *buffer)
         LedManager_UpdateSleepModes();
         BtPair_ClearUnknownBonds();
         BtConn_UpdateHostConnectionPeerAllocations();
+        MacroVariables_Reset();
         WIDGET_REFRESH(&TargetWidget); // the target may have been renamed
 
         // Update counts

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -2355,6 +2355,9 @@ static macro_result_t processCommand(parser_context_t* ctx)
             else if (ConsumeToken(ctx, "statsPostponerStack")) {
                 return Macros_ProcessStatsPostponerStackCommand();
             }
+            else if (ConsumeToken(ctx, "statsVariables")) {
+                return Macros_ProcessStatsVariablesCommand();
+            }
             else if (ConsumeToken(ctx, "switchKeymap")) {
                 return processSwitchKeymapCommand(ctx);
             }

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -2,6 +2,7 @@
 #include "macros/string_reader.h"
 #include "postponer.h"
 #include "macros/keyid_parser.h"
+#include "typedefs.h"
 #include "utils.h"
 #include "str_utils.h"
 #include "macros/core.h"
@@ -12,6 +13,7 @@
 #include "debug.h"
 #include "macros/set_command.h"
 #include "config_manager.h"
+#include "str_utils.h"
 
 #if !defined(MAX)
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
@@ -48,6 +50,19 @@ static macro_variable_t consumeValue(parser_context_t* ctx);
 static macro_variable_t negate(parser_context_t *ctx, macro_variable_t res);
 static macro_variable_t consumeMinMaxOperation(parser_context_t* ctx, operator_t op);
 static macro_variable_t negateBool(parser_context_t *ctx, macro_variable_t res);
+
+macro_result_t Macros_ProcessStatsVariablesCommand(void) {
+    if (Macros_DryRun) {
+        return MacroResult_Finished;
+    }
+
+    PRINTM("Variables:");
+    for (uint8_t i = 0; i < macroVariableCount; i++) {
+        PRINTM("  %.*s: %d", EXPAND_REF(macroVariables[i].name), macroVariables[i].asInt);
+    }
+
+    return MacroResult_Finished;
+}
 
 static macro_variable_t intVar(int32_t value)
 {
@@ -838,6 +853,10 @@ ATTR_UNUSED static void test(const char* command, macro_variable_t expectedResul
         LogU("  Test succes: '%s': %s\n", command, comment);
     }
 #endif
+}
+
+void MacroVariables_Reset(void) {
+    macroVariableCount = 0;
 }
 
 

--- a/right/src/macros/vars.h
+++ b/right/src/macros/vars.h
@@ -41,6 +41,8 @@
 
 // Functions:
 
+    void MacroVariables_Reset(void);
+    macro_result_t Macros_ProcessStatsVariablesCommand(void);
     macro_result_t Macros_ProcessSetVarCommand(parser_context_t* ctx);
     macro_variable_t* Macros_ConsumeExistingWritableVariable(parser_context_t* ctx);
     int32_t Macros_ConsumeInt(parser_context_t* ctx);

--- a/right/src/str_utils.h
+++ b/right/src/str_utils.h
@@ -19,6 +19,7 @@
 // Macros:
 
     #define EXPAND_SEGMENT(SEGMENT) SegmentLen(SEGMENT), SEGMENT.start
+    #define EXPAND_REF(REF) REF.len, (const char*)ValidatedUserConfigBuffer.buffer + REF.offset
 
 // Typedefs:
 


### PR DESCRIPTION
Steps to reproduce.
- create some variables (save & run the macro):
```
setVar test1 1
setVar test2 2
setVar test3 3
setVar test4 4
setVar test5 5
```
- run `statsVariables`
- induce a shift in UserConfig: e.g., add some characters to some host connection name, and save the config
- run the variable macro again
- run `statsVariables`
- observe that five new variables were allocated while the previous five's names are garbled.

Closes #1193, #1195. (Maybe also some older ones.)