### PR TITLE
Fix layer stack reset

### DIFF
--- a/device/src/messenger_queue.c
+++ b/device/src/messenger_queue.c
@@ -116,7 +116,7 @@ uint8_t* MessengerQueue_AllocateMemory() {
     }
     ThreadStats_Snap();
     Trace_Printf("E0");
-    Trace_Print();
+    Trace_Print("Messenger pool space ran out!");
     ThreadStats_Print();
     LogUOS("Messenger message pool space ran out!\n");
     return blackholeBuffer;

--- a/device/src/shell.c
+++ b/device/src/shell.c
@@ -184,7 +184,7 @@ static int cmd_uhk_threads(const struct shell *shell, size_t argc, char *argv[])
 
 static int cmd_uhk_trace(const struct shell *shell, size_t argc, char *argv[])
 {
-    Trace_Print();
+    Trace_Print("Triggered by zephyr shell.");
     return 0;
 }
 

--- a/right/src/keymap.c
+++ b/right/src/keymap.c
@@ -11,6 +11,7 @@
 #include "macros/core.h"
 #include "macro_events.h"
 #include "segment_display.h"
+#include "layer_stack.h"
 #include "debug.h"
 #include "slave_drivers/uhk_module_driver.h"
 
@@ -32,7 +33,7 @@ uint8_t AllKeymapsCount;
 uint8_t DefaultKeymapIndex;
 uint8_t CurrentKeymapIndex = 0;
 
-void SwitchKeymapById(uint8_t index)
+void SwitchKeymapById(uint8_t index, bool resetLayerStack)
 {
     parse_config_t parseConfig = (parse_config_t) {
         .mode = ParserRunDry ? ParseKeymapMode_DryRun : ParseKeymapMode_FullRun
@@ -50,6 +51,9 @@ void SwitchKeymapById(uint8_t index)
         MacroEvent_OnKeymapChange(index);
         MacroEvent_OnLayerChange(ActiveLayer);
     }
+    if (resetLayerStack) {
+        LayerStack_Reset();
+    }
     EventVector_Set(EventVector_LedMapUpdateNeeded);
     EventVector_Unset(EventVector_KeymapReloadNeeded);
 }
@@ -64,12 +68,12 @@ uint8_t FindKeymapByAbbreviation(uint8_t length, const char *abbrev) {
     return 0xFF;
 }
 
-bool SwitchKeymapByAbbreviation(uint8_t length, const char *abbrev)
+bool SwitchKeymapByAbbreviation(uint8_t length, const char *abbrev, bool resetLayerStack)
 {
     uint8_t keymapId = FindKeymapByAbbreviation(length, abbrev);
 
     if (keymapId != 0xFF) {
-        SwitchKeymapById(keymapId);
+        SwitchKeymapById(keymapId, resetLayerStack);
         return true;
     } else {
         return false;

--- a/right/src/keymap.h
+++ b/right/src/keymap.h
@@ -30,8 +30,8 @@
 
 // Functions:
 
-    void SwitchKeymapById(uint8_t index);
-    bool SwitchKeymapByAbbreviation(uint8_t length, const char *abbrev);
+    void SwitchKeymapById(uint8_t index, bool resetLayerStack);
+    bool SwitchKeymapByAbbreviation(uint8_t length, const char *abbrev, bool resetLayerStack);
     uint8_t FindKeymapByAbbreviation(uint8_t length, const char *abbrev);
 
     string_segment_t GetKeymapName(uint8_t keymapId);

--- a/right/src/layer_stack.c
+++ b/right/src/layer_stack.c
@@ -89,7 +89,7 @@ void LayerStack_Pop(bool forceRemoveTop, bool toggledInsteadOfTop)
         LayerStack_Reset();
     }
     if (LayerStack[LayerStack_TopIdx].keymap != CurrentKeymapIndex) {
-        SwitchKeymapById(LayerStack[LayerStack_TopIdx].keymap);
+        SwitchKeymapById(LayerStack[LayerStack_TopIdx].keymap, false);
     }
     activateLayer(LayerStack[LayerStack_TopIdx].layer);
 }
@@ -115,7 +115,7 @@ void LayerStack_Push(uint8_t layer, uint8_t keymap, bool hold)
     LayerStack[LayerStack_TopIdx].removed = false;
     LayerStack_Size = LayerStack_Size < LAYER_STACK_SIZE - 1 ? LayerStack_Size+1 : LayerStack_Size;
     if (keymap != CurrentKeymapIndex) {
-        SwitchKeymapById(keymap);
+        SwitchKeymapById(keymap, false);
     }
     activateLayer(LayerStack[LayerStack_TopIdx].layer);
 }

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -2406,7 +2406,7 @@ static macro_result_t processCommand(parser_context_t* ctx)
                 return Macros_ProcessTapKeySeqCommand(ctx);
             }
             else if (ConsumeToken(ctx, "trace")) {
-                Trace_Print();
+                Trace_Print("Triggered by macro command");
                 return MacroResult_Finished;
             }
             else {

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -309,8 +309,7 @@ static macro_result_t processSwitchKeymapCommand(parser_context_t* ctx)
             return MacroResult_Finished;
         }
 
-        SwitchKeymapById(newKeymapIdx);
-        LayerStack_Reset();
+        SwitchKeymapById(newKeymapIdx, true);
     }
     lastKeymapIdx = tmpKeymapIdx;
     return MacroResult_Finished;

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -2405,7 +2405,9 @@ static macro_result_t processCommand(parser_context_t* ctx)
                 return Macros_ProcessTapKeySeqCommand(ctx);
             }
             else if (ConsumeToken(ctx, "trace")) {
-                Trace_Print("Triggered by macro command");
+                if (!Macros_DryRun) {
+                    Trace_Print("Triggered by macro command");
+                }
                 return MacroResult_Finished;
             }
             else {

--- a/right/src/main.c
+++ b/right/src/main.c
@@ -142,7 +142,7 @@ int main(void)
         if (!StateWormhole.wasReboot) {
             StateWormhole.persistStatusBuffer = true;
             MacroStatusBuffer_InitFromWormhole();
-            Trace_Print();
+            Trace_Print("Looks like your uhk60 crashed.");
         }
         StateWormhole_Clean();
     } else {

--- a/right/src/trace.c
+++ b/right/src/trace.c
@@ -57,10 +57,11 @@ void Trace_Init(void) {
     Trace_Printf("###");
 }
 
-void Trace_Print(void) {
+void Trace_Print(const char* reason) {
     uint16_t iter;
     enabled = false;
 
+    Macros_ReportPrintf("Printing trace buffer because: %s\n", reason);
     Macros_ReportPrintf("Last EV: %d\n", StateWormhole.traceBuffer.eventVector);
     Macros_ReportPrintf("Trace:\n");
 

--- a/right/src/trace.h
+++ b/right/src/trace.h
@@ -25,7 +25,7 @@
 
     void Trace_Init(void);
     void Trace(char a);
-    void Trace_Print(void);
+    void Trace_Print(const char* reason);
     void Trace_Printf(const char *fmt, ...);
 
 #endif

--- a/right/src/usb_commands/usb_command_apply_config.c
+++ b/right/src/usb_commands/usb_command_apply_config.c
@@ -146,11 +146,11 @@ uint8_t UsbCommand_ApplyConfig(const uint8_t *GenericHidOutBuffer, uint8_t *Gene
 #endif
 
     // Switch to the keymap of the updated configuration of the same name or the default keymap.
-    if (SwitchKeymapByAbbreviation(oldKeymapAbbreviationLen, oldKeymapAbbreviation)) {
+    if (SwitchKeymapByAbbreviation(oldKeymapAbbreviationLen, oldKeymapAbbreviation, true)) {
         return UsbStatusCode_Success;
     }
 
-    SwitchKeymapById(DefaultKeymapIndex);
+    SwitchKeymapById(DefaultKeymapIndex, true);
     isBoot = false;
 
     return UsbStatusCode_Success;

--- a/right/src/usb_commands/usb_command_switch_keymap.c
+++ b/right/src/usb_commands/usb_command_switch_keymap.c
@@ -12,8 +12,7 @@ void UsbCommand_SwitchKeymap(const uint8_t *GenericHidOutBuffer, uint8_t *Generi
         SetUsbTxBufferUint8(0, UsbStatusCode_SwitchKeymap_InvalidAbbreviationLength);
     }
 
-    uint8_t res = SwitchKeymapByAbbreviation(keymapLength, keymapAbbrev);
-    LayerStack_Reset();
+    uint8_t res = SwitchKeymapByAbbreviation(keymapLength, keymapAbbrev, true);
 
     if (!res) {
         SetUsbTxBufferUint8(0, UsbStatusCode_SwitchKeymap_InvalidAbbreviation);

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -414,8 +414,7 @@ void ApplyKeyAction(key_state_t *keyState, key_action_cached_t *cachedAction, ke
         case KeyActionType_SwitchKeymap:
             if (KeyState_ActivatedNow(keyState)) {
                 resetStickyMods(cachedAction);
-                SwitchKeymapById(action->switchKeymap.keymapId);
-                LayerStack_Reset();
+                SwitchKeymapById(action->switchKeymap.keymapId, true);
             }
             break;
         case KeyActionType_PlayMacro:

--- a/right/src/user_logic.c
+++ b/right/src/user_logic.c
@@ -1,5 +1,6 @@
 #include "user_logic.h"
 #include "keymap.h"
+#include "layer_stack.h"
 #include "ledmap.h"
 #include "slave_drivers/is31fl3xxx_driver.h"
 #include "slave_drivers/uhk_module_driver.h"
@@ -25,7 +26,7 @@ void RunUserLogic(void) {
     }
     if (EventVector_IsSet(EventVector_KeymapReloadNeeded)) {
         Trace_Printf("l2");
-        SwitchKeymapById(CurrentKeymapIndex);
+        SwitchKeymapById(CurrentKeymapIndex, true);
     }
 #ifndef __ZEPHYR__
     if (EventVector_IsSet(EventVector_ProtocolChanged)) {


### PR DESCRIPTION
Closes [#2620](https://github.com/UltimateHackingKeyboard/agent/issues/2620#issuecomment-2840547847).

Reproduction instructions:
- Take a low integer keymapIdx, that corresponds to your favorite keymap in your standard UserConfig.
- Prepare a User config that contains less keymaps than keymapIdx. (I.e., keymap keymapIdx doesn't exist in it.)
- Save your standard UserConfig to your UHK (if it isn't already).
- Switch to your favorite keymap whose index is keymapIdx.
- Import and save the other prepared user config
- Tap a hold layer switcher
