### PR TITLE
Fix charger stopped detection.

### DIFF
--- a/device/src/keyboard/charger.c
+++ b/device/src/keyboard/charger.c
@@ -316,10 +316,11 @@ void Charger_UpdateBatteryState() {
             setChargerEnPin(false);
 
             if (actuallyCharging) {
+                chargerStopped = false;
                 previousVoltage = getVoltage();
                 previousCharging = true;
             } else {
-                chargerStopped = actuallyEnabled && !actuallyCharging;
+                chargerStopped = actuallyEnabled && !actuallyCharging && batteryState.powered;
                 previousVoltage = 0;
                 previousCharging = false;
             }


### PR DESCRIPTION
Closes #1298

Steps to reproduce:
- charge battery to 100% (say 4050 or so mV).
- now disconnect power and let it discharge. 
- observe that battery stays on 100% all the way down to 3800mV.
- also observe `Charger stopped bellow %dmV. This is suspicious!` logs. 

Still testing -> draft.