### PR TITLE
Fix key equality

### DIFF
--- a/right/src/macro_events.c
+++ b/right/src/macro_events.c
@@ -50,7 +50,7 @@ void MacroEvent_OnInit()
     const char* name = "$onInit";
     uint8_t idx = FindMacroIndexByName(name, name + strlen(name), false);
     if (idx != 255) {
-        previousEventMacroSlot = Macros_StartMacro(idx, NULL, 255, false);
+        previousEventMacroSlot = Macros_StartMacro(idx, NULL, 255, 255, false);
     }
 
     registerKeyboardStates();
@@ -60,9 +60,9 @@ void MacroEvent_OnInit()
 static void startMacroInSlot(macro_index_t macroIndex, uint8_t* slotId) {
     if (macroIndex != MacroIndex_None) {
         if (*slotId != 255 && MacroState[*slotId].ms.macroPlaying) {
-            *slotId = Macros_QueueMacro(macroIndex, NULL, *slotId);
+            *slotId = Macros_QueueMacro(macroIndex, NULL, 255, *slotId);
         } else {
-            *slotId = Macros_StartMacro(macroIndex, NULL, 255, false);
+            *slotId = Macros_StartMacro(macroIndex, NULL, 255, 255, false);
         }
     }
 }

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1327,7 +1327,7 @@ static macro_result_t processOneShotCommand(parser_context_t* ctx) {
      * */
     if (!S->ms.macroInterrupted || !S->ms.oneShotUsbChangeDetected) {
         S->ms.oneShotState = 1;
-    } else if (S->ms.oneShotState < 3) {
+    } else if (0 < S->ms.oneShotState && S->ms.oneShotState < 3) {
         S->ms.oneShotState++;
     } else {
         S->ms.oneShotState = 0;

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -109,11 +109,13 @@ bool Macros_CurrentMacroKeyIsActive()
         return S->ms.oneShotState;
     }
     if (S->ms.postponeNextNCommands > 0 || S->ls->as.modifierPostpone) {
+        bool isSameActivation = (S->ms.currentMacroKey->timestamp == S->ms.currentMacroKeyStamp);
         bool keyIsActive = (KeyState_Active(S->ms.currentMacroKey) && !PostponerQuery_IsKeyReleased(S->ms.currentMacroKey));
-        return  keyIsActive || S->ms.oneShotState;
+        return  (isSameActivation && keyIsActive) || S->ms.oneShotState;
     } else {
+        bool isSameActivation = (S->ms.currentMacroKey->timestamp == S->ms.currentMacroKeyStamp);
         bool keyIsActive = KeyState_Active(S->ms.currentMacroKey);
-        return keyIsActive || S->ms.oneShotState;
+        return (isSameActivation && keyIsActive) || S->ms.oneShotState;
     }
 }
 

--- a/right/src/macros/core.h
+++ b/right/src/macros/core.h
@@ -147,6 +147,7 @@
             uint32_t currentMacroStartTime;
             uint16_t currentMacroActionIndex;
             uint16_t bufferOffset;
+            uint8_t currentMacroKeyStamp;
             uint8_t parentMacroSlot;
             uint8_t currentMacroIndex;
             uint8_t postponeNextNCommands;
@@ -271,8 +272,8 @@
     macro_result_t Macros_SleepTillKeystateChange();
     macro_result_t Macros_SleepTillTime(uint32_t time, const char* reason);
     uint8_t Macros_ConsumeLayerId(parser_context_t* ctx);
-    uint8_t Macros_QueueMacro(uint8_t index, key_state_t *keyState, uint8_t queueAfterSlot);
-    uint8_t Macros_StartMacro(uint8_t index, key_state_t *keyState, uint8_t parentMacroSlot, bool runFirstAction);
+    uint8_t Macros_QueueMacro(uint8_t index, key_state_t *keyState, uint8_t timestamp, uint8_t queueAfterSlot);
+    uint8_t Macros_StartMacro(uint8_t index, key_state_t *keyState, uint8_t timestamp, uint8_t parentMacroSlot, bool runFirstAction);
     uint8_t Macros_TryConsumeKeyId(parser_context_t* ctx);
     void Macros_ContinueMacro(void);
     void Macros_Initialize();

--- a/right/src/usb_commands/usb_command_exec_macro_command.c
+++ b/right/src/usb_commands/usb_command_exec_macro_command.c
@@ -37,7 +37,7 @@ static bool canExecute()
 
 void UsbMacroCommand_ExecuteSynchronously()
 {
-    Macros_StartMacro(MacroIndex_UsbCmdReserved, &dummyState, MacroIndex_None, false);
+    Macros_StartMacro(MacroIndex_UsbCmdReserved, &dummyState, 255, MacroIndex_None, false);
     EventVector_Unset(EventVector_UsbMacroCommandWaitingForExecution);
 }
 


### PR DESCRIPTION
Closes https://github.com/UltimateHackingKeyboard/firmware/issues/807 .

Steps to reproduce:
- Bind this on your mod+f:
```
set oneShotTimeout 0
oneShot holdKey iLS-
```
- focus text editor
- tap mod+f
- tap f
- expected result: "F" appears
- tap f again
- expected result: "f"
- actual: "F"

This may also affect behavior of quite a few other commands, since part of the fix is significantly more general.p