### PR TITLE
Fix overwriting first action of a noneBlock when overlaying layers.

### DIFF
--- a/right/src/config_parser/parse_keymap.c
+++ b/right/src/config_parser/parse_keymap.c
@@ -322,7 +322,8 @@ static parser_error_t parseKeyActions(uint8_t targetLayer, config_buffer_t *buff
 
         bool isValidRange = actionIdx < MAX_KEY_COUNT_PER_MODULE;
         bool isDryRun = parseMode == ParseMode_DryRun;
-        bool isTransparent = parseMode == ParseMode_Overlay && keyActionType == SerializedKeyActionType_None;
+        bool isNoneActionType = keyActionType == SerializedKeyActionType_None || keyActionType == SerializedKeyActionType_NoneBlock;
+        bool isTransparent = parseMode == ParseMode_Overlay && isNoneActionType;
 
         key_action_t *keyAction = (isValidRange && !isDryRun && !isTransparent) ? &CurrentKeymap[targetLayer][slotId][actionIdx] : &dummyKeyAction;
 


### PR DESCRIPTION
For example config and reproduction steps see: https://github.com/UltimateHackingKeyboard/firmware/issues/1419

Example:
- Assume:
  - layer 1: `qwertyuiop`
  - layer 2: `Q__Q_Q____`
  - where `_` stands for none action
- now `overlayLayer` 2 onto 1.
  - expected: `QweQtQuiop`
  - actual: `Q_eQtQ_iop`

Changelog:
- fix issue where, when using `overlayLayer`, the first empty action after any nonempty action would be written through. (When in a sequence of at least two empty actions, to be precise.)

Closes #1419 