### PR TITLE
Fix broken scrolling on Linux wake from suspend

### DIFF
--- a/right/src/usb_interfaces/usb_interface_mouse.c
+++ b/right/src/usb_interfaces/usb_interface_mouse.c
@@ -36,7 +36,7 @@ static void SwitchActiveUsbMouseReport(void)
 
 #ifndef __ZEPHYR__
 
-static uint8_t usbMouseFeatBuffer[USB_MOUSE_FEAT_REPORT_LENGTH];
+static uint8_t usbMouseFeatBuffer[USB_MOUSE_FEAT_REPORT_LENGTH] = {0};
 
 usb_hid_protocol_t UsbMouseGetProtocol(void)
 {
@@ -80,7 +80,6 @@ usb_status_t UsbMouseCallback(class_handle_t handle, uint32_t event, void *param
 
     switch (event) {
         case ((uint32_t)-kUSB_DeviceEventSetConfiguration):
-            usbMouseFeatBuffer[0] = 0;
             error = kStatus_USB_Success;
             break;
         case ((uint32_t)-kUSB_DeviceEventSetInterface):


### PR DESCRIPTION
When waking from sleep, a Linux host will communicate with the device such that `kUSB_DeviceEventSetConfiguration` is triggered, but won't send `SetReport` like it does when first initializing the device upon connection. This broke scrolling when waking from sleep since the `usbMouseFeatBuffer` got re-initialized to `0` but never got the `SetReport` that would set it back to `1`, resulting in the device thinking it should operate in low-res scrolling mode while the host continues to expect high-resolution scrolling.

To fix this, I've removed the initialization of `usbMouseFeatBuffer` from `kUSB_DeviceEventSetConfiguration` and instead initialize it globally, when it's declared.

Fixes #1261.

I've tested this on my Linux desktop (running CachyOS). From my earlier testing, Windows wasn't affected by this issue, and I don't think this fix will affect anything on it, but it should be tested on Windows to make sure that high-res scrolling works as expected, including after waking from suspend. I can't boot into Windows for the moment so it'd be great if someone else could verify.

Ideally, this should also be tested to make sure that nothing breaks on an OS that doesn't support the high-res scrolling (MacOS, maybe? I seem to recall we didn't have a clear consensus on whether it worked there or not), but this is probably just paranoia on my part... I really don't think there's anything in this fix that would affect that scenario.