### PR TITLE
Firngrod/timeout noop option

### DIFF
--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -146,7 +146,7 @@ COMMAND = set module.touchpad.pinchZoomMode NAVIGATION_MODE
 COMMAND = set module.touchpad.holdContinuationTimeout <0-65535 (INT)>
 COMMAND = set secondaryRole.defaultStrategy { simple | advanced }
 COMMAND = set secondaryRole.advanced.timeout <ms, 0-500 (INT)>
-COMMAND = set secondaryRole.advanced.timeoutAction { primary | secondary }
+COMMAND = set secondaryRole.advanced.timeoutAction { primary | secondary | noAction }
 COMMAND = set secondaryRole.advanced.safetyMargin <ms, higher value adjusts sensitivity towards primary role -50-50 (INT)>
 COMMAND = set secondaryRole.advanced.triggerByPress <trigger immediately on action key press (BOOL)>
 COMMAND = set secondaryRole.advanced.triggerByRelease <trigger secondary role if action key is released before dual role (BOOL)>
@@ -688,7 +688,7 @@ Internally, values are saved in one of the following types, and types are automa
     - simple strategy listens for other key activations until the dual-role key is released. If there is any such activation, it activates the secondary role and then the action of the other key without any further delays. If there is no such other action, it performs primary role on the dual-role key release.
     - advanced strategy may trigger secondary role depending on timeout, or depending on key release order.
       - `set secondaryRole.advanced.timeout <timeout in ms, 350 (INT)>` if this timeout is reached, `timeoutAction` (secondary by default) role is activated.
-      - `set secondaryRole.advanced.timeoutAction { primary | secondary }` defines whether the primary action or the secondary role should be activated when timeout is reached
+      - `set secondaryRole.advanced.timeoutAction { primary | secondary | noAction}` defines whether the primary action or the secondary role, or no action at all, should be activated when timeout is reached
       - `set secondaryRole.advanced.triggerByRelease BOOL` if enabled, secondary role is chosen depending on the release order of the keys (`press-A, press-B, release-B, release-A` leads to secondary action; `press-A, press-B, release-A, release-B` leads to primary action). This is further modified by safetyMargin.
       - `set secondaryRole.advanced.triggerByPress BOOL` if enabled, secondary role is triggered when there is another press, simiarly to the simple strategy. Unlike simple strategy, this allows setting timeout behaviors, and also is modified by safetyMargin.
       - `set secondaryRole.advanced.triggerByMouse BOOL` if enabled, any mouse (module) activity triggers secondary role immediately.

--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -146,7 +146,7 @@ COMMAND = set module.touchpad.pinchZoomMode NAVIGATION_MODE
 COMMAND = set module.touchpad.holdContinuationTimeout <0-65535 (INT)>
 COMMAND = set secondaryRole.defaultStrategy { simple | advanced }
 COMMAND = set secondaryRole.advanced.timeout <ms, 0-500 (INT)>
-COMMAND = set secondaryRole.advanced.timeoutAction { primary | secondary | noAction }
+COMMAND = set secondaryRole.advanced.timeoutAction { primary | secondary | none }
 COMMAND = set secondaryRole.advanced.safetyMargin <ms, higher value adjusts sensitivity towards primary role -50-50 (INT)>
 COMMAND = set secondaryRole.advanced.triggerByPress <trigger immediately on action key press (BOOL)>
 COMMAND = set secondaryRole.advanced.triggerByRelease <trigger secondary role if action key is released before dual role (BOOL)>
@@ -688,7 +688,7 @@ Internally, values are saved in one of the following types, and types are automa
     - simple strategy listens for other key activations until the dual-role key is released. If there is any such activation, it activates the secondary role and then the action of the other key without any further delays. If there is no such other action, it performs primary role on the dual-role key release.
     - advanced strategy may trigger secondary role depending on timeout, or depending on key release order.
       - `set secondaryRole.advanced.timeout <timeout in ms, 350 (INT)>` if this timeout is reached, `timeoutAction` (secondary by default) role is activated.
-      - `set secondaryRole.advanced.timeoutAction { primary | secondary | noAction}` defines whether the primary action or the secondary role, or no action at all, should be activated when timeout is reached
+      - `set secondaryRole.advanced.timeoutAction { primary | secondary | none}` defines whether the primary action or the secondary role, or no action at all, should be activated when timeout is reached
       - `set secondaryRole.advanced.triggerByRelease BOOL` if enabled, secondary role is chosen depending on the release order of the keys (`press-A, press-B, release-B, release-A` leads to secondary action; `press-A, press-B, release-A, release-B` leads to primary action). This is further modified by safetyMargin.
       - `set secondaryRole.advanced.triggerByPress BOOL` if enabled, secondary role is triggered when there is another press, simiarly to the simple strategy. Unlike simple strategy, this allows setting timeout behaviors, and also is modified by safetyMargin.
       - `set secondaryRole.advanced.triggerByMouse BOOL` if enabled, any mouse (module) activity triggers secondary role immediately.

--- a/doc-dev/user-guide.md
+++ b/doc-dev/user-guide.md
@@ -479,7 +479,7 @@ Firngrod's Home Row Mods (HRM) configuration (Recommended):
 ```
 set secondaryRole.defaultStrategy advanced
 set secondaryRole.advanced.triggerByRelease 1
-set secondaryRole.advanced.timeout 1000
+set secondaryRole.advanced.timeout 300
 set secondaryRole.advanced.timeoutAction secondary
 set secondaryRole.advanced.doubletapToPrimary 1
 set secondaryRole.advanced.safetyMargin -100

--- a/right/src/key_states.h
+++ b/right/src/key_states.h
@@ -13,8 +13,8 @@
 
     typedef enum {
         SecondaryRoleState_DontKnowYet,
-        SecondaryRoleState_Secondary,
         SecondaryRoleState_Primary,
+        SecondaryRoleState_Secondary,
         SecondaryRoleState_NoOp,
     } secondary_role_state_t;
 

--- a/right/src/key_states.h
+++ b/right/src/key_states.h
@@ -11,7 +11,7 @@
 
 // Typedefs:
 
-    typedef enum : uint8_t {
+    typedef enum {
         SecondaryRoleState_DontKnowYet,
         SecondaryRoleState_Secondary,
         SecondaryRoleState_Primary,

--- a/right/src/key_states.h
+++ b/right/src/key_states.h
@@ -11,6 +11,13 @@
 
 // Typedefs:
 
+    typedef enum : uint8_t {
+        SecondaryRoleState_DontKnowYet,
+        SecondaryRoleState_Secondary,
+        SecondaryRoleState_Primary,
+        SecondaryRoleState_NoOp,
+    } secondary_role_state_t;
+
     // Next is used as an accumulator of the state - asynchronous state updates
     // are stored there. The hardwareSwitchState always contains the most up-to-date
     // information about hardware state of the switch.
@@ -29,7 +36,7 @@
         bool current : 1;
         bool previous : 1;
         bool debouncing : 1;
-        bool secondary : 1;
+        secondary_role_state_t secondaryState : 2;
     } key_state_t;
 
 // Variables:

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1029,11 +1029,10 @@ static macro_result_t processIfSecondaryCommand(parser_context_t* ctx, bool nega
     }
 
     postponeCurrentCycle();
-    secondary_role_result_t res = SecondaryRoles_ResolveState(S->ms.currentMacroKey, strategy, true, fromSameHalf);
+    secondary_role_state_t res = SecondaryRoles_ResolveState(S->ms.currentMacroKey, strategy, true, fromSameHalf);
 
-    S->as.actionActive = res.state == SecondaryRoleState_DontKnowYet;
-
-    switch(res.state) {
+    S->as.actionActive = res == SecondaryRoleState_DontKnowYet;
+    switch(res) {
     case SecondaryRoleState_DontKnowYet:
         // secondary role driver has its own scheduler hook to wake us up
         return MacroResult_Sleeping;

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1029,7 +1029,7 @@ static macro_result_t processIfSecondaryCommand(parser_context_t* ctx, bool nega
     }
 
     postponeCurrentCycle();
-    secondary_role_result_t res = SecondaryRoles_ResolveState(S->ms.currentMacroKey, strategy, !S->as.actionActive, true, fromSameHalf);
+    secondary_role_result_t res = SecondaryRoles_ResolveState(S->ms.currentMacroKey, strategy, true, fromSameHalf);
 
     S->as.actionActive = res.state == SecondaryRoleState_DontKnowYet;
 
@@ -1050,7 +1050,10 @@ static macro_result_t processIfSecondaryCommand(parser_context_t* ctx, bool nega
         } else {
             goto conditionPassed;
         }
+    case SecondaryRoleState_NoOp:
+        return MacroResult_Finished | MacroResult_ConditionFailedFlag;
     }
+     
 conditionPassed:
     S->ls->as.currentIfSecondaryConditionPassed = true;
     S->ls->as.currentConditionPassed = false; //otherwise following conditions would be skipped

--- a/right/src/secondary_role_driver.c
+++ b/right/src/secondary_role_driver.c
@@ -256,27 +256,20 @@ static secondary_role_state_t resolveCurrentKeyRoleIfDontKnowSimple()
 
 static secondary_role_state_t resolveCurrentKey(secondary_role_strategy_t strategy)
 {
-    switch (resolutionKey->secondaryState) {
-    case SecondaryRoleState_Primary:
-    case SecondaryRoleState_Secondary:
-        return resolutionKey->secondaryState;
-    case SecondaryRoleState_DontKnowYet:
-        if (activateSecondaryImmediately) {
-            activateSecondaryImmediately = false;
-            KEY_TIMING(KeyTiming_RecordComment(resolutionKey, "SM"));
-            return SecondaryRoleState_Secondary;
-        }
-        switch (strategy) {
+    if (activateSecondaryImmediately) {
+        activateSecondaryImmediately = false;
+        KEY_TIMING(KeyTiming_RecordComment(resolutionKey, "SM"));
+        return SecondaryRoleState_Secondary;
+    }
+    switch (strategy) {
         case SecondaryRoleStrategy_Simple:
             return resolveCurrentKeyRoleIfDontKnowSimple();
         default:
         case SecondaryRoleStrategy_Advanced:
             return resolveCurrentKeyRoleIfDontKnowTimeout();
-        }
-    default:
-        return SecondaryRoleState_DontKnowYet; // prevent warning
     }
 }
+
 
 static void startResolution(
     key_state_t *keyState,

--- a/right/src/secondary_role_driver.c
+++ b/right/src/secondary_role_driver.c
@@ -98,7 +98,6 @@ static void sleepTimeoutStrategy(uint16_t wakeTimeOffset) {
 static secondary_role_state_t resolveCurrentKeyRoleIfDontKnowTimeout()
 {
     //gather data
-    uint32_t dualRolePressTime = resolutionStartTime;
     postponer_buffer_record_type_t *dummy;
     postponer_buffer_record_type_t *dualRoleRelease;
     postponer_buffer_record_type_t *actionPress;
@@ -114,7 +113,7 @@ static secondary_role_state_t resolveCurrentKeyRoleIfDontKnowTimeout()
     uint16_t actionKeyId = actionPress != NULL ? Utils_KeyStateToKeyId(actionPress->event.key.keyState) : 255;
     uint16_t dualRoleId = Utils_KeyStateToKeyId(resolutionKey);
 
-    int32_t activeTime = (dualRoleRelease == NULL ? Timer_GetCurrentTime() : dualRoleRelease->time) - dualRolePressTime;
+    int32_t activeTime = (dualRoleRelease == NULL ? Timer_GetCurrentTime() : dualRoleRelease->time) - resolutionStartTime;
     bool dualRoleWasHeldLongEnoughToBeAllowedSecondary = activeTime >= Cfg.SecondaryRoles_AdvancedStrategyMinimumHoldTime;
 
     if (dualRoleRelease != NULL && !dualRoleWasHeldLongEnoughToBeAllowedSecondary) {

--- a/right/src/secondary_role_driver.h
+++ b/right/src/secondary_role_driver.h
@@ -56,11 +56,6 @@
         Stick_Always
     } sticky_strategy_t;
 
-    typedef enum {
-        SecondaryRoleState_DontKnowYet,
-        SecondaryRoleState_Secondary,
-        SecondaryRoleState_Primary,
-    } secondary_role_state_t;
 
     typedef enum {
         SecondaryRoleStrategy_Simple,
@@ -82,10 +77,10 @@
 
 // Functions:
 
-    secondary_role_result_t SecondaryRoles_ResolveState(key_state_t* keyState, secondary_role_strategy_t strategy, bool isNewResolution, bool isMacroResolution, secondary_role_same_half_t fromSameHalf);
-    void SecondaryRoles_FakeActivation(secondary_role_result_t res);
+    secondary_role_result_t SecondaryRoles_ResolveState(key_state_t* keyState, secondary_role_strategy_t strategy, bool isMacroResolution, secondary_role_same_half_t fromSameHalf);
+    void SecondaryRoles_FakeActivation();
     void SecondaryRoles_ActivateSecondaryImmediately();
 
-
+    void SecondaryRoles_ResetResolution(key_state_t* keyState);
 
 #endif /* SRC_SECONDARY_ROLE_DRIVER_H_ */

--- a/right/src/secondary_role_driver.h
+++ b/right/src/secondary_role_driver.h
@@ -62,11 +62,6 @@
         SecondaryRoleStrategy_Advanced
     } secondary_role_strategy_t;
 
-    typedef struct {
-        secondary_role_state_t state;
-        bool activatedNow;
-    } secondary_role_result_t;
-
     typedef enum {
         SecondaryRole_DefaultFromSameHalf,
         SecondaryRole_PrimaryFromSameHalf,
@@ -77,10 +72,9 @@
 
 // Functions:
 
-    secondary_role_result_t SecondaryRoles_ResolveState(key_state_t* keyState, secondary_role_strategy_t strategy, bool isMacroResolution, secondary_role_same_half_t fromSameHalf);
-    void SecondaryRoles_FakeActivation();
     void SecondaryRoles_ActivateSecondaryImmediately();
 
-    void SecondaryRoles_ResetResolution(key_state_t* keyState);
+    secondary_role_state_t SecondaryRoles_ResolveState(key_state_t* keyState, secondary_role_strategy_t strategy, bool isMacroResolution, secondary_role_same_half_t actionFromSameHalf);
+
 
 #endif /* SRC_SECONDARY_ROLE_DRIVER_H_ */

--- a/right/src/str_utils.c
+++ b/right/src/str_utils.c
@@ -466,7 +466,7 @@ secondary_role_state_t ConsumeSecondaryRoleTimeoutAction(parser_context_t* ctx)
     else if (ConsumeToken(ctx, "secondary")) {
         return SecondaryRoleState_Secondary;
     }
-    else if (ConsumeToken(ctx, "noAction")) {
+    else if (ConsumeToken(ctx, "none")) {
         return SecondaryRoleState_NoOp;
     }
     else {

--- a/right/src/str_utils.c
+++ b/right/src/str_utils.c
@@ -466,6 +466,9 @@ secondary_role_state_t ConsumeSecondaryRoleTimeoutAction(parser_context_t* ctx)
     else if (ConsumeToken(ctx, "secondary")) {
         return SecondaryRoleState_Secondary;
     }
+    else if (ConsumeToken(ctx, "noAction")) {
+        return SecondaryRoleState_NoOp;
+    }
     else {
         Macros_ReportError("Parameter not recognized:", ctx->at, ctx->end);
         return SecondaryRoleState_DontKnowYet;

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -323,14 +323,8 @@ static void applyKeystroke(key_state_t *keyState, key_action_cached_t *cachedAct
 {
     key_action_t* action = &cachedAction->action;
     if (action->keystroke.secondaryRole) {
-        if ( KeyState_ActivatedNow(keyState) ) {
-            SecondaryRoles_ResetResolution(keyState);
-        }
-        secondary_role_result_t res = SecondaryRoles_ResolveState(keyState, Cfg.SecondaryRoles_Strategy, false, SecondaryRole_DefaultFromSameHalf);
-        if (res.activatedNow) {
-            SecondaryRoles_FakeActivation();
-        }
-        switch (res.state) {
+        secondary_role_state_t res = SecondaryRoles_ResolveState(keyState, Cfg.SecondaryRoles_Strategy, false, SecondaryRole_DefaultFromSameHalf);
+        switch (res) {
             case SecondaryRoleState_Primary:
                 applyKeystrokePrimary(keyState, cachedAction, reports);
                 return;
@@ -428,7 +422,6 @@ void ApplyKeyAction(key_state_t *keyState, key_action_cached_t *cachedAction, ke
             break;
         case KeyActionType_PlayMacro:
             if (KeyState_ActivatedNow(keyState)) {
-                SecondaryRoles_ResetResolution(keyState);
                 resetStickyMods(cachedAction);
                 Macros_StartMacro(action->playMacro.macroId, keyState, action->playMacro.offset, keyState->timestamp, 255, true);
             }
@@ -643,6 +636,7 @@ static void updateActionStates() {
                     // cache action so that key's meaning remains the same as long
                     // as it is pressed
                     actionCache[slotId][keyId].modifierLayerMask = 0;
+                    keyState->secondaryState = SecondaryRoleState_DontKnowYet;
 
                     if (CurrentPowerMode > PowerMode_LastAwake && CurrentPowerMode <= PowerMode_LightSleep) {
                         Trace_Printf("y1.%d", CurrentPowerMode);


### PR DESCRIPTION
The biggest change in this PR is how the caching of resolutions of secondary key state is handled.  Now the fact that a key needs a new resolution is explicitly set for new presses both in the case of secondary role keys and macros.  The big difference here is that a macro will only allow this resolution to run once for it's triggering key, and any future `ifPrimary/ifSecondary` will reference the outcome of that first resolution.

Then I've also added a "no action" resolution option, currently available only on timeout.  It's not that I'm actually going to use that before I have added more logic, but it's a necessity for what I want to make next.

As mentioned in the comments, I am not really happy with how the cache is managed.  There is a mixture of responsibility of values and variables which I don't like.
The best solution in my opinion would be to add another bit to the key state struct for resolution cache tracking, either by an explicit value, or more flexibly by expanding the state enum.  Expanding the state enum would make it 5 values, thus requiring a third bit, but then additional values could be added later.  The reason I have not done so already is that it would take another bit of memory for each key, in addition to what I've already added.

Otherwise, I have tested the changes to the logic by running it for a few days with no issues.