### PR TITLE
UHK80 linux scrolling workaround

### DIFF
--- a/device/src/usb/mouse_app.cpp
+++ b/device/src/usb/mouse_app.cpp
@@ -21,10 +21,14 @@ mouse_app &mouse_app::ble_handle()
 
 void mouse_app::start(hid::protocol prot)
 {
-    // TODO start handling mouse events
     report_buffer_ = {};
-    resolution_buffer_ = {};
     receive_report(&resolution_buffer_);
+}
+
+void mouse_app::stop()
+{
+    app_base::stop();
+    set_resolution_report({});
 }
 
 void mouse_app::set_report_state(const mouse_report_base<> &data)
@@ -37,9 +41,13 @@ void mouse_app::set_report(hid::report::type type, const std::span<const uint8_t
     if (hid::report::selector(type, data.front()) != resolution_buffer_.selector()) {
         return;
     }
-    resolution_buffer_ = *reinterpret_cast<const decltype(resolution_buffer_) *>(data.data());
+    set_resolution_report(*reinterpret_cast<const decltype(resolution_buffer_) *>(data.data()));
     receive_report(&resolution_buffer_);
+}
 
+void mouse_app::set_resolution_report(const scroll_resolution_report &report)
+{
+    resolution_buffer_ = report;
     // When running on dongle, update the scroll multiplier state
     if (DEVICE_IS_UHK_DONGLE) {
         DongleScrollMultipliers.vertical = resolution_buffer_.vertical_scroll_multiplier();

--- a/device/src/usb/mouse_app.hpp
+++ b/device/src/usb/mouse_app.hpp
@@ -89,22 +89,25 @@ class mouse_app : public app_base {
 
     void set_report_state(const mouse_report_base<> &data);
 
+    using scroll_resolution_report =
+        hid::app::mouse::resolution_multiplier_report<MAX_SCROLL_RESOLUTION,
+            report_ids::FEATURE_MOUSE>;
+
   private:
     mouse_app() : app_base(this, report_buffer_) {}
 
     void start(hid::protocol prot) override;
+    void stop() override;
     void set_report(hid::report::type type, const std::span<const uint8_t> &data) override;
     void get_report(hid::report::selector select, const std::span<uint8_t> &buffer) override;
 
     using mouse_report = mouse_report_base<report_ids::IN_MOUSE>;
     C2USB_USB_TRANSFER_ALIGN(mouse_report, report_buffer_) {};
-    using scroll_resolution_report =
-        hid::app::mouse::resolution_multiplier_report<MAX_SCROLL_RESOLUTION,
-            report_ids::FEATURE_MOUSE>;
     C2USB_USB_TRANSFER_ALIGN(scroll_resolution_report, resolution_buffer_) {};
 
   public:
     const auto &resolution_report() const { return resolution_buffer_; }
+    void set_resolution_report(const scroll_resolution_report &report);
 };
 
 using mouse_buffer = mouse_app::mouse_report_base<>;

--- a/device/src/usb/usb.cpp
+++ b/device/src/usb/usb.cpp
@@ -11,8 +11,8 @@ extern "C" {
 #include "timer.h"
 #include "usb_report_updater.h"
 #include "user_logic.h"
-#include <zephyr/kernel.h>
 #include <nrfx_power.h>
+#include <zephyr/kernel.h>
 }
 #include "command_app.hpp"
 #include "controls_app.hpp"
@@ -55,7 +55,8 @@ class multi_hid : public hid::multi_application {
     }
 
   private:
-    std::array<hid::application *, sizeof...(Args) + 1> app_array_{(&Args::ble_handle())..., nullptr};
+    std::array<hid::application *, sizeof...(Args) + 1> app_array_{
+        (&Args::ble_handle())..., nullptr};
     multi_hid() : multi_application({{}, 0, 0, 0}, app_array_)
     {
         static constexpr const auto desc = report_desc();
@@ -138,7 +139,9 @@ struct usb_manager {
                 usb::df::microsoft::xconfig(
                     usb_xpad, usb::endpoint::address(0x85), 1, usb::endpoint::address(0x05), 255));
 
-        printk("USB config changing to %s\n", magic_enum::enum_name(conf).data() == NULL ? "NULL" : magic_enum::enum_name(conf).data());
+        printk("USB config changing to %s\n", magic_enum::enum_name(conf).data() == NULL
+                                                  ? "NULL"
+                                                  : magic_enum::enum_name(conf).data());
         if (conf == Hid_NoGamepad) {
             ms_enum_.set_config({});
             device_.set_config(base_config);
@@ -150,23 +153,24 @@ struct usb_manager {
     }
 
     usb_manager()
-     : mac_{DEVICE_DT_GET(DT_NODELABEL(zephyr_udc0)),
-        (nrfx_power_usbstatus_get() == NRFX_POWER_USB_STATE_CONNECTED) ?
-        usb::power::state::L2_SUSPEND : usb::power::state::L3_OFF}
+        : mac_{DEVICE_DT_GET(DT_NODELABEL(zephyr_udc0)),
+              (nrfx_power_usbstatus_get() == NRFX_POWER_USB_STATE_CONNECTED)
+                  ? usb::power::state::L2_SUSPEND
+                  : usb::power::state::L3_OFF}
     {
         device_.set_power_event_delegate([](usb::df::device &dev, usb::df::device::event ev) {
             using event = enum usb::df::device::event;
             if ((ev & event::POWER_STATE_CHANGE) != event::NONE) {
                 switch (dev.power_state()) {
-                    case usb::power::state::L2_SUSPEND:
-                        PowerMode_SetUsbAwake(false);
-                        break;
-                    case usb::power::state::L0_ON:
-                        PowerMode_SetUsbAwake(true);
-                        break;
-                    default:
-                        break;
-                    }
+                case usb::power::state::L2_SUSPEND:
+                    PowerMode_SetUsbAwake(false);
+                    break;
+                case usb::power::state::L0_ON:
+                    PowerMode_SetUsbAwake(true);
+                    break;
+                default:
+                    break;
+                }
             }
         });
     }


### PR DESCRIPTION
This is an attempt to fix slow scrolling after suspend on Linux. @kareltucek please test. If it's still not working, please rebuild cleanly, with `device/Kconfig`'s `LOG_DEFAULT_MINIMAL` set to `default n`, and send me the log output.