### PR TITLE
Fix a typo that caused postponeKeys modifier suppress modifiers instead.

### DIFF
--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -965,7 +965,7 @@ static void processPostponeKeysCommand()
         return;
     }
     postponeCurrentCycle();
-    S->ls->as.modifierSuppressMods = true;
+    S->ls->as.modifierPostpone = true;
 }
 
 static macro_result_t processNoOpCommand()

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -79,7 +79,6 @@ volatile uint8_t UsbReportUpdateSemaphore = 0;
 //     composite shortcut is applied
 //   - implementation: they are kept in one global place
 
-uint8_t NativeActionInputModifiers;
 uint8_t InputModifiers;
 uint8_t InputModifiersPrevious;
 uint8_t OutputModifiers;


### PR DESCRIPTION
Changelog: 

- Fix a bug that made `postponeKeys` modifier act as `suppressMods` instead.

Closes https://github.com/UltimateHackingKeyboard/firmware/issues/1311

Steps to reproduce: 
- import user config from the issue
- press left mod + left case button (in this order)
- observe QWR on the display
- press and hold left shift
- while still holding the shift, tap s repeatedly
- observe output like `SssSsSsSssss...` 