### PR TITLE
Don't detect buspal reboot as crash.

### DIFF
--- a/right/src/buspal/command.c
+++ b/right/src/buspal/command.c
@@ -4,6 +4,7 @@
 #include "peripherals/test_led.h"
 #include "microseconds/microseconds.h"
 #include "bootloader/wormhole.h"
+#include "usb_commands/usb_command_reenumerate.h"
 
 #define FIXED_BUSPAL_BOOTLOADER  1 // Used to mark the fixed BusPal bootloader. Macro usage can be removed in the future.
 
@@ -486,7 +487,8 @@ status_t bootloader_command_pump()
             } else if (cmdTag == kCommandTag_Reset) {
                 Wormhole.magicNumber = WORMHOLE_MAGIC_NUMBER;
                 Wormhole.enumerationMode = EnumerationMode_NormalKeyboard;
-                NVIC_SystemReset();
+                // Otherwise the reboot will be detected as a crash.
+                Reboot(false);
             }
 
             status = handle_command_internal(g_commandData.packet, g_commandData.packetLength);


### PR DESCRIPTION
Some users reported that flashing uhk60 triggered a crash report. I am failing to find these, but I have figured out one way to reproduce it: to flash modules. 

Reproduce steps: 
- connect trackpoint module to your uhk60
- go to trackpoint directory
- `make flash`
- observe `ERR` flashing on your uhk afterwards. Also the trace report pops up in Agent.

Closes #1273 
Closes #1278 
Closes #1287