### PR TITLE
Prevent bricking due to boot loops.

### DIFF
--- a/device/src/main.c
+++ b/device/src/main.c
@@ -127,7 +127,6 @@ void mainRuntime(void) {
     }
 
     if (!DEVICE_IS_UHK_DONGLE) {
-        InitUart();
         InitZephyrI2c();
         InitSpi();
 
@@ -182,6 +181,17 @@ void mainRuntime(void) {
     HID_SetGamepadActive(false);
     USB_Enable(); // has to be after USB_SetSerialNumber
 
+    if (LastRunWasCrash) {
+        printk("CRASH DETECTED, waiting for 5 seconds to allow Agent to reenumerate\n");
+        k_sleep(K_MSEC(5*1000));
+    }
+
+    // Uart has to be enabled only after we have given Agent a chance to reenumarate into bootloader after a crash
+    if (!DEVICE_IS_UHK_DONGLE) {
+        InitUart();
+    }
+
+    // Uart has to be enabled only after we have given Agent a chance to reenumarate into bootloader after a crash
     // has to be after InitSettings
     BtManager_InitBt();
     BtManager_StartBt();

--- a/right/src/macros/status_buffer.c
+++ b/right/src/macros/status_buffer.c
@@ -29,6 +29,8 @@ static uint16_t consumeStatusCharReadingPos = 0;
 bool Macros_ConsumeStatusCharDirtyFlag = false;
 bool Macros_StatusBufferError = false;
 
+bool LastRunWasCrash = false;
+
 #define Buf StateWormhole.statusBuffer
 
 static void updateErrorIndicator(bool newValue) {
@@ -390,6 +392,7 @@ void MacroStatusBuffer_InitFromWormhole() {
     containsWormholeData = looksValid && StateWormhole.persistStatusBuffer;
 
     if (containsWormholeData) {
+        LastRunWasCrash = true;
         indicateError();
     } else {
         Macros_ProcessClearStatusCommand(true);

--- a/right/src/macros/status_buffer.h
+++ b/right/src/macros/status_buffer.h
@@ -24,6 +24,7 @@
 //
     extern bool Macros_ConsumeStatusCharDirtyFlag;
     extern bool Macros_StatusBufferError;
+    extern bool LastRunWasCrash;
 
 // Functions:
 

--- a/right/src/main.c
+++ b/right/src/main.c
@@ -143,6 +143,7 @@ int main(void)
             StateWormhole.persistStatusBuffer = true;
             MacroStatusBuffer_InitFromWormhole();
             Trace_Print("Looks like your uhk60 crashed.");
+            LastRunWasCrash = true;
         }
         StateWormhole_Clean();
     } else {


### PR DESCRIPTION
Testing firmware (its left half keeps crashing): 
[uhk-firmware-14.0.0-left_crash_loop1.1.tar.gz](https://github.com/user-attachments/files/20350752/uhk-firmware-14.0.0-left_crash_loop1.1.tar.gz)

Testing:
- flash the testing firmware from Agent
- observe that left half keeps crashing (it goes out every 5 seconds; yes, it is slower than before, because now it waits before allowing connections from outside)
- flash any firmware from Agent (it doesn't matter which; the crashing firmware is the one that is "fixed").
