### PR TITLE
Fix reset button induced "crashes".

### DIFF
--- a/right/src/main.c
+++ b/right/src/main.c
@@ -206,7 +206,7 @@ int main(void)
 {
     Trace_Init();
     if (StateWormhole_IsOpen()) {
-        if (StateWormhole.wasReboot || Trace_LooksLikeNaturalCauses() || !StateWormhole.devMode) {
+        if (StateWormhole.wasReboot || Trace_LooksLikeNaturalCauses()) {
             // Looks like a normal reboot or power on startup
             MacroStatusBuffer_InitNormal();
         }

--- a/right/src/peripherals/reset_button.c
+++ b/right/src/peripherals/reset_button.c
@@ -1,13 +1,31 @@
 #include <stdbool.h>
 #include "reset_button.h"
+#include "timer.h"
 #ifndef __ZEPHYR__
 #include "fsl_port.h"
 #include "bootloader/wormhole.h"
 #include "wormhole.h"
 #include "trace.h"
+#include "config_manager.h"
+#include "macros/status_buffer.h"
 
 void RESET_BUTTON_IRQ_HANDLER(void)
 {
+    static uint8_t count = 0;
+
+    if (count++ > 10) {
+        DisableIRQ(RESET_BUTTON_IRQ);
+        Macros_ReportError("Looks like spurious factory button activation. Disabling factory button. Please report this.", NULL, NULL);
+    }
+
+    // We are getting spurious activations, so check that it is pressed for at least some 20ms straight
+    for (volatile uint32_t i = 0; i < 300*1000; i++) {
+    }
+
+    if (!RESET_BUTTON_IS_PRESSED) {
+        return;
+    }
+
     StateWormhole.wasReboot = true;
     Wormhole.magicNumber = WORMHOLE_MAGIC_NUMBER;
     Wormhole.enumerationMode = EnumerationMode_NormalKeyboard;


### PR DESCRIPTION
Closes #1380 

Changelog:
- Prevent crashes due to spurious activations of uhk60 reset button: 
  - Require the button to be continually pressed for at least 20ms.
  - If too many such activations are encountered, disable the button entirelly and report to the user. 
  - Leave general uhk60 crash logging on by default - let's squash all crash scenarios!