### PR TITLE
Ble fixes.

### DIFF
--- a/device/src/bt_advertise.c
+++ b/device/src/bt_advertise.c
@@ -248,7 +248,7 @@ adv_config_t BtAdvertise_Config() {
                         return ADVERTISEMENT( 0 );
                     }
                 }
-                else if (BtConn_ConnectedHidCount() > 0) {
+                else if (BtConn_ConnectedHidCount(NULL) > 0) {
                     /** we can't handle multiple HID connections, so don't advertise it when one HID is already connected */
                     return ADVERTISEMENT(ADVERTISE_NUS);
                 } else {

--- a/device/src/bt_conn.c
+++ b/device/src/bt_conn.c
@@ -820,7 +820,7 @@ static void pairing_complete(struct bt_conn *conn, bool bonded) {
             Bt_NewPairedDevice = true;
         }
 
-        HostConnections_SelectByHostConnIndex(connectionId - ConnectionId_HostConnectionFirst);
+        HostConnection_SetSelectedConnection(connectionId);
 
         LOG_INF("Pairing complete, passing connection %d to authenticatedConnection handler. Selected conn is %d\n", connectionId, SelectedHostConnectionId);
 

--- a/device/src/bt_conn.h
+++ b/device/src/bt_conn.h
@@ -79,7 +79,7 @@ typedef enum {
     void Bt_SetEnabled(bool enabled);
     void BtConn_MakeSpaceForHid();
 
-    uint8_t BtConn_ConnectedHidCount();
+    uint8_t BtConn_ConnectedHidCount(const bt_addr_le_t* excludeAddr);
 
     static inline bool BtAddrEq(const bt_addr_le_t *a, const bt_addr_le_t *b) {
         return 0 == memcmp(a->a.val, b->a.val, sizeof(a->a.val));

--- a/right/src/bt_defs.h
+++ b/right/src/bt_defs.h
@@ -13,10 +13,10 @@
 // Typedefs:
 
     typedef enum {
-        PairingMode_Oob,
-        PairingMode_PairHid,
-        PairingMode_Advertise,
-        PairingMode_Default,
+        PairingMode_Oob = 0,
+        PairingMode_PairHid = 1,
+        PairingMode_Advertise = 2,
+        PairingMode_Default = 3,
         PairingMode_Off = PairingMode_Default,
     } pairing_mode_t;
 


### PR DESCRIPTION
This fixes a disconnect during ble hid pairing. 

Changes as imagined: there should be no reconnect when pairing is complete, and no suspicious logs.

Behaviors that might have been affected: switchover logic and pairing logic. 

This PR really could use a serious review and serious testing.

I think I will merge it with the max-style-slots PR and try to stress them both?

Changelog:
- Fix bluetooth disconnect during pairing.