### PR TITLE
Ble icon updates

### DIFF
--- a/device/src/bt_advertise.c
+++ b/device/src/bt_advertise.c
@@ -108,6 +108,10 @@ static void updateAdvertisingIcon(bool newAdvertising) {
     }
 }
 
+void BtAdvertise_DisableAdvertisingIcon(void) {
+    updateAdvertisingIcon(false);
+}
+
 uint8_t BtAdvertise_Start(adv_config_t advConfig)
 {
     int err = 0;

--- a/device/src/bt_advertise.h
+++ b/device/src/bt_advertise.h
@@ -27,6 +27,7 @@
 
 // Functions:
 
+    void BtAdvertise_DisableAdvertisingIcon(void);
     uint8_t BtAdvertise_Start(adv_config_t advConfig);
     void BtAdvertise_Stop(void);
     adv_config_t BtAdvertise_Config();

--- a/device/src/bt_manager.c
+++ b/device/src/bt_manager.c
@@ -72,6 +72,8 @@ void BtManager_StopBt() {
     if (DEVICE_IS_UHK80_RIGHT || DEVICE_IS_UHK_DONGLE) {
         BtScan_Stop();
     }
+
+    BtAdvertise_DisableAdvertisingIcon();
 }
 
 
@@ -142,6 +144,7 @@ void BtManager_StartScanningAndAdvertising() {
     if (shouldScan) {
         err = BtScan_Start();
         success &= err == 0;
+        BtAdvertise_DisableAdvertisingIcon();
     }
 #endif
 

--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -341,8 +341,8 @@ COMMAND = setEmergencyKey KEYID
 - `bluetooth [toggle] { pair | advertise | noAdvertise }` controls advertising for hid devices - this doesn't affect dongle and left half advertising.
   - `pair` will start pairing mode. The device will be discoverable for 2 minutes, and will refuse connections from all known devices so that it is possible to pair a new device.
   - `advertise` will make the device discoverable for 2 minutes. This allows ble hid devices to either connect or pair.
-  - `noAdvertise` will return the normal operation mode (depends on bluetooth.alwaysAdvertiseHid). 
-  - `toggle` will make keyboard enter the default mode if the supplied mode is active. This doesn't disable advertisement if bluetooth.alwaysAdvertiseHid is set to true. 
+  - `noAdvertise` will disable alwaysAdvertiseHid and stop advertising.
+  - `toggle` will make keyboard enter the default mode if the supplied mode is active.
 - `switchHost { last | next | previous | <host connection name (IDENTIFIER)> | <host connection name (STRING)> }` switches the host connection. 
   - `previous | next` switch to the next currently connected host in the list of hosts. E.g., this iterates over blue dongles, as well as some other connections.
   - `last` switches to the previously active host connection. For instance the last in `switchHost "pc"; switchHost "laptop"; switchHost last` switches to "pc".

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -741,6 +741,9 @@ static macro_result_t processBluetoothCommand(parser_context_t *ctx)
         return MacroResult_Finished;
     }
 
+    if (mode == PairingMode_Off) {
+        Cfg.Bt_AlwaysAdvertiseHid = false;
+    }
 #ifdef __ZEPHYR__
     BtManager_EnterMode(mode, toggle);
 #endif

--- a/right/src/stubs.c
+++ b/right/src/stubs.c
@@ -33,3 +33,4 @@
     ATTRS void StateSync_CheckDongleProtocolVersion() {};
     ATTRS void Trace(char a) {};
     ATTRS void Trace_Printf(const char *fmt, ...) {};
+    ATTRS void BtAdvertise_DisableAdvertisingIcon(void) {};

--- a/right/src/stubs.h
+++ b/right/src/stubs.h
@@ -53,6 +53,7 @@
     extern void StateSync_CheckDongleProtocolVersion();
     extern void Trace(char a);
     extern void Trace_Printf(const char *fmt, ...);
+    extern void BtAdvertise_DisableAdvertisingIcon(void);
 
 #if DEVICE_HAS_OLED
 #define WIDGET_REFRESH(W) Widget_Refresh(W)


### PR DESCRIPTION
- Fix ble advertising icon updates when bluetooth is disabled.
- Make `bluetooth noAdvertise` disable `bluetooth.alwaysAdvertiseHid`.

Reported in https://forum.ultimatehackingkeyboard.com/t/how-to-properly-disable-bluetooth-while-connected-via-usb/2238/14