### PR TITLE
Fix things around usb macro commands.

### DIFF
--- a/doc-dev/user-guide.md
+++ b/doc-dev/user-guide.md
@@ -838,7 +838,7 @@ Or, in linux, you can put the following script into your path... and then use it
 ```
 #!/bin/bash
 hidraw="hidraw`grep 'UHK 60' /sys/class/hidraw/hidraw*/device/uevent | sed -nE 's/.*hidraw([0-9]+)\/.*/\1/p' | sort -rn | head -n 1`"
-echo -e "\x14$*" > "/dev/$hidraw"
+echo -e "\x14$*\x00" > "/dev/$hidraw"
 ```
 
 

--- a/right/src/usb_commands/usb_command_exec_macro_command.c
+++ b/right/src/usb_commands/usb_command_exec_macro_command.c
@@ -20,8 +20,11 @@ static void requestExecution(const uint8_t *GenericHidOutBuffer)
     uint8_t len = Utils_SafeStrCopy(UsbMacroCommand, ((char*)GenericHidOutBuffer) + 1, USB_GENERIC_HID_OUT_BUFFER_LENGTH - 1);
     UsbMacroCommandLength = len;
 
-
     EventVector_Set(EventVector_UsbMacroCommandWaitingForExecution);
+
+#ifdef __ZEPHYR__
+    Main_Wake();
+#endif
 }
 
 static bool canExecute()

--- a/right/src/usb_commands/usb_command_exec_macro_command.c
+++ b/right/src/usb_commands/usb_command_exec_macro_command.c
@@ -2,6 +2,7 @@
 #include "fsl_common.h"
 #endif
 #include "macros/core.h"
+#include "macros/status_buffer.h"
 #include "usb_commands/usb_command_exec_macro_command.h"
 #include "usb_interfaces/usb_interface_generic_hid.h"
 #include "usb_protocol_handler.h"
@@ -16,8 +17,9 @@ key_state_t dummyState;
 
 static void requestExecution(const uint8_t *GenericHidOutBuffer)
 {
-    Utils_SafeStrCopy(UsbMacroCommand, ((char*)GenericHidOutBuffer) + 1, USB_GENERIC_HID_OUT_BUFFER_LENGTH - 1);
-    UsbMacroCommandLength = strlen(UsbMacroCommand);
+    uint8_t len = Utils_SafeStrCopy(UsbMacroCommand, ((char*)GenericHidOutBuffer) + 1, USB_GENERIC_HID_OUT_BUFFER_LENGTH - 1);
+    UsbMacroCommandLength = len;
+
 
     EventVector_Set(EventVector_UsbMacroCommandWaitingForExecution);
 }

--- a/right/src/usb_commands/usb_command_exec_macro_command.c
+++ b/right/src/usb_commands/usb_command_exec_macro_command.c
@@ -47,5 +47,8 @@ void UsbCommand_ExecMacroCommand(const uint8_t *GenericHidOutBuffer, uint8_t *Ge
 {
     if (canExecute()) {
         requestExecution(GenericHidOutBuffer);
+    } else {
+        SetUsbTxBufferUint8(0, UsbStatusCode_Busy);
+        Macros_ReportErrorPrintf(NULL, "Another usb macro command executing, cannot execute now.\n");
     }
 }

--- a/right/src/usb_interfaces/usb_interface_generic_hid.c
+++ b/right/src/usb_interfaces/usb_interface_generic_hid.c
@@ -52,6 +52,8 @@ usb_status_t UsbGenericHidCallback(class_handle_t handle, uint32_t event, void *
         case kUSB_DeviceHidEventRecvResponse:
             UsbProtocolHandler(GenericHidOut, GenericHidIn);
 
+            bzero(GenericHidOut, USB_GENERIC_HID_IN_BUFFER_LENGTH);
+
             USB_DeviceHidSend(UsbCompositeDevice.genericHidHandle,
                               USB_GENERIC_HID_ENDPOINT_IN_INDEX,
                               GenericHidIn,

--- a/right/src/usb_protocol_handler.h
+++ b/right/src/usb_protocol_handler.h
@@ -85,6 +85,7 @@
     typedef enum {
         UsbStatusCode_Success        = 0,
         UsbStatusCode_InvalidCommand = 1,
+        UsbStatusCode_Busy = 2,
     } usb_status_code_general_t;
 
 // Variables:

--- a/right/src/utils.c
+++ b/right/src/utils.c
@@ -137,10 +137,11 @@ void Utils_PrintReport(const char* prefix, usb_basic_keyboard_report_t* report)
     Macros_SetStatusString("\n", NULL);
 }
 
-void Utils_SafeStrCopy(char* target, const char* src, uint8_t max) {
+uint8_t Utils_SafeStrCopy(char* target, const char* src, uint8_t max) {
     uint8_t stringlength = MIN(strlen(src)+1, (max));
     memcpy(target, src, stringlength);
     target[stringlength-1] = '\0';
+    return stringlength-1;
 }
 
 const char* Utils_KeyAbbreviation(key_state_t* keyState)

--- a/right/src/utils.h
+++ b/right/src/utils.h
@@ -33,7 +33,7 @@ if (reentrancyGuard_active) {                    \
 
 // Functions:
 
-    void Utils_SafeStrCopy(char* target, const char* src, uint8_t max);
+    uint8_t Utils_SafeStrCopy(char* target, const char* src, uint8_t max);
     key_state_t* Utils_KeyIdToKeyState(uint16_t keyid);
     uint16_t Utils_KeyStateToKeyId(key_state_t* key);
     const char* Utils_KeyStateToKeyAbbreviation(key_state_t* key);


### PR DESCRIPTION
Closes #1285 .

- Uhk60 suffered by buffer underruns on generic hid out reports. As a result, for instance `setLedTxt 500 ABC; sleep 1; uhkcmd noOp` would get mingled into a `noOp dTxt 500 ABC` command and throw error.
- Uhk80 wouldn't be awaken when the command is received. As a result, the command would be started only after some time, when the event loop got awaken by another event.
- Make the usb command return an error code when the macro command cannot be executed.
- Fix the user guide hid raw to explicitly terminate macro commands.

Steps to reproduce: difficult, unreliable. 
- Set up uhkcmd according to user guide.
- Run `setLedTxt 500 ABC; sleep 1; uhkcmd noOp` against uhk60.
- Observe error in status buffer about not recognized command `dTxt 500 ABC`
