### PR TITLE
Fix warnings on switchHost macros with uhk60.

### DIFF
--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1807,6 +1807,8 @@ static macro_result_t processSwitchHostCommand(parser_context_t* ctx)
         }
         Macros_ConsumeStringToken(ctx);
     }
+#else
+    Macros_ConsumeStringToken(ctx);
 #endif
 
 #undef DRY_RUN_FINISH


### PR DESCRIPTION
Reported in https://forum.ultimatehackingkeyboard.com/t/agent-and-firmware-for-uhk60/2271/4

Steps to reproduce: 
- create a `switchHost "abc"` macro and save the config to uhk60.
- yellow bar pops up with a warning due to macro validation