### PR TITLE
Add persistent macro usb reports, toggleKey command and persistent arg.

### DIFF
--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -374,7 +374,7 @@ COMMAND = setEmergencyKey KEYID
   - **tap** means pressing a key (more precisely, activating the scancode) and immediately releasing it again
   - **hold** means pressing the key, waiting until the key which activated the macro is released, and then releasing the key again. I.e., `holdKey <x>` is equivalent to `pressKey <x>; delayUntilRelease; releaseKey <x>`, while `tapKey <x>` is equivalent to `pressKey <x>; releaseKey <x>`.
   - **toggle** will check if the shortcut is pressed in this macro's reports. If it is, it will deactivate the shortcut, otherwise it will activate it. This always acts on persistent reports.
-  - **persistent** argument will global reports. These reports can be accessed from any macro and will not be cleared when the macro ends. This is useful for long-term key toggling. E.g., `toggleKey persistent LS` acts similar to caps lock.
+  - **persistent** argument will use global reports. These reports can be accessed from any macro and will not be cleared when the macro ends. This is useful for long-term key toggling. E.g., `toggleKey persistent LS` acts similar to caps lock.
   - `tapKeySeq` can be used for executing custom sequences. The default action for each shortcut in the sequence is tap. Other actions can be specified using `MODMASK`. E.g.:
     - `CS-u 1 2 3 space` - control shift U + number + space - linux shortcut for a custom unicode character.
     - `pA- tab tab rA-` - tap alt tab twice to bring forward the second background window.

--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -112,8 +112,8 @@ COMMAND = {stopRecording | stopRecordingBlind}
 COMMAND = playMacro [<slot identifier (MACROID)>]
 COMMAND = {startMouse|stopMouse} {move DIRECTION|scroll DIRECTION|accelerate|decelerate}
 COMMAND = setVar <variable name (IDENTIFIER)> <value (PARENTHESSED_EXPRESSION)>
-COMMAND = {pressKey|holdKey|tapKey|releaseKey} SHORTCUT
-COMMAND = tapKeySeq [SHORTCUT]+
+COMMAND = {pressKey|holdKey|tapKey|releaseKey|toggleKey} [persistent] SHORTCUT
+COMMAND = tapKeySeq [persistent] [SHORTCUT]+
 COMMAND = powerMode [toggle] { wake | lock | sleep }
 COMMAND = reboot
 COMMAND = bluetooth [toggle] { pair | advertise | noAdvertise }
@@ -368,11 +368,13 @@ COMMAND = setEmergencyKey KEYID
 
 - `write <custom text>` will type the provided string. Strings are single quote- (for literal strings) or double quote- (for interpolated strings) enclosed. E.g., `write "keystrokeDelay is $keystrokeDelay, 1+1=$(1+1)\n"`, or `'$ will show as literal dollar sign.'`.
 - `startMouse/stopMouse` start/stop corresponding mouse action. E.g., `startMouse move left`
-- `pressKey|holdKey|tapKey|releaseKey` Presses/holds/taps/releases the provided scancode. E.g., `pressKey mouseBtnLeft`, `tapKey LC-v` (Left Control + (lowercase) v), `tapKey CS-f5` (Ctrl + Shift + F5), `LS-` (just tap left Shift).
+- `pressKey|holdKey|tapKey|releaseKey|toggleKey` Presses/holds/taps/releases the provided scancode. E.g., `pressKey mouseBtnLeft`, `tapKey LC-v` (Left Control + (lowercase) v), `tapKey CS-f5` (Ctrl + Shift + F5), `LS-` (just tap left Shift).
   - **press** means adding the scancode into a list of "active keys" and continuing the macro. The key is released once the macro ends. I.e., if the command is not followed by any sort of delay, the key will be released again almost immediately.
   - **release** means removing the scancode from the list of "active keys". I.e., it negates the effect of `pressKey` within the same macro. This does not affect scancodes emitted by different keyboard actions.
   - **tap** means pressing a key (more precisely, activating the scancode) and immediately releasing it again
   - **hold** means pressing the key, waiting until the key which activated the macro is released, and then releasing the key again. I.e., `holdKey <x>` is equivalent to `pressKey <x>; delayUntilRelease; releaseKey <x>`, while `tapKey <x>` is equivalent to `pressKey <x>; releaseKey <x>`.
+  - **toggle** will check if the shortcut is pressed in this macro's reports. If it is, it will deactivate the shortcut, otherwise it will activate it. This always acts on persistent reports.
+  - **persistent** argument will global reports. These reports can be accessed from any macro and will not be cleared when the macro ends. This is useful for long-term key toggling. E.g., `toggleKey persistent LS` acts similar to caps lock.
   - `tapKeySeq` can be used for executing custom sequences. The default action for each shortcut in the sequence is tap. Other actions can be specified using `MODMASK`. E.g.:
     - `CS-u 1 2 3 space` - control shift U + number + space - linux shortcut for a custom unicode character.
     - `pA- tab tab rA-` - tap alt tab twice to bring forward the second background window.

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -924,7 +924,7 @@ static macro_result_t processPlayMacroCommand(parser_context_t* ctx)
     if (Macros_DryRun) {
         return MacroResult_Finished;
     }
-    bool res = MacroRecorder_PlayRuntimeMacroSmart(id, &S->ms.macroBasicKeyboardReport);
+    bool res = MacroRecorder_PlayRuntimeMacroSmart(id, &S->ms.reports.macroBasicKeyboardReport);
     return res ? MacroResult_Blocking : MacroResult_Finished;
 }
 
@@ -1959,7 +1959,7 @@ static macro_result_t processCommand(parser_context_t* ctx)
                 return processHoldKeymapLayerMaxCommand(ctx);
             }
             else if (ConsumeToken(ctx, "holdKey")) {
-                return Macros_ProcessKeyCommandAndConsume(ctx, MacroSubAction_Hold);
+                return Macros_ProcessKeyCommandAndConsume(ctx, MacroSubAction_Hold, &S->ms.reports);
             }
             else {
                 goto failed;
@@ -2284,7 +2284,7 @@ static macro_result_t processCommand(parser_context_t* ctx)
                 return processPlayMacroCommand(ctx);
             }
             else if (ConsumeToken(ctx, "pressKey")) {
-                return Macros_ProcessKeyCommandAndConsume(ctx, MacroSubAction_Press);
+                return Macros_ProcessKeyCommandAndConsume(ctx, MacroSubAction_Press, &S->ms.reports);
             }
             else if (ConsumeToken(ctx, "postponeKeys")) {
                 processPostponeKeysCommand();
@@ -2319,7 +2319,7 @@ static macro_result_t processCommand(parser_context_t* ctx)
                 return processResolveNextKeyIdCommand();
             }
             else if (ConsumeToken(ctx, "releaseKey")) {
-                return Macros_ProcessKeyCommandAndConsume(ctx, MacroSubAction_Release);
+                return Macros_ProcessKeyCommandAndConsume(ctx, MacroSubAction_Release, &S->ms.reports);
             }
             else if (ConsumeToken(ctx, "repeatFor")) {
                 return processRepeatForCommand(ctx);
@@ -2448,10 +2448,13 @@ static macro_result_t processCommand(parser_context_t* ctx)
                 return processToggleLayerCommand(ctx);
             }
             else if (ConsumeToken(ctx, "tapKey")) {
-                return Macros_ProcessKeyCommandAndConsume(ctx, MacroSubAction_Tap);
+                return Macros_ProcessKeyCommandAndConsume(ctx, MacroSubAction_Tap, &S->ms.reports);
             }
             else if (ConsumeToken(ctx, "tapKeySeq")) {
                 return Macros_ProcessTapKeySeqCommand(ctx);
+            }
+            else if (ConsumeToken(ctx, "toggleKey")) {
+                return Macros_ProcessKeyCommandAndConsume(ctx, MacroSubAction_Toggle, &S->ms.reports);
             }
             else if (ConsumeToken(ctx, "trace")) {
                 if (!Macros_DryRun) {

--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -31,6 +31,8 @@ bool Macros_WakedBecauseOfKeystateChange = false;
 uint32_t Macros_WakeMeOnTime = 0xFFFFFFFF;
 bool Macros_WakeMeOnKeystateChange = false;
 
+macro_usb_keyboard_reports_t Macros_PersistentReports = {};
+
 bool Macros_ParserError = false;
 bool Macros_DryRun = false;
 bool Macros_ValidationInProgress = false;
@@ -888,6 +890,7 @@ bool Macros_MacroHasActiveInstance(macro_index_t macroIdx)
 void Macros_ResetBasicKeyboardReports()
 {
     for(uint8_t j = 0; j < MACRO_STATE_POOL_SIZE; j++) {
-        memset(&MacroState[j].ms.macroBasicKeyboardReport, 0, sizeof MacroState[j].ms.macroBasicKeyboardReport);
+        memset(&MacroState[j].ms.reports.macroBasicKeyboardReport, 0, sizeof MacroState[j].ms.reports.macroBasicKeyboardReport);
     }
+    memset(&Macros_PersistentReports, 0, sizeof Macros_PersistentReports);
 }

--- a/right/src/macros/core.h
+++ b/right/src/macros/core.h
@@ -151,6 +151,7 @@
             uint8_t parentMacroSlot;
             uint8_t currentMacroIndex;
             uint8_t postponeNextNCommands;
+            // ---- 4-aligned ----
             uint8_t nextSlot;
             uint8_t oneShotState : 2;
             bool oneShotUsbChangeDetected : 1;
@@ -165,12 +166,9 @@
             bool wakeMeOnKeystateChange: 1;
             bool autoRepeatInitialDelayPassed: 1;
             macro_autorepeat_state_t autoRepeatPhase: 1;
+            // ---- 4-aligned ----
 
-            uint8_t inputModifierMask;
-            usb_mouse_report_t macroMouseReport;
-            usb_basic_keyboard_report_t macroBasicKeyboardReport;
-            usb_media_keyboard_report_t macroMediaKeyboardReport;
-            usb_system_keyboard_report_t macroSystemKeyboardReport;
+            macro_usb_keyboard_reports_t reports;
         } ms;
 
         // action scope data
@@ -202,6 +200,7 @@
                 } holdLayerData;
                 struct {
                     uint8_t atKeyIdx;
+                    bool toggleShouldActivate : 1;
                 } keySeqData;
             };
 
@@ -250,6 +249,7 @@
     extern bool Macros_ParserError;
     extern bool Macros_DryRun;
     extern bool Macros_ValidationInProgress;
+    extern macro_usb_keyboard_reports_t Macros_PersistentReports;
 
 // Functions:
 

--- a/right/src/macros/scancode_commands.c
+++ b/right/src/macros/scancode_commands.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include "macros/scancode_commands.h"
+#include "macros/typedefs.h"
 #include "usb_interfaces/usb_interface_basic_keyboard.h"
 #include "usb_interfaces/usb_interface_media_keyboard.h"
 #include "usb_interfaces/usb_interface_mouse.h"
@@ -11,114 +12,137 @@
 #include "macros/shortcut_parser.h"
 #include "macros/string_reader.h"
 
-static void addBasicScancode(uint8_t scancode)
+static void addBasicScancode(uint8_t scancode, macro_usb_keyboard_reports_t* reports)
 {
     if (!scancode) {
         return;
     }
-    if (!UsbBasicKeyboard_ContainsScancode(&S->ms.macroBasicKeyboardReport, scancode)) {
-        UsbBasicKeyboard_AddScancode(&S->ms.macroBasicKeyboardReport, scancode);
+    if (!UsbBasicKeyboard_ContainsScancode(&reports->macroBasicKeyboardReport, scancode)) {
+        UsbBasicKeyboard_AddScancode(&reports->macroBasicKeyboardReport, scancode);
     }
 }
 
-static void deleteBasicScancode(uint8_t scancode)
+static void deleteBasicScancode(uint8_t scancode, macro_usb_keyboard_reports_t* reports)
 {
     if (!scancode) {
         return;
     }
-    UsbBasicKeyboard_RemoveScancode(&S->ms.macroBasicKeyboardReport, scancode);
+    UsbBasicKeyboard_RemoveScancode(&reports->macroBasicKeyboardReport, scancode);
 }
 
-static void addModifiers(uint8_t inputModifiers, uint8_t outputModifiers)
+static void addModifiers(uint8_t inputModifiers, uint8_t outputModifiers, macro_usb_keyboard_reports_t* reports)
 {
-    S->ms.inputModifierMask |= inputModifiers;
-    S->ms.macroBasicKeyboardReport.modifiers |= outputModifiers;
+    reports->inputModifierMask |= inputModifiers;
+    reports->macroBasicKeyboardReport.modifiers |= outputModifiers;
 }
 
-static void deleteModifiers(uint8_t inputModifiers, uint8_t outputModifiers)
+static void deleteModifiers(uint8_t inputModifiers, uint8_t outputModifiers, macro_usb_keyboard_reports_t* reports)
 {
-    S->ms.inputModifierMask &= ~inputModifiers;
-    S->ms.macroBasicKeyboardReport.modifiers &= ~outputModifiers;
+    reports->inputModifierMask &= ~inputModifiers;
+    reports->macroBasicKeyboardReport.modifiers &= ~outputModifiers;
 }
 
-static void addMediaScancode(uint16_t scancode)
+static void addMediaScancode(uint16_t scancode, macro_usb_keyboard_reports_t* reports)
 {
     if (!scancode) {
         return;
     }
     for (uint8_t i = 0; i < USB_MEDIA_KEYBOARD_MAX_KEYS; i++) {
-        if (S->ms.macroMediaKeyboardReport.scancodes[i] == scancode) {
+        if (reports->macroMediaKeyboardReport.scancodes[i] == scancode) {
             return;
         }
     }
     for (uint8_t i = 0; i < USB_MEDIA_KEYBOARD_MAX_KEYS; i++) {
-        if (!S->ms.macroMediaKeyboardReport.scancodes[i]) {
-            S->ms.macroMediaKeyboardReport.scancodes[i] = scancode;
+        if (!reports->macroMediaKeyboardReport.scancodes[i]) {
+            reports->macroMediaKeyboardReport.scancodes[i] = scancode;
             break;
         }
     }
 }
 
-static void deleteMediaScancode(uint16_t scancode)
+static void deleteMediaScancode(uint16_t scancode, macro_usb_keyboard_reports_t* reports)
 {
     if (!scancode) {
         return;
     }
     for (uint8_t i = 0; i < USB_MEDIA_KEYBOARD_MAX_KEYS; i++) {
-        if (S->ms.macroMediaKeyboardReport.scancodes[i] == scancode) {
-            S->ms.macroMediaKeyboardReport.scancodes[i] = 0;
+        if (reports->macroMediaKeyboardReport.scancodes[i] == scancode) {
+            reports->macroMediaKeyboardReport.scancodes[i] = 0;
             return;
         }
     }
 }
 
-static void addSystemScancode(uint8_t scancode)
+static void addSystemScancode(uint8_t scancode, macro_usb_keyboard_reports_t* reports)
 {
     if (!scancode) {
         return;
     }
-    UsbSystemKeyboard_AddScancode(&S->ms.macroSystemKeyboardReport, scancode);
+    UsbSystemKeyboard_AddScancode(&reports->macroSystemKeyboardReport, scancode);
 }
 
-static void deleteSystemScancode(uint8_t scancode)
+static void deleteSystemScancode(uint8_t scancode, macro_usb_keyboard_reports_t* reports)
 {
     if (!scancode) {
         return;
     }
-    UsbSystemKeyboard_RemoveScancode(&S->ms.macroSystemKeyboardReport, scancode);
+    UsbSystemKeyboard_RemoveScancode(&reports->macroSystemKeyboardReport, scancode);
 }
 
-static void addScancode(uint16_t scancode, keystroke_type_t type)
+static void addScancode(uint16_t scancode, keystroke_type_t type, macro_usb_keyboard_reports_t* reports)
 {
     switch (type) {
         case KeystrokeType_Basic:
-            addBasicScancode(scancode);
+            addBasicScancode(scancode, reports);
             break;
         case KeystrokeType_Media:
-            addMediaScancode(scancode);
+            addMediaScancode(scancode, reports);
             break;
         case KeystrokeType_System:
-            addSystemScancode(scancode);
+            addSystemScancode(scancode, reports);
             break;
     }
 }
 
-static void deleteScancode(uint16_t scancode, keystroke_type_t type)
+static void deleteScancode(uint16_t scancode, keystroke_type_t type, macro_usb_keyboard_reports_t* reports)
 {
     switch (type) {
         case KeystrokeType_Basic:
-            deleteBasicScancode(scancode);
+            deleteBasicScancode(scancode, reports);
             break;
         case KeystrokeType_Media:
-            deleteMediaScancode(scancode);
+            deleteMediaScancode(scancode, reports);
             break;
         case KeystrokeType_System:
-            deleteSystemScancode(scancode);
+            deleteSystemScancode(scancode, reports);
             break;
     }
 }
 
-static macro_result_t processKey(macro_action_t macro_action)
+static bool containsScancode(uint16_t scancode, keystroke_type_t type, macro_usb_keyboard_reports_t* reports)
+{
+    switch (type) {
+        case KeystrokeType_Basic:
+            return UsbBasicKeyboard_ContainsScancode(&reports->macroBasicKeyboardReport, scancode);
+        case KeystrokeType_Media:
+            return UsbMediaKeyboard_ContainsScancode(&reports->macroMediaKeyboardReport, scancode);
+        case KeystrokeType_System:
+            return UsbSystemKeyboard_ContainsScancode(&reports->macroSystemKeyboardReport, scancode);
+    }
+    return false;
+}
+
+static bool shortcutMatches(macro_action_t macro_action, macro_usb_keyboard_reports_t* reports)
+{
+    bool matches = true;
+    matches &= (macro_action.key.inputModMask & reports->inputModifierMask) == macro_action.key.inputModMask;
+    matches &= (macro_action.key.outputModMask & reports->macroBasicKeyboardReport.modifiers) == macro_action.key.outputModMask;
+    matches &= (macro_action.key.stickyModMask & reports->macroBasicKeyboardReport.modifiers) == macro_action.key.stickyModMask;
+    matches &= macro_action.key.scancode == 0 || containsScancode(macro_action.key.scancode, macro_action.key.type, reports);
+    return matches;
+}
+
+static macro_result_t processKey(macro_action_t macro_action, macro_usb_keyboard_reports_t* reports)
 {
     S->ms.reportsUsed = true;
     macro_sub_action_t action = macro_action.key.action;
@@ -135,23 +159,23 @@ static macro_result_t processKey(macro_action_t macro_action)
         case MacroSubAction_Tap:
             switch(S->as.actionPhase) {
                 case 1:
-                    addModifiers(inputModMask, outputModMask);
+                    addModifiers(inputModMask, outputModMask, reports);
                     if (stickyModMask) {
                         ActivateStickyMods(S->ms.currentMacroKey, stickyModMask);
                     }
                     return MacroResult_Blocking;
                 case 2:
-                    addScancode(scancode, type);
+                    addScancode(scancode, type, reports);
                     return MacroResult_Blocking;
                 case 3:
                     if (Macros_CurrentMacroKeyIsActive() && action == MacroSubAction_Hold) {
                         S->as.actionPhase--;
                         return Macros_SleepTillKeystateChange();
                     }
-                    deleteScancode(scancode, type);
+                    deleteScancode(scancode, type, reports);
                     return MacroResult_Blocking;
                 case 4:
-                    deleteModifiers(inputModMask, outputModMask);
+                    deleteModifiers(inputModMask, outputModMask, reports);
                     return MacroResult_Blocking;
                 case 5:
                     S->as.actionPhase = 0;
@@ -161,10 +185,10 @@ static macro_result_t processKey(macro_action_t macro_action)
         case MacroSubAction_Release:
             switch (S->as.actionPhase) {
                 case 1:
-                    deleteScancode(scancode, type);
+                    deleteScancode(scancode, type, reports);
                     return MacroResult_Blocking;
                 case 2:
-                    deleteModifiers(inputModMask, outputModMask);
+                    deleteModifiers(inputModMask, outputModMask, reports);
                     return MacroResult_Blocking;
                 case 3:
                     S->as.actionPhase = 0;
@@ -174,16 +198,45 @@ static macro_result_t processKey(macro_action_t macro_action)
         case MacroSubAction_Press:
             switch (S->as.actionPhase) {
                 case 1:
-                    addModifiers(inputModMask, outputModMask);
+                    addModifiers(inputModMask, outputModMask, reports);
                     if (stickyModMask) {
                         ActivateStickyMods(S->ms.currentMacroKey, stickyModMask);
                     }
                     return MacroResult_Blocking;
                 case 2:
-                    addScancode(scancode, type);
+                    addScancode(scancode, type, reports);
                     return MacroResult_Blocking;
                 case 3:
                     S->as.actionPhase = 0;
+                    return MacroResult_Finished;
+            }
+            break;
+        case MacroSubAction_Toggle:
+            switch (S->as.actionPhase) {
+                case 1:
+                    S->as.keySeqData.toggleShouldActivate = !shortcutMatches(macro_action, reports);
+                    S->as.actionPhase++;
+                    __attribute__((fallthrough));
+                case 2:
+                    if (S->as.keySeqData.toggleShouldActivate) {
+                        addModifiers(inputModMask, outputModMask, reports);
+                        if (stickyModMask) {
+                            ActivateStickyMods(S->ms.currentMacroKey, stickyModMask);
+                        }
+                    } else {
+                        deleteScancode(scancode, type, reports);
+                    }
+                    return MacroResult_Blocking;
+                case 3:
+                    if (S->as.keySeqData.toggleShouldActivate) {
+                        addScancode(scancode, type, reports);
+                    } else {
+                        deleteModifiers(inputModMask, outputModMask, reports);
+                    }
+                    return MacroResult_Blocking;
+                case 4:
+                    S->as.actionPhase = 0;
+                    S->as.keySeqData.toggleShouldActivate = false;
                     return MacroResult_Finished;
             }
             break;
@@ -193,10 +246,10 @@ static macro_result_t processKey(macro_action_t macro_action)
 
 macro_result_t Macros_ProcessKeyAction()
 {
-    return processKey(S->ms.currentMacroAction);
+    return processKey(S->ms.currentMacroAction, &S->ms.reports);
 }
 
-static macro_result_t processMouseButton(macro_action_t macro_action)
+static macro_result_t processMouseButton(macro_action_t macro_action, macro_usb_keyboard_reports_t* reports)
 {
     S->ms.reportsUsed = true;
     uint32_t mouseButtonMask = macro_action.mouseButton.mouseButtonsMask;
@@ -209,14 +262,14 @@ static macro_result_t processMouseButton(macro_action_t macro_action)
         case MacroSubAction_Tap:
             switch(S->as.actionPhase) {
             case 1:
-                S->ms.macroMouseReport.buttons |= mouseButtonMask;
+                reports->macroMouseReport.buttons |= mouseButtonMask;
                 return MacroResult_Blocking;
             case 2:
                 if (Macros_CurrentMacroKeyIsActive() && action == MacroSubAction_Hold) {
                     S->as.actionPhase--;
                     return Macros_SleepTillKeystateChange();
                 }
-                S->ms.macroMouseReport.buttons &= ~mouseButtonMask;
+                reports->macroMouseReport.buttons &= ~mouseButtonMask;
                 return MacroResult_Blocking;
             case 3:
                 S->as.actionPhase = 0;
@@ -227,7 +280,7 @@ static macro_result_t processMouseButton(macro_action_t macro_action)
         case MacroSubAction_Release:
             switch(S->as.actionPhase) {
             case 1:
-                S->ms.macroMouseReport.buttons &= ~mouseButtonMask;
+                reports->macroMouseReport.buttons &= ~mouseButtonMask;
                 return MacroResult_Blocking;
             case 2:
                 S->as.actionPhase = 0;
@@ -237,9 +290,19 @@ static macro_result_t processMouseButton(macro_action_t macro_action)
         case MacroSubAction_Press:
             switch(S->as.actionPhase) {
                 case 1:
-                    S->ms.macroMouseReport.buttons |= mouseButtonMask;
+                    reports->macroMouseReport.buttons |= mouseButtonMask;
                     return MacroResult_Blocking;
                 case 2:
+                    S->as.actionPhase = 0;
+                    return MacroResult_Finished;
+            }
+            break;
+        case MacroSubAction_Toggle:
+            switch(S->as.actionPhase) {
+                case 2:
+                    reports->macroMouseReport.buttons ^= mouseButtonMask;
+                    return MacroResult_Blocking;
+                case 3:
                     S->as.actionPhase = 0;
                     return MacroResult_Finished;
             }
@@ -250,19 +313,20 @@ static macro_result_t processMouseButton(macro_action_t macro_action)
 
 macro_result_t Macros_ProcessMouseButtonAction(void)
 {
-    return processMouseButton(S->ms.currentMacroAction);
+    return processMouseButton(S->ms.currentMacroAction, &S->ms.reports);
 }
 
 macro_result_t Macros_ProcessMoveMouseAction(void)
 {
+    macro_usb_keyboard_reports_t* reports = &S->ms.reports;
     S->ms.reportsUsed = true;
     if (S->as.actionActive) {
-        S->ms.macroMouseReport.x = 0;
-        S->ms.macroMouseReport.y = 0;
+        reports->macroMouseReport.x = 0;
+        reports->macroMouseReport.y = 0;
         S->as.actionActive = false;
     } else {
-        S->ms.macroMouseReport.x = S->ms.currentMacroAction.moveMouse.x;
-        S->ms.macroMouseReport.y = S->ms.currentMacroAction.moveMouse.y;
+        reports->macroMouseReport.x = S->ms.currentMacroAction.moveMouse.x;
+        reports->macroMouseReport.y = S->ms.currentMacroAction.moveMouse.y;
         S->as.actionActive = true;
     }
     return S->as.actionActive ? MacroResult_Blocking : MacroResult_Finished;
@@ -270,14 +334,15 @@ macro_result_t Macros_ProcessMoveMouseAction(void)
 
 macro_result_t Macros_ProcessScrollMouseAction(void)
 {
+    macro_usb_keyboard_reports_t* reports = &S->ms.reports;
     S->ms.reportsUsed = true;
     if (S->as.actionActive) {
-        S->ms.macroMouseReport.wheelX = 0;
-        S->ms.macroMouseReport.wheelY = 0;
+        reports->macroMouseReport.wheelX = 0;
+        reports->macroMouseReport.wheelY = 0;
         S->as.actionActive = false;
     } else {
-        S->ms.macroMouseReport.wheelX = S->ms.currentMacroAction.scrollMouse.x;
-        S->ms.macroMouseReport.wheelY = S->ms.currentMacroAction.scrollMouse.y;
+        reports->macroMouseReport.wheelX = S->ms.currentMacroAction.scrollMouse.x;
+        reports->macroMouseReport.wheelY = S->ms.currentMacroAction.scrollMouse.y;
         S->as.actionActive = true;
     }
     return S->as.actionActive ? MacroResult_Blocking : MacroResult_Finished;
@@ -286,9 +351,9 @@ macro_result_t Macros_ProcessScrollMouseAction(void)
 
 static void clearScancodes()
 {
-    uint8_t oldMods = S->ms.macroBasicKeyboardReport.modifiers;
-    memset(&S->ms.macroBasicKeyboardReport, 0, sizeof S->ms.macroBasicKeyboardReport);
-    S->ms.macroBasicKeyboardReport.modifiers = oldMods;
+    uint8_t oldMods = S->ms.reports.macroBasicKeyboardReport.modifiers;
+    memset(&S->ms.reports.macroBasicKeyboardReport, 0, sizeof S->ms.reports.macroBasicKeyboardReport);
+    S->ms.reports.macroBasicKeyboardReport.modifiers = oldMods;
 }
 
 macro_result_t Macros_DispatchText(const char* text, uint16_t textLen, bool rawString)
@@ -337,14 +402,14 @@ macro_result_t Macros_DispatchText(const char* text, uint16_t textLen, bool rawS
     // If required modifiers differ, first clear scancodes and send empty report
     // containing only old modifiers. Then set new modifiers and send that new report.
     // Just then continue.
-    if (mods != S->ms.macroBasicKeyboardReport.modifiers) {
+    if (mods != S->ms.reports.macroBasicKeyboardReport.modifiers) {
         if (S->as.dispatchData.reportState != REPORT_EMPTY) {
             S->as.dispatchData.reportState = REPORT_EMPTY;
             clearScancodes();
             currentReportSize = 0;
             return MacroResult_Blocking;
         } else {
-            S->ms.macroBasicKeyboardReport.modifiers = mods;
+            S->ms.reports.macroBasicKeyboardReport.modifiers = mods;
             return MacroResult_Blocking;
         }
     }
@@ -354,7 +419,7 @@ macro_result_t Macros_DispatchText(const char* text, uint16_t textLen, bool rawS
         if (S->as.dispatchData.reportState != REPORT_EMPTY) {
             currentReportSize = 0;
             S->as.dispatchData.reportState = REPORT_EMPTY;
-            memset(&S->ms.macroBasicKeyboardReport, 0, sizeof S->ms.macroBasicKeyboardReport);
+            memset(&S->ms.reports.macroBasicKeyboardReport, 0, sizeof S->ms.reports.macroBasicKeyboardReport);
             return MacroResult_Blocking;
         } else {
             S->as.dispatchData.textIdx = 0;
@@ -369,20 +434,20 @@ macro_result_t Macros_DispatchText(const char* text, uint16_t textLen, bool rawS
     if (S->as.dispatchData.reportState == REPORT_FULL) {
         currentReportSize = 0;
         S->as.dispatchData.reportState = REPORT_EMPTY;
-        memset(&S->ms.macroBasicKeyboardReport, 0, sizeof S->ms.macroBasicKeyboardReport);
+        memset(&S->ms.reports.macroBasicKeyboardReport, 0, sizeof S->ms.reports.macroBasicKeyboardReport);
         return MacroResult_Blocking;
     }
 
     // If current character is already contained in the report, we need to
     // release it first. We do so by artificially marking the report
     // full. Next call will do rest of the work for us.
-    if (UsbBasicKeyboard_ContainsScancode(&S->ms.macroBasicKeyboardReport, scancode)) {
+    if (UsbBasicKeyboard_ContainsScancode(&S->ms.reports.macroBasicKeyboardReport, scancode)) {
         S->as.dispatchData.reportState = REPORT_FULL;
         return MacroResult_Blocking;
     }
 
     // Send the scancode.
-    UsbBasicKeyboard_AddScancode(&S->ms.macroBasicKeyboardReport, scancode);
+    UsbBasicKeyboard_AddScancode(&S->ms.reports.macroBasicKeyboardReport, scancode);
     S->as.dispatchData.reportState = ++currentReportSize >= maxGroupSize ? REPORT_FULL : REPORT_PARTIAL;
     if (rawString) {
         ++S->as.dispatchData.textIdx;
@@ -414,8 +479,15 @@ static macro_action_t decodeKeyAndConsume(parser_context_t* ctx, macro_sub_actio
     return action;
 }
 
-macro_result_t Macros_ProcessKeyCommandAndConsume(parser_context_t* ctx, macro_sub_action_t type)
+macro_result_t Macros_ProcessKeyCommandAndConsume(parser_context_t* ctx, macro_sub_action_t type, macro_usb_keyboard_reports_t* reports)
 {
+    if (reports == NULL) {
+        reports = &S->ms.reports;
+    }
+    if (ConsumeToken(ctx, "persistent") || type == MacroSubAction_Toggle) {
+        reports = &Macros_PersistentReports;
+    }
+
     macro_action_t action = decodeKeyAndConsume(ctx, type);
 
     if (Macros_DryRun) {
@@ -424,9 +496,9 @@ macro_result_t Macros_ProcessKeyCommandAndConsume(parser_context_t* ctx, macro_s
 
     switch (action.type) {
         case MacroActionType_Key:
-            return processKey(action);
+            return processKey(action, reports);
         case MacroActionType_MouseButton:
-            return processMouseButton(action);
+            return processMouseButton(action, reports);
         default:
             return MacroResult_Finished;
     }
@@ -434,9 +506,14 @@ macro_result_t Macros_ProcessKeyCommandAndConsume(parser_context_t* ctx, macro_s
 
 macro_result_t Macros_ProcessTapKeySeqCommand(parser_context_t* ctx)
 {
+    macro_usb_keyboard_reports_t* reports = &S->ms.reports;
+    if (ConsumeToken(ctx, "persistent")) {
+        reports = &Macros_PersistentReports;
+    }
+
     if (Macros_DryRun) {
         while(ctx->at != ctx->end) {
-            Macros_ProcessKeyCommandAndConsume(ctx, MacroSubAction_Tap);
+            Macros_ProcessKeyCommandAndConsume(ctx, MacroSubAction_Tap, reports);
         }
         return MacroResult_Finished;
     }
@@ -450,7 +527,7 @@ macro_result_t Macros_ProcessTapKeySeqCommand(parser_context_t* ctx)
         };
     }
 
-    macro_result_t res = Macros_ProcessKeyCommandAndConsume(ctx, MacroSubAction_Tap);
+    macro_result_t res = Macros_ProcessKeyCommandAndConsume(ctx, MacroSubAction_Tap, reports);
 
     if(res == MacroResult_Finished) {
         S->as.keySeqData.atKeyIdx++;

--- a/right/src/macros/scancode_commands.h
+++ b/right/src/macros/scancode_commands.h
@@ -19,7 +19,7 @@
 // Functions:
 
     macro_result_t Macros_DispatchText(const char* text, uint16_t textLen, bool rawString);
-    macro_result_t Macros_ProcessKeyCommandAndConsume(parser_context_t* ctx, macro_sub_action_t type);
+    macro_result_t Macros_ProcessKeyCommandAndConsume(parser_context_t* ctx, macro_sub_action_t type, macro_usb_keyboard_reports_t* reports);
     macro_result_t Macros_ProcessTapKeySeqCommand(parser_context_t* ctx);
     macro_result_t Macros_ProcessMouseButtonAction(void);
     macro_result_t Macros_ProcessTextAction(void);

--- a/right/src/macros/typedefs.h
+++ b/right/src/macros/typedefs.h
@@ -3,6 +3,11 @@
 
 // Includes:
 
+
+    #include <stdbool.h>
+    #include <stdint.h>
+    #include "usb_device_config.h"
+
 // Macros:
 
     #define STATUS_BUFFER_MAX_LENGTH 3000
@@ -14,7 +19,8 @@
         MacroSubAction_Tap,
         MacroSubAction_Press,
         MacroSubAction_Release,
-        MacroSubAction_Hold
+        MacroSubAction_Hold,
+        MacroSubAction_Toggle,
     } macro_sub_action_t;
 
     typedef enum {
@@ -33,6 +39,14 @@
         MacroResult_JumpedForward = MacroResult_DoneFlag,
         MacroResult_JumpedBackward = MacroResult_DoneFlag | MacroResult_YieldFlag,
     } macro_result_t;
+
+    typedef struct {
+        usb_mouse_report_t macroMouseReport;
+        usb_basic_keyboard_report_t macroBasicKeyboardReport;
+        usb_media_keyboard_report_t macroMediaKeyboardReport;
+        usb_system_keyboard_report_t macroSystemKeyboardReport;
+        uint8_t inputModifierMask;
+    } macro_usb_keyboard_reports_t;
 
 // Variables:
 

--- a/right/src/usb_interfaces/usb_interface_media_keyboard.c
+++ b/right/src/usb_interfaces/usb_interface_media_keyboard.c
@@ -141,3 +141,17 @@ bool UsbMediaKeyboard_AddScancode(usb_media_keyboard_report_t* report, uint16_t 
 
     return false;
 }
+
+bool UsbMediaKeyboard_ContainsScancode(const usb_media_keyboard_report_t* report, uint16_t scancode)
+{
+    if (scancode == 0) {
+        return false;
+    }
+
+    for (uint8_t i = 0; i < UTILS_ARRAY_SIZE(report->scancodes); i++) {
+        if (report->scancodes[i] == scancode) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/right/src/usb_interfaces/usb_interface_media_keyboard.h
+++ b/right/src/usb_interfaces/usb_interface_media_keyboard.h
@@ -38,6 +38,7 @@
 #endif
 
     bool UsbMediaKeyboard_AddScancode(usb_media_keyboard_report_t* report, uint16_t scancode);
+    bool UsbMediaKeyboard_ContainsScancode(const usb_media_keyboard_report_t* report, uint16_t scancode);
     void UsbMediaKeyboardResetActiveReport(void);
     void SwitchActiveUsbMediaKeyboardReport(void);
     usb_status_t UsbMediaKeyboardCheckIdleElapsed();

--- a/right/src/usb_interfaces/usb_interface_system_keyboard.c
+++ b/right/src/usb_interfaces/usb_interface_system_keyboard.c
@@ -124,6 +124,14 @@ bool UsbSystemKeyboard_AddScancode(usb_system_keyboard_report_t* report, uint8_t
     return true;
 }
 
+bool UsbSystemKeyboard_ContainsScancode(const usb_system_keyboard_report_t* report, uint8_t scancode)
+{
+    if (!UsbSystemKeyboard_UsedScancode(scancode))
+        return false;
+
+    return test_bit(scancode - USB_SYSTEM_KEYBOARD_MIN_BITFIELD_SCANCODE, report->bitfield);
+}
+
 void UsbSystemKeyboard_RemoveScancode(usb_system_keyboard_report_t* report, uint8_t scancode)
 {
     if (!UsbSystemKeyboard_UsedScancode(scancode))

--- a/right/src/usb_interfaces/usb_interface_system_keyboard.h
+++ b/right/src/usb_interfaces/usb_interface_system_keyboard.h
@@ -34,6 +34,7 @@
 // Functions:
 
     bool UsbSystemKeyboard_AddScancode(usb_system_keyboard_report_t* report, uint8_t scancode);
+    bool UsbSystemKeyboard_ContainsScancode(const usb_system_keyboard_report_t* report, uint8_t scancode);
     static inline bool UsbSystemKeyboard_UsedScancode(uint8_t scancode)
     {
         return (scancode >= USB_SYSTEM_KEYBOARD_MIN_BITFIELD_SCANCODE) &&

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -442,19 +442,27 @@ static void mergeReports(void)
 
     InputModifiers = 0;
 
+    {
+        UsbBasicKeyboard_MergeReports(&Macros_PersistentReports.macroBasicKeyboardReport, ActiveUsbBasicKeyboardReport);
+        UsbMediaKeyboard_MergeReports(&Macros_PersistentReports.macroMediaKeyboardReport, ActiveUsbMediaKeyboardReport);
+        UsbSystemKeyboard_MergeReports(&Macros_PersistentReports.macroSystemKeyboardReport, ActiveUsbSystemKeyboardReport);
+        UsbMouse_MergeReports(&Macros_PersistentReports.macroMouseReport, ActiveUsbMouseReport);
+        InputModifiers |= Macros_PersistentReports.inputModifierMask;
+    }
+
     if (EventVector_IsSet(EventVector_MacroReportsUsed)) {
-        for(uint8_t j = 0; j < MACRO_STATE_POOL_SIZE; j++) {
-            if(MacroState[j].ms.reportsUsed) {
+        for (uint8_t j = 0; j < MACRO_STATE_POOL_SIZE; j++) {
+            if (MacroState[j].ms.reportsUsed) {
                 //if the macro ended right now, we still want to flush the last report
                 MacroState[j].ms.reportsUsed &= MacroState[j].ms.macroPlaying;
                 macro_state_t *macroState = &MacroState[j];
 
-                UsbBasicKeyboard_MergeReports(&(macroState->ms.macroBasicKeyboardReport), ActiveUsbBasicKeyboardReport);
-                UsbMediaKeyboard_MergeReports(&(macroState->ms.macroMediaKeyboardReport), ActiveUsbMediaKeyboardReport);
-                UsbSystemKeyboard_MergeReports(&(macroState->ms.macroSystemKeyboardReport), ActiveUsbSystemKeyboardReport);
-                UsbMouse_MergeReports(&(macroState->ms.macroMouseReport), ActiveUsbMouseReport);
+                UsbBasicKeyboard_MergeReports(&(macroState->ms.reports.macroBasicKeyboardReport), ActiveUsbBasicKeyboardReport);
+                UsbMediaKeyboard_MergeReports(&(macroState->ms.reports.macroMediaKeyboardReport), ActiveUsbMediaKeyboardReport);
+                UsbSystemKeyboard_MergeReports(&(macroState->ms.reports.macroSystemKeyboardReport), ActiveUsbSystemKeyboardReport);
+                UsbMouse_MergeReports(&(macroState->ms.reports.macroMouseReport), ActiveUsbMouseReport);
 
-                InputModifiers |= macroState->ms.inputModifierMask;
+                InputModifiers |= macroState->ms.reports.inputModifierMask;
             }
         }
     }


### PR DESCRIPTION
Closes https://github.com/UltimateHackingKeyboard/firmware/issues/1264

Changelog:
- add `toggleKey SHORTCUT` command
- add `persistent` option to pressKey and other scancode handling commands, to allow locking a key even between macro activations.