### PR TITLE
Fix flash write race.

### DIFF
--- a/device/src/main.c
+++ b/device/src/main.c
@@ -166,7 +166,7 @@ void mainRuntime(void) {
             Flash_ReadAreaSync(userConfigArea, 0, StagingUserConfigBuffer.buffer, USER_CONFIG_SIZE);
             printk("Applying user config\n");
             bool factoryMode = false;
-            if (factoryMode || UsbCommand_ApplyConfig(NULL, NULL) != UsbStatusCode_Success) {
+            if (factoryMode || UsbCommand_ValidateAndApplyConfigSync(NULL, NULL) != UsbStatusCode_Success) {
                 UsbCommand_ApplyFactory(NULL, NULL);
             }
             printk("User config applied\n");

--- a/right/src/main.c
+++ b/right/src/main.c
@@ -59,7 +59,7 @@ static void initConfig()
     while (!IsConfigInitialized) {
         if (IsEepromInitialized) {
 
-            if (IsFactoryResetModeEnabled || UsbCommand_ApplyConfig(NULL, NULL) != UsbStatusCode_Success) {
+            if (IsFactoryResetModeEnabled || UsbCommand_ValidateAndApplyConfigSync(NULL, NULL) != UsbStatusCode_Success) {
                 UsbCommand_ApplyFactory(NULL, NULL);
             }
             ShortcutParser_initialize();

--- a/right/src/usb_commands/usb_command_apply_config.h
+++ b/right/src/usb_commands/usb_command_apply_config.h
@@ -15,8 +15,9 @@
 
 // Functions:
 
-    uint8_t UsbCommand_ApplyConfig(const uint8_t *GenericHidOutBuffer, uint8_t *GenericHidInBuffer);
     void UsbCommand_ApplyFactory(const uint8_t *GenericHidOutBuffer, uint8_t *GenericHidInBuffer);
-    void UsbCommand_ApplyConfigAsync(const uint8_t *GenericHidOutBuffer, uint8_t *GenericHidInBuffer);
+    uint8_t UsbCommand_ApplyConfigSync(const uint8_t *GenericHidOutBuffer, uint8_t *GenericHidInBuffer);
+    uint8_t UsbCommand_ValidateAndApplyConfigSync(const uint8_t *GenericHidOutBuffer, uint8_t *GenericHidInBuffer);
+    uint8_t UsbCommand_ValidateAndApplyConfigAsync(const uint8_t *GenericHidOutBuffer, uint8_t *GenericHidInBuffer);
 
 #endif

--- a/right/src/usb_commands/usb_command_launch_storage_transfer.h
+++ b/right/src/usb_commands/usb_command_launch_storage_transfer.h
@@ -11,6 +11,7 @@
         UsbStatusCode_LaunchStorageTransferInvalidStorageOperation = 2,
         UsbStatusCode_LaunchStorageTransferInvalidConfigBufferId = 3,
         UsbStatusCode_LaunchStorageTransferTransferError = 4,
+        UsbStatusCode_LaunchStorageTransferInvalidConfigBuffer = 5,
     } usb_status_code_launch_storage_transfer_t;
 
 // Functions:

--- a/right/src/usb_commands/usb_command_write_config.c
+++ b/right/src/usb_commands/usb_command_write_config.c
@@ -17,7 +17,8 @@ void UsbCommand_WriteConfig(config_buffer_id_t configBufferId, const uint8_t *Ge
         return;
     }
 
-    uint8_t *buffer = ConfigBufferIdToConfigBuffer(configBufferId)->buffer;
+    config_buffer_t* bufferHead = ConfigBufferIdToConfigBuffer(configBufferId);
+    uint8_t *buffer = bufferHead->buffer;
     uint16_t bufferLength = ConfigBufferIdToBufferSize(configBufferId);
 
     if (offset + length > bufferLength) {
@@ -25,5 +26,6 @@ void UsbCommand_WriteConfig(config_buffer_id_t configBufferId, const uint8_t *Ge
         return;
     }
 
+    bufferHead->isValid = false;
     memcpy(buffer + offset, GenericHidOutBuffer + paramsSize, length);
 }

--- a/right/src/usb_protocol_handler.c
+++ b/right/src/usb_protocol_handler.c
@@ -1,4 +1,5 @@
 #include <strings.h>
+#include "config_parser/config_globals.h"
 #include "macros/status_buffer.h"
 #include "usb_protocol_handler.h"
 #include "usb_commands/usb_command_get_device_state.h"
@@ -53,9 +54,9 @@ void UsbProtocolHandler(const uint8_t *GenericHidOutBuffer, uint8_t *GenericHidI
         case UsbCommandId_ApplyConfig:
 
 #ifdef __ZEPHYR__
-            UsbCommand_ApplyConfigAsync(GenericHidOutBuffer, GenericHidInBuffer);
+            UsbCommand_ValidateAndApplyConfigAsync(GenericHidOutBuffer, GenericHidInBuffer);
 #else
-            UsbCommand_ApplyConfig(GenericHidOutBuffer, GenericHidInBuffer);
+            UsbCommand_ValidateAndApplyConfigSync(GenericHidOutBuffer, GenericHidInBuffer);
 #endif
             break;
         case UsbCommandId_GetDeviceState:

--- a/right/src/user_logic.c
+++ b/right/src/user_logic.c
@@ -24,7 +24,7 @@ uint32_t UserLogic_LastEventloopTime = 0;
 void RunUserLogic(void) {
     if (EventVector_IsSet(EventVector_ApplyConfig)) {
         Trace_Printc("l1");
-        UsbCommand_ApplyConfig(NULL, NULL);
+        UsbCommand_ApplyConfigSync(NULL, NULL);
     }
     if (EventVector_IsSet(EventVector_KeymapReloadNeeded)) {
         Trace_Printc("l2");


### PR DESCRIPTION
Closes https://github.com/UltimateHackingKeyboard/firmware/issues/1249 . 

Original writing sequence:
- load new config into staging area via usb
- apply the config:
  - parse the config in dry run mode
  - if this succeeds, swap the buffers
  - parse it again, but this time actually apply it
  - execute effects 
- launch storage transfers

Issues with the above:
- c2usb has small stack. This used to cause stack overflows on uhk80.
- we don't want to trigger all the application effects from an interrupt.

As a result I had decided to make the application asynchronous and execute it from the main thread. 

So the new uhk 80 sequence up until now was: 
- load new config into staging area via usb
- apply the config usb command:
  - validate config in dry run mode
  - if it succeeds, return success
  - schedule application for the main thread
- from the main thread: 
  - validate the config again
  - if this succeeds, swap the buffers
  - parse it again, but this time actually apply it
  - execute effects 
- launch storage transfers

This now leads to a race on these two events: 
- write validated buffer to flash
- swap the buffers