### PR TITLE
Increase uart thread priority.

### DIFF
--- a/device/src/keyboard/uart.c
+++ b/device/src/keyboard/uart.c
@@ -18,7 +18,7 @@
 // Thread definitions
 
 #define THREAD_STACK_SIZE 1000
-#define THREAD_PRIORITY 5
+#define THREAD_PRIORITY -5
 
 #define UART_FOREVER_TIMEOUT 10000
 #define UART_RESEND_DELAY 100

--- a/device/src/thread_stats.c
+++ b/device/src/thread_stats.c
@@ -98,7 +98,7 @@ void ThreadStats_Print(void) {
     ThreadStats_Snap();
     LogUS("Threads (%d), interval %d ms:\n", threadCount, MONITOR_INTERVAL_MS);
     for (uint8_t i = 0; i < threadCount; i++) {
-        LogUS("    - %s (%d): %d\n", threadStats[i].name, shortId(threadStats[i].threadId), (uint32_t)(threadStats[i].time*100/timeTotal));
+        LogUS("    - %s (id %d): %d\n", threadStats[i].name, shortId(threadStats[i].threadId), (uint32_t)(threadStats[i].time*100/timeTotal));
     }
     enabled = true;
 }


### PR DESCRIPTION
Phil has reported this to me. 

The issue: when using snap tap macros, the macros would keep the main thread busy constantly. Since macros are processed in the main thread whose priority is higher (0), the uart thread would not get a chance to run at all, leading to bridge cable timeouts, and consequently lagging and possibly stuck keys. 

A strange thing is that Phil says that it used to work fine. I don't see what is different now.