### PR TITLE
Add macro time quota.

### DIFF
--- a/right/src/debug.h
+++ b/right/src/debug.h
@@ -7,9 +7,11 @@
 #define DEBUG_STATESYNC false
 #define DEBUG_CONSOLE false
 #define DEBUG_EVENTLOOP_SCHEDULE false
+#define DEBUG_CHECK_MACRO_RUN_TIMES false
 #define DEBUG_POSTPONER false
 #define DEBUG_THREAD_STATS true
 #define WATCH_INTERVAL 500
+
 
 #define DEBUG_MODE false
 #define DEBUG_STRESS_UART false

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -2599,7 +2599,18 @@ macro_result_t Macros_ProcessCommandAction(void)
 
     macro_result_t macroResult;
 
+#if (DEBUG_CHECK_MACRO_RUN_TIMES && defined(__ZEPHYR__))
+    uint32_t start = CurrentTime;
     macroResult = processCommand(&ctx);
+    uint64_t end = CurrentTime;
+    uint32_t time = end - start;
+    if (time > 20) {
+        uint32_t cmdLength = (uint32_t)(cmdEnd - cmd);
+        Macros_ReportErrorPrintf(cmd, "Macro command took: %d ms to evaluate.\n", time, cmdLength, cmd);
+    }
+#else
+    macroResult = processCommand(&ctx);
+#endif
 
     if (ctx.at != ctx.end && !Macros_ParserError && Macros_DryRun) {
         Macros_ReportWarn("Unprocessed input encountered.", ctx.at, ctx.at);


### PR DESCRIPTION
This PR: 

- limits the macro engine quota to 5ms of runtime 
- adds functionality (disabled by default) to measure these parse times.

it however doesn't eliminate the problem...