### PR TITLE
Fix UHK60 backlight sleep mode.

### DIFF
--- a/right/src/main.c
+++ b/right/src/main.c
@@ -83,7 +83,8 @@ static void initConfig()
 static void sendFirstReport()
 {
     bool success = false;
-    while (!success) {
+    // Wait until sending a report is successful, but don't block longer than 5 seconds.
+    while (!success && Timer_GetCurrentTime() < 5000) {
         UsbReportUpdateSemaphore |= 1 << USB_BASIC_KEYBOARD_INTERFACE_INDEX;
         usb_status_t status = UsbBasicKeyboardAction();
         if (status != kStatus_USB_Success) {
@@ -94,7 +95,7 @@ static void sendFirstReport()
         }
     }
     while (UsbReportUpdateSemaphore) {
-            __WFI();
+        __WFI();
     }
 }
 

--- a/right/src/usb_interfaces/usb_interface_basic_keyboard.c
+++ b/right/src/usb_interfaces/usb_interface_basic_keyboard.c
@@ -27,6 +27,7 @@ bool UsbBasicKeyboard_NumLockOn = false;
 bool UsbBasicKeyboard_ScrollLockOn = false;
 
 static bool needsResending = false;
+static uint8_t retries = 0;
 
 usb_hid_protocol_t usbBasicKeyboardProtocol;
 
@@ -205,7 +206,7 @@ void UsbBasicKeyboardSendActiveReport(void)
     UsbReportUpdateSemaphore |= 1 << USB_BASIC_KEYBOARD_INTERFACE_INDEX;
     usb_status_t status = UsbBasicKeyboardAction();
     //The semaphore has to be set before the call. Assume what happens if a bus reset happens asynchronously here. (Deadlock.)
-    if (status != kStatus_USB_Success) {
+    if (ShouldResendReport(status == kStatus_USB_Success, &retries)) {
         //This is *not* asynchronously safe as long as multiple reports of different type can be sent at the same time.
         //TODO: consider either making it atomic, or lowering semaphore reset delay
         needsResending = true;

--- a/right/src/usb_interfaces/usb_interface_media_keyboard.c
+++ b/right/src/usb_interfaces/usb_interface_media_keyboard.c
@@ -4,12 +4,12 @@
 #include "utils.h"
 #include "event_scheduler.h"
 
-
 uint32_t UsbMediaKeyboardActionCounter;
 static usb_media_keyboard_report_t usbMediaKeyboardReports[2];
 usb_media_keyboard_report_t* ActiveUsbMediaKeyboardReport = usbMediaKeyboardReports;
 
 static bool needsResending = false;
+static uint8_t retries = 0;
 
 static usb_media_keyboard_report_t* GetInactiveUsbMediaKeyboardReport(void)
 {
@@ -46,7 +46,7 @@ usb_status_t UsbMediaKeyboardAction(void)
 void UsbMediaKeyboardSendActiveReport(void) {
     UsbReportUpdateSemaphore |= 1 << USB_MEDIA_KEYBOARD_INTERFACE_INDEX;
     usb_status_t status = UsbMediaKeyboardAction();
-    if (status != kStatus_USB_Success) {
+    if (ShouldResendReport(status == kStatus_USB_Success, &retries)) {
         UsbReportUpdateSemaphore &= ~(1 << USB_MEDIA_KEYBOARD_INTERFACE_INDEX);
         EventVector_Set(EventVector_ResendUsbReports);
         needsResending = true;

--- a/right/src/usb_interfaces/usb_interface_mouse.c
+++ b/right/src/usb_interfaces/usb_interface_mouse.c
@@ -4,12 +4,14 @@
 #include "event_scheduler.h"
 #include "attributes.h"
 #include "macros/status_buffer.h"
+#include "utils.h"
 
 #ifdef __ZEPHYR__
 #include "usb/usb_compatibility.h"
 #endif
 
 static bool needsResending = false;
+static uint8_t retries = 0;
 
 #include "usb_descriptors/usb_descriptor_mouse_report.h"
 
@@ -178,7 +180,7 @@ void UsbMouseSendActiveReport(void)
 #else
     UsbReportUpdateSemaphore |= 1 << USB_MOUSE_INTERFACE_INDEX;
     usb_status_t status = UsbMouseAction();
-    if (status != kStatus_USB_Success) {
+    if (ShouldResendReport(status == kStatus_USB_Success, &retries)) {
         UsbReportUpdateSemaphore &= ~(1 << USB_MOUSE_INTERFACE_INDEX);
         EventVector_Set(EventVector_ResendUsbReports);
         needsResending = true;

--- a/right/src/usb_interfaces/usb_interface_system_keyboard.c
+++ b/right/src/usb_interfaces/usb_interface_system_keyboard.c
@@ -2,12 +2,14 @@
 #include "usb_composite_device.h"
 #include "usb_report_updater.h"
 #include "event_scheduler.h"
+#include "utils.h"
 
 #ifndef UTILS_ARRAY_SIZE
 #define UTILS_ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 #endif
 
 static bool needsResending = false;
+static uint8_t retries = 0;
 
 uint32_t UsbSystemKeyboardActionCounter;
 static usb_system_keyboard_report_t usbSystemKeyboardReports[2];
@@ -50,7 +52,7 @@ usb_status_t UsbSystemKeyboardAction(void)
 void UsbSystemKeyboardSendActiveReport(void) {
     UsbReportUpdateSemaphore |= 1 << USB_SYSTEM_KEYBOARD_INTERFACE_INDEX;
     usb_status_t status = UsbSystemKeyboardAction();
-    if (status != kStatus_USB_Success) {
+    if (ShouldResendReport(status == kStatus_USB_Success, &retries)) {
         UsbReportUpdateSemaphore &= ~(1 << USB_SYSTEM_KEYBOARD_INTERFACE_INDEX);
         EventVector_Set(EventVector_ResendUsbReports);
         needsResending = true;

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -785,7 +785,7 @@ static void sendActiveReports(bool resending) {
             usbReportsChangedByAction = true;
             usbReportsChangedByAnything = true;
             lastBasicReportTime = Timer_GetCurrentTime();
-            UsbReportUpdater_LastActivityTime = Timer_GetCurrentTime();
+            UsbReportUpdater_LastActivityTime = resending ? UsbReportUpdater_LastActivityTime : Timer_GetCurrentTime();
         }
     }
 
@@ -794,21 +794,21 @@ static void sendActiveReports(bool resending) {
         UsbCompatibility_SendConsumerReport(ActiveUsbMediaKeyboardReport, ActiveUsbSystemKeyboardReport);
         SwitchActiveUsbMediaKeyboardReport();
         SwitchActiveUsbSystemKeyboardReport();
-        UsbReportUpdater_LastActivityTime = Timer_GetCurrentTime();
+        UsbReportUpdater_LastActivityTime = resending ? UsbReportUpdater_LastActivityTime : Timer_GetCurrentTime();
         usbReportsChangedByAction = true;
         usbReportsChangedByAnything = true;
     }
 #else
     if ((UsbMediaKeyboardCheckReportReady(resending) == kStatus_USB_Success) && (CurrentPowerMode == PowerMode_Awake)) {
         UsbMediaKeyboardSendActiveReport();
-        UsbReportUpdater_LastActivityTime = Timer_GetCurrentTime();
+        UsbReportUpdater_LastActivityTime = resending ? UsbReportUpdater_LastActivityTime : Timer_GetCurrentTime();
         usbReportsChangedByAction = true;
         usbReportsChangedByAnything = true;
     }
 
     if ((UsbSystemKeyboardCheckReportReady(resending) == kStatus_USB_Success) && (CurrentPowerMode == PowerMode_Awake)) {
         UsbSystemKeyboardSendActiveReport();
-        UsbReportUpdater_LastActivityTime = Timer_GetCurrentTime();
+        UsbReportUpdater_LastActivityTime = resending ? UsbReportUpdater_LastActivityTime : Timer_GetCurrentTime();
         usbReportsChangedByAction = true;
         usbReportsChangedByAnything = true;
     }
@@ -819,7 +819,7 @@ static void sendActiveReports(bool resending) {
         // Macros_Printf("sm\n");
 
         UsbMouseSendActiveReport();
-        UsbReportUpdater_LastActivityTime = Timer_GetCurrentTime();
+        UsbReportUpdater_LastActivityTime = resending ? UsbReportUpdater_LastActivityTime : Timer_GetCurrentTime();
         usbReportsChangedByAction |= usbMouseButtonsChanged;
         usbReportsChangedByAnything = true;
     }

--- a/right/src/utils.c
+++ b/right/src/utils.c
@@ -150,3 +150,18 @@ const char* Utils_KeyAbbreviation(key_state_t* keyState)
     uint8_t keyId = Utils_KeyStateToKeyId(keyState);
     return MacroKeyIdParser_KeyIdToAbbreviation(keyId);
 }
+
+bool ShouldResendReport(bool statusOk, uint8_t* counter) {
+    static uint8_t resendCount = 0;
+    if (statusOk) {
+        resendCount = 0;
+        return false;
+    }
+
+    if (*counter < 5) {
+        (*counter)++;
+        return true;
+    } {
+        return false;
+    }
+}

--- a/right/src/utils.c
+++ b/right/src/utils.c
@@ -160,13 +160,16 @@ bool ShouldResendReport(bool statusOk, uint8_t* counter) {
         return false;
     }
 
+    // keep this low, since the actual delay this causes with a full queue is
+    // queueLength * maxDelay
+    const uint16_t maxDelay = 128; //ms
     const uint8_t granularity = 16; //ms
     uint8_t minimizedTime = Timer_GetCurrentTime() / granularity;
 
     if (*counter == 0) {
         *counter = minimizedTime;
         return true;
-    } else if ((uint8_t)(minimizedTime - *counter) < (512 / granularity)) {
+    } else if ((uint8_t)(minimizedTime - *counter) < (maxDelay / granularity)) {
         return true;
     } else {
         *counter = 0;

--- a/right/src/utils.h
+++ b/right/src/utils.h
@@ -41,6 +41,7 @@ if (reentrancyGuard_active) {                    \
     void Utils_PrintReport(const char* prefix, usb_basic_keyboard_report_t* report);
     key_coordinates_t Utils_KeyIdToKeyCoordinates(uint16_t keyId);
     const char* Utils_KeyAbbreviation(key_state_t* keyState);
+    bool ShouldResendReport(bool statusOk, uint8_t* counter);
 
 
 #endif /* SRC_UTILS_H_ */


### PR DESCRIPTION
Closes #1176 

Reproduction steps:
- set backlight fade timeout on a UHK60 to say 4 seconds
- connect uhk60 into a dumb usb charger (the older, the better)
- observe that after four seconds it doesn't turn its backlight of
- in case it does, tap some key (a one that has a scancode mapped)
- again observe that after four seconds it doesn't turn its backlight of 

