### PR TITLE
Fix update of last report when macro ends.

### DIFF
--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -265,6 +265,12 @@ static void freeLocalScopes()
 
 static macro_result_t endMacro(void)
 {
+    /* If macro has finished and some keys are pressed, we need to merge the reports once more in order to release them */
+    if (S->ms.reportsUsed) {
+        S->ms.reportsUsed = false;
+        EventVector_Set(EventVector_SendUsbReports);
+    }
+
     freeLocalScopes();
 
     S->ms.macroSleeping = false;


### PR DESCRIPTION
Changelog: 
- Fix a macro engine bug where usb reports weren't updated at the end of a macro. This would exhibit as keys activated from the macro would get stuck.

Steps to reproduce: 
- run a macro with a single action: `pressKey a`
- Expected: brief a tap
- Actual: a gets stuck until another scancode key is pressed.

Reported in https://forum.ultimatehackingkeyboard.com/t/gaming-config-tips-tricks/2447/16