### PR TITLE
Fix layer hold bug.

### DIFF
--- a/right/src/config_parser/parse_keymap.c
+++ b/right/src/config_parser/parse_keymap.c
@@ -514,5 +514,9 @@ parser_error_t ParseKeymap(config_buffer_t *buffer, uint8_t keymapIdx, uint8_t k
     }
 #endif
 
+    if (parseConfig.mode != ParseKeymapMode_DryRun) {
+        LayerSwitcher_MarkMappingsChanged();
+    }
+
     return ParserError_Success;
 }

--- a/right/src/layer_switcher.c
+++ b/right/src/layer_switcher.c
@@ -176,6 +176,8 @@ void LayerSwitcher_UnToggleLayerOnly(layer_id_t layer) {
 
 static bool heldLayers[LayerId_Count];
 
+static bool mappingsChanged = false;
+
 // Called by pressed hold-layer keys during every cycle
 void LayerSwitcher_HoldLayer(layer_id_t layer, bool forceSwap) {
     heldLayers[layer] = true;
@@ -232,12 +234,23 @@ void LayerSwitcher_UpdateHeldLayer() {
     if (previousHeldLayer != heldLayer) {
         updateActiveLayer();
     }
+
+    if (mappingsChanged) {
+        // this runs before a native action update, so update native actions, and in next cycle, update layer holds again
+        EventVector_Set(EventVector_NativeActions | EventVector_LayerHolds);
+        mappingsChanged = false;
+    }
 }
 
 void LayerSwitcher_ResetHolds() {
     for (uint8_t i = 0; i < LayerId_Count; i++) {
         heldLayers[i] = false;
     }
+}
+
+void LayerSwitcher_MarkMappingsChanged() {
+    EventVector_Unset(EventVector_LayerHolds);
+    mappingsChanged = true;
 }
 
 /**

--- a/right/src/layer_switcher.h
+++ b/right/src/layer_switcher.h
@@ -31,4 +31,6 @@
 
     void LayerSwitcher_RecalculateLayerComposition();
 
+    void LayerSwitcher_MarkMappingsChanged();
+
 #endif /* SRC_LAYER_SWITCHER_H_ */

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -412,6 +412,8 @@ void ApplyKeyAction(key_state_t *keyState, key_action_cached_t *cachedAction, ke
             if (keyState->current != keyState->previous) {
                 applyToggleLayerAction(keyState, action);
             }
+            // also apply holds in order to process the cached action
+            applyLayerHolds(keyState, action);
             break;
         case KeyActionType_SwitchKeymap:
             if (KeyState_ActivatedNow(keyState)) {


### PR DESCRIPTION
Steps to reproduce: well described in https://github.com/UltimateHackingKeyboard/firmware/issues/1377#issuecomment-3429264710 (The key part is that the fn switch is mapped on different keys in the two keymaps.)

Closes https://github.com/UltimateHackingKeyboard/firmware/issues/1377

Changelog:
- Fix stuck layer when switching keymaps. (When a held switch is not mapped in the new keymap.)