### PR TITLE
Add replaceKeymap command, and current KEYID alias.

### DIFF
--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -88,6 +88,7 @@ COMMAND = holdLayerMax LAYERID <time in ms (INT)>
 COMMAND = holdKeymapLayer KEYMAPID LAYERID
 COMMAND = holdKeymapLayerMax KEYMAPID LAYERID <time in ms (INT)>
 COMMAND = overlayKeymap KEYMAPID
+COMMAND = replaceKeymap KEYMAPID
 COMMAND = overlayLayer <target layer (LAYERID)> <source keymap (KEYMAPID)> <source layer (LAYERID)>
 COMMAND = replaceLayer <target layer (LAYERID)> <source keymap (KEYMAPID)> <source layer (LAYERID)>
 COMMAND = resolveNextKeyId
@@ -210,9 +211,9 @@ MODIFIER = autoRepeat
 MODIFIER = oneShot
 IFSHORTCUT_OPTIONS = noConsume | transitive | anyOrder | orGate | timeoutIn <time in ms (INT)> | cancelIn <time in ms(INT)>
 DIRECTION = {left|right|up|down}
-LAYERID = {fn|mouse|mod|base|fn2|fn3|fn4|fn5|alt|shift|super|ctrl}|last|previous
+LAYERID = {fn|mouse|mod|base|fn2|fn3|fn4|fn5|alt|shift|super|ctrl}|last|previous|current
 LAYERID_BASIC = {fn|mouse|mod|base|fn2|fn3|fn4|fn5}
-KEYMAPID = <short keymap abbreviation(IDENTIFIER)>|last
+KEYMAPID = <short keymap abbreviation(IDENTIFIER)>|last|current
 MACROID = last | <single char slot identifier(CHAR)> | <single number slot identifier(INT)>
 OPERATOR = + | - | * | / | % | < | > | <= | >= | == | != | && | ||
 VARIABLE_EXPANSION = $<variable name(IDENTIFIER)> | $<config value name> | $currentAddress | $currentTime | $thisKeyId | $queuedKeyId.<queue index (INT)> | $keyId.KEYID_ABBREV
@@ -467,6 +468,7 @@ These alterations will last only until keymap is reloaded. I.e., switching keyma
 - `replaceLayer <target layer (LAYERID)> <source keymap (KEYMAPID)> <source layer (LAYERID)>` will replace one layer with a layer from another keymap. You can use this to share layers across keymaps. For instance, add `replaceLayer mod QWR fn` to your `$onKeymapChange QTY` macro event to "permanently" replace the mod layer of your QTY keymap by the fn layer of the QWR keymap
 - `overlayLayer <target layer (LAYERID)> <source keymap (KEYMAPID)> <source layer (LAYERID)>` will take defined actions from the source layer and apply them on the target layer. Assume `ARR base` layer contains just arrows on `ijkl` keys. Now, in your QWERTY layout, call `overlayLayer base ARR base` and you get QWERTY that has arrows on `ijkl`.
 - `overlayKeymap KEYMAPID` as `overlayLayer`, but overlays all layers by corresponding layers of the provided keymap.
+- `replaceKeymap KEYMAPID` as `replaceLayer`, but replaces all layers by corresponding layers of the provided keymap. This is very similar to `switchKeymap`, but is useful for `$onKeymapChange` magic.
 
 ### Postponing mechanisms.
 

--- a/right/src/config_parser/parse_keymap.c
+++ b/right/src/config_parser/parse_keymap.c
@@ -428,6 +428,10 @@ void interpretConfig(parse_config_t parseConfig, layer_id_t srcLayer, layer_id_t
                 *parseMode = ParseMode_DryRun;
             }
             break;
+        case ParseKeymapMode_ReplaceKeymap:
+            *dstLayer = srcLayer;
+            *parseMode = ParseMode_FullRun;
+            break;
         default:
             {
                 Macros_ReportErrorPrintf(NULL, "Unrecognized parse mode: %d\n", parseConfig.mode);
@@ -501,7 +505,7 @@ parser_error_t ParseKeymap(config_buffer_t *buffer, uint8_t keymapIdx, uint8_t k
     }
 
 #ifdef __ZEPHYR__
-    if (parseConfig.mode == ParseKeymapMode_FullRun || parseConfig.mode == ParseKeymapMode_OverlayKeymap) {
+    if (parseConfig.mode == ParseKeymapMode_FullRun || parseConfig.mode == ParseKeymapMode_OverlayKeymap || parseConfig.mode == ParseKeymapMode_ReplaceKeymap) {
         for (uint8_t layerId = 0; layerId < LayerId_Count; layerId++) {
             StateSync_UpdateLayer(layerId, Cfg.LayerConfig[layerId].layerIsDefined);
         }

--- a/right/src/config_parser/parse_keymap.h
+++ b/right/src/config_parser/parse_keymap.h
@@ -100,6 +100,7 @@
         ParseKeymapMode_OverlayKeymap,
         ParseKeymapMode_OverlayLayer,
         ParseKeymapMode_ReplaceLayer,
+        ParseKeymapMode_ReplaceKeymap,
     } parse_keymap_mode_t;
 
     typedef enum {

--- a/right/src/keymap.c
+++ b/right/src/keymap.c
@@ -116,6 +116,15 @@ void ReplaceLayer(layer_id_t dstLayer, uint8_t srcKeymap, layer_id_t srcLayer)
     ParseKeymap(&ValidatedUserConfigBuffer, srcKeymap, AllKeymapsCount, AllMacrosCount, parseConfig);
 }
 
+void ReplaceKeymap(uint8_t srcKeymap)
+{
+    parse_config_t parseConfig = (parse_config_t) {
+        .mode = ParseKeymapMode_ReplaceKeymap,
+    };
+    ValidatedUserConfigBuffer.offset = AllKeymaps[srcKeymap].offset;
+    ParseKeymap(&ValidatedUserConfigBuffer, srcKeymap, AllKeymapsCount, AllMacrosCount, parseConfig);
+}
+
 string_segment_t GetKeymapName(uint8_t keymapId)
 {
     const char* name;

--- a/right/src/keymap.h
+++ b/right/src/keymap.h
@@ -39,5 +39,6 @@
     void OverlayKeymap(uint8_t srcKeymap);
     void OverlayLayer(layer_id_t dstLayer, uint8_t srcKeymap, layer_id_t srcLayer);
     void ReplaceLayer(layer_id_t dstLayer, uint8_t srcKeymap, layer_id_t srcLayer);
+    void ReplaceKeymap(uint8_t srcKeymap);
 
 #endif


### PR DESCRIPTION
Discussed in #1356

Changelog:
- Add `replaceKeymap` macro command
- Add `current` alias for `KEYMAPID` and `LAYERID` macro constructs.
