### PR TITLE
Arg template validation fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ node_modules
 .cache
 build
 .vscode/settings.json
+.jj
 mcux_include.json

--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -188,6 +188,7 @@ COMMAND = set battery.chargeLimit { full | optimizeHealth }
 COMMAND = set bluetooth.enabled BOOL
 COMMAND = set bluetooth.alwaysAdvertiseHid BOOL
 COMMAND = set modifierLayerTriggers.{shift|alt|super|ctrl} {left|right|both}
+COMMAND = &macroArg.<macro argument index (INT)>
 CONDITION = <condition>
 CONDITION = if (EXPRESSION)
 CONDITION = else
@@ -218,7 +219,6 @@ MODIFIER = postponeKeys
 MODIFIER = final
 MODIFIER = autoRepeat
 MODIFIER = oneShot
-TEMPLATE = $macroArg.<macro argument index (INT)>
 IFSHORTCUT_OPTIONS = noConsume | transitive | anyOrder | orGate | timeoutIn <time in ms (INT)> | cancelIn <time in ms(INT)>
 DIRECTION = {left|right|up|down}
 LAYERID = {fn|mouse|mod|base|fn2|fn3|fn4|fn5|alt|shift|super|ctrl}|last|previous|current
@@ -227,7 +227,7 @@ KEYMAPID = <short keymap abbreviation(IDENTIFIER)>|last|current
 MACROID = last | <single char slot identifier(CHAR)> | <single number slot identifier(INT)>
 OPERATOR = + | - | * | / | % | < | > | <= | >= | == | != | && | ||
 VARIABLE_EXPANSION = $<variable name(IDENTIFIER)> | $<config value name>
-VARIABLE_EXPANSION = $currentAddress | $currentTime | $thisKeyId | $queuedKeyId.<queue index (INT)> | $keyId.KEYID_ABBREV | $uhk.name
+VARIABLE_EXPANSION = $currentAddress | $currentTime | $thisKeyId | $queuedKeyId.<queue index (INT)> | $keyId.KEYID_ABBREV | $uhk.name | $macroArg.<macro argument index (INT)>
 EXPRESSION = <expression> | (EXPRESSION) | INT | BOOL | FLOAT | VARIABLE_EXPANSION | EXPRESSION OPERATOR EXPRESSION | !EXPRESSION | min(EXPRESSION [, EXPRESSION]+) | max(EXPRESSION [, EXPRESSION]+)
 EXPRESSION = STRING == STRING | STRING != STRING
 PARENTHESSED_EXPRESSION = (EXPRESSION)
@@ -582,6 +582,15 @@ Internally, values are saved in one of the following types, and types are automa
 - `FLOAT` - as 32-bit floating point value. E.g., `(7/3.0)` yields 2.333...
 - `BOOL` - 1 or 0 value
 - `STRING` - a string _reference_. These strings can use interpolation, but this interpolation is always applied at the expansion site / time.
+
+### Argument expansion:
+
+Key actions can be parametrized with macro arguments. These arguments can be expanded in two ways:
+
+- `$macroArg.<idx>` - in which case they are parsed as a single value. This is the normal and safe variant that prevents context corruption.
+- `&macroArg.<idx>` - this variant substitutes the argument into current parser context. These allow substituing any string, including full commands or their parts. This is an experimental feature and might be unsafe in some contexts. Following limitations apply:
+  - the argument bounds must correspond to token bounds in the fully expanded string
+  - the argument cannot span multiple lines
 
 ### Configuration options:
 

--- a/right/src/config_parser/parse_keymap.c
+++ b/right/src/config_parser/parse_keymap.c
@@ -346,7 +346,7 @@ static parser_error_t parseKeyActions(uint8_t targetLayer, config_buffer_t *buff
 
         if (wasAction) {
             if (keyAction->type == KeyActionType_PlayMacro && Macros_ValidationInProgress) {
-                Macros_ValidateMacro(keyAction->playMacro.macroId, keyAction->playMacro.offset, moduleId, actionIdx, keymapIdx);
+                Macros_ValidateMacro(keyAction->playMacro.macroId, keyAction->playMacro.offset, moduleId, actionIdx, keymapIdx, targetLayer);
             }
 
             actionIdx++;

--- a/right/src/config_parser/parse_keymap.c
+++ b/right/src/config_parser/parse_keymap.c
@@ -307,8 +307,6 @@ static parser_error_t parseKeyActions(uint8_t targetLayer, config_buffer_t *buff
     uint8_t noneBlockUntil = 0;
     rgb_t noneBlockColor = {0, 0, 0};
     uint8_t actionIdx = 0;
-    key_action_t currentAction = {};
-    bool currentActionHasArguments = false;
     for (uint8_t i = 0; i < actionCount; i++) {
         bool isNoneActionInNoneBlock = actionIdx < noneBlockUntil;
 
@@ -347,25 +345,12 @@ static parser_error_t parseKeyActions(uint8_t targetLayer, config_buffer_t *buff
         }
 
         if (wasAction) {
-            // validate previous action
-            if (currentAction.type == KeyActionType_PlayMacro && currentActionHasArguments && Macros_ValidationInProgress) {
-                //validate it
-                Macros_ValidateMacro(currentAction.playMacro.macroId, currentAction.playMacro.offset, currentActionHasArguments, moduleId, actionIdx-1, keymapIdx);
+            if (keyAction->type == KeyActionType_PlayMacro && Macros_ValidationInProgress) {
+                Macros_ValidateMacro(keyAction->playMacro.macroId, keyAction->playMacro.offset, moduleId, actionIdx, keymapIdx);
             }
 
             actionIdx++;
-
-            // cache current action
-            currentAction = *keyAction;
-            currentActionHasArguments = false;
-        } else {
-            currentActionHasArguments = true;
         }
-    }
-    // validate previous action
-    if (currentAction.type == KeyActionType_PlayMacro && currentActionHasArguments && Macros_ValidationInProgress) {
-        //validate it
-        Macros_ValidateMacro(currentAction.playMacro.macroId, currentAction.playMacro.offset, currentActionHasArguments, moduleId, actionIdx-1, keymapIdx);
     }
 
     /* default second touchpad action to right button */

--- a/right/src/debug.h
+++ b/right/src/debug.h
@@ -23,7 +23,7 @@
 #define DEBUG_BATTERY_TESTING true
 #define DEBUG_UHK60_SLEEPS false
 
-#define DEBUG_ROLL_STATUS_BUFFER true
+#define DEBUG_ROLL_STATUS_BUFFER false
 
 #ifdef __ZEPHYR__
     #include "logger.h"

--- a/right/src/macro_events.c
+++ b/right/src/macro_events.c
@@ -218,7 +218,7 @@ void MacroEvent_TriggerGenericEvent(generic_macro_event_t eventId)
 void MacroEvent_OnError() {
     static uint32_t last = 0;
 
-    if (Timer_GetCurrentTime() - last > 1000) {
+    if (Timer_GetCurrentTime() - last > 1000 && Macros_ValidationInProgress == false) {
         last = Timer_GetCurrentTime();
         MacroEvent_TriggerGenericEvent(GenericMacroEvent_OnError);
     }

--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -482,7 +482,7 @@ uint8_t Macros_StartMacro(uint8_t index, key_state_t *keyState, uint16_t argumen
     return slotIndex;
 }
 
-void Macros_ValidateMacro(uint8_t macroIndex, uint16_t argumentOffset, uint8_t moduleId, uint8_t keyIdx, uint8_t keymapIdx) {
+void Macros_ValidateMacro(uint8_t macroIndex, uint16_t argumentOffset, uint8_t moduleId, uint8_t keyIdx, uint8_t keymapIdx, uint8_t layerIdx) {
     bool wasValid = true;
     uint8_t slotIndex = initMacro(macroIndex, NULL, argumentOffset, 255, 255);
 
@@ -515,7 +515,7 @@ void Macros_ValidateMacro(uint8_t macroIndex, uint16_t argumentOffset, uint8_t m
         const char* keymapAbbrev = AllKeymaps[keymapIdx].abbreviation;
         uint8_t keymapAbbrevLen = AllKeymaps[keymapIdx].abbreviationLen;
         const char* moduleName = ModuleIdToStr(moduleId);
-        Macros_ReportErrorPrintf(NULL, "> '%.*s' bound at %.*s/%s/%s.\n", nameEnd - name, name, keymapAbbrevLen, keymapAbbrev, moduleName, keyAbbrev);
+        Macros_ReportErrorPrintf(NULL, ">     '%.*s' bound at %.*s/%s/%s/%s.\n", nameEnd - name, name, keymapAbbrevLen, keymapAbbrev, LayerNames[layerIdx], moduleName, keyAbbrev);
     }
     Macros_ParserError = false;
 }

--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -482,7 +482,7 @@ uint8_t Macros_StartMacro(uint8_t index, key_state_t *keyState, uint16_t argumen
     return slotIndex;
 }
 
-void Macros_ValidateMacro(uint8_t macroIndex, uint16_t argumentOffset, bool hasArgs, uint8_t moduleId, uint8_t keyIdx, uint8_t keymapIdx) {
+void Macros_ValidateMacro(uint8_t macroIndex, uint16_t argumentOffset, uint8_t moduleId, uint8_t keyIdx, uint8_t keymapIdx) {
     bool wasValid = true;
     uint8_t slotIndex = initMacro(macroIndex, NULL, argumentOffset, 255, 255);
 
@@ -493,6 +493,7 @@ void Macros_ValidateMacro(uint8_t macroIndex, uint16_t argumentOffset, bool hasA
 
     scheduleSlot(slotIndex);
 
+    Macros_ParserError = false;
     bool macroHasNotEnded = AllMacros[macroIndex].macroActionsCount;
     while (macroHasNotEnded) {
         if (S->ms.currentMacroAction.type == MacroActionType_Command) {
@@ -506,14 +507,17 @@ void Macros_ValidateMacro(uint8_t macroIndex, uint16_t argumentOffset, bool hasA
     endMacro();
     S = NULL;
 
-    if (!wasValid && hasArgs && moduleId != 255 && keyIdx != 255 && keymapIdx != 255) {
+    if (!wasValid && moduleId != 255 && keyIdx != 255 && keymapIdx != 255) {
+        const char *name, *nameEnd;
+        FindMacroName(&AllMacros[macroIndex], &name, &nameEnd);
         uint8_t keyId = Utils_KeyCoordinatesToKeyId(ModuleIdToSlotId(moduleId), keyIdx);
         const char* keyAbbrev = MacroKeyIdParser_KeyIdToAbbreviation(keyId);
         const char* keymapAbbrev = AllKeymaps[keymapIdx].abbreviation;
         uint8_t keymapAbbrevLen = AllKeymaps[keymapIdx].abbreviationLen;
         const char* moduleName = ModuleIdToStr(moduleId);
-        Macros_ReportErrorPrintf(NULL, "> Bound at %.*s/%s/%s.\n", keymapAbbrevLen, keymapAbbrev, moduleName, keyAbbrev);
+        Macros_ReportErrorPrintf(NULL, "> '%.*s' bound at %.*s/%s/%s.\n", nameEnd - name, name, keymapAbbrevLen, keymapAbbrev, moduleName, keyAbbrev);
     }
+    Macros_ParserError = false;
 }
 
 /**
@@ -526,16 +530,10 @@ void Macros_ValidateAllMacros()
     macro_state_t* oldS = S;
     scheduler_state_t schedulerState = Macros_SchedulerState;
     memset(&Macros_SchedulerState, 0, sizeof Macros_SchedulerState);
+    LogU("Validating macros with arguments...\n");
     Macros_DryRun = true;
     Macros_ValidationInProgress = true;
-    // Validate macros without arguments
     uint32_t t1 = Timer_GetCurrentTime();
-    LogU("Validating macros without arguments...\n");
-    for (uint8_t macroIndex = 0; macroIndex < AllMacrosCount; macroIndex++) {
-        Macros_ValidateMacro(macroIndex, 0, false, 255, 255, 255);
-    }
-    LogU("Validating macros with arguments...\n");
-    // Validate macros that have arguments
     for (uint8_t keymapIndex = 0; keymapIndex < AllKeymapsCount; keymapIndex++) {
         DryParseKeymap(keymapIndex);
     }

--- a/right/src/macros/core.h
+++ b/right/src/macros/core.h
@@ -282,7 +282,7 @@
     void Macros_SignalInterrupt(void);
     void Macros_SignalUsbReportsChange();
     void Macros_ValidateAllMacros();
-    void Macros_ValidateMacro(uint8_t macroIndex, uint16_t argumentOffset, bool hasArgs, uint8_t moduleId, uint8_t keyIdx, uint8_t keymapIdx);
+    void Macros_ValidateMacro(uint8_t macroIndex, uint16_t argumentOffset, uint8_t moduleId, uint8_t keyIdx, uint8_t keymapIdx);
     void Macros_WakeBecauseOfKeystateChange();
 
 #endif

--- a/right/src/macros/core.h
+++ b/right/src/macros/core.h
@@ -282,7 +282,7 @@
     void Macros_SignalInterrupt(void);
     void Macros_SignalUsbReportsChange();
     void Macros_ValidateAllMacros();
-    void Macros_ValidateMacro(uint8_t macroIndex, uint16_t argumentOffset, uint8_t moduleId, uint8_t keyIdx, uint8_t keymapIdx);
+    void Macros_ValidateMacro(uint8_t macroIndex, uint16_t argumentOffset, uint8_t moduleId, uint8_t keyIdx, uint8_t keymapIdx, uint8_t layerIdx);
     void Macros_WakeBecauseOfKeystateChange();
 
 #endif

--- a/right/src/macros/set_command.c
+++ b/right/src/macros/set_command.c
@@ -349,7 +349,7 @@ static macro_variable_t allowUnsecuredConnections(parser_context_t* ctx, set_com
 {
     ASSIGN_BOOL(Cfg.Bt_AllowUnsecuredConnections);
     if (Cfg.Bt_AllowUnsecuredConnections) {
-        Macros_PrintfWithPos(ctx->at, "Warning: insecure connections were allowed. This may allow eavesdropping on your keyboard input!");
+        Macros_PrintfWithPos(ctx, "Warning: insecure connections were allowed. This may allow eavesdropping on your keyboard input!");
     }
 
     return noneVar();

--- a/right/src/macros/status_buffer.c
+++ b/right/src/macros/status_buffer.c
@@ -262,9 +262,12 @@ static void reportErrorHeader(const char* status, uint16_t pos)
     }
 }
 
-static void reportCommandLocation(uint16_t line, uint16_t pos, const char* begin, const char* end, bool markPosition)
+static void reportCommandLocation(uint16_t line, uint16_t pos, const char* begin, const char* end, bool markPosition, uint8_t indent)
 {
     Macros_SetStatusString("> ", NULL);
+    for (uint8_t i = 0; i < indent; i++) {
+        Macros_SetStatusString(" ", NULL);
+    }
     uint16_t l = Buf.len;
     Macros_SetStatusNumSpaced(line, false);
     l = Buf.len - l;
@@ -273,7 +276,7 @@ static void reportCommandLocation(uint16_t line, uint16_t pos, const char* begin
     Macros_SetStatusString("\n", NULL);
     if (markPosition) {
         Macros_SetStatusString("> ", NULL);
-        for (uint8_t i = 0; i < l; i++) {
+        for (uint8_t i = 0; i < l + indent; i++) {
             Macros_SetStatusString(" ", NULL);
         }
         Macros_SetStatusString(" | ", NULL);
@@ -285,21 +288,23 @@ static void reportCommandLocation(uint16_t line, uint16_t pos, const char* begin
     }
 }
 
-static void reportLocationStackLevel(const parser_context_t* ctx, uint16_t line) {
+static void reportLocationStackLevel(const parser_context_t* ctx, uint16_t line, uint8_t indent) {
     uint16_t pos = ctx->at - ctx->begin;
     bool positionIsValid = ctx->begin <= ctx->at && ctx->at <= ctx->end;
     if (positionIsValid) {
-        reportCommandLocation(line, pos, ctx->begin, ctx->end, positionIsValid);
+        reportCommandLocation(line, pos, ctx->begin, ctx->end, positionIsValid, indent);
     } else {
         Macros_SetStatusString("> Position not available here.\n", NULL);
     }
 }
 
 static void reportLocationStack(parser_context_t* ctx, uint16_t line) {
+    uint8_t indent = 0;
     for (uint8_t level = 0; level < ctx->nestingLevel; level++) {
-        reportLocationStackLevel(ViewContext(level), line);
+        reportLocationStackLevel(ViewContext(level), line, indent);
+        indent = 0;
     }
-    reportLocationStackLevel(ctx, line);
+    reportLocationStackLevel(ctx, line, indent);
 }
 
 static void reportError(
@@ -321,7 +326,7 @@ static void reportError(
         const char* endOfLine = S->ms.currentMacroAction.cmd.text + S->ls->ms.commandEnd;
         uint16_t line = findCurrentCommandLine();
         if (startOfLine <= arg && arg <= endOfLine) {
-            reportCommandLocation(line, arg - startOfLine, startOfLine, endOfLine, argIsCommand);
+            reportCommandLocation(line, arg - startOfLine, startOfLine, endOfLine, argIsCommand, 0);
         } else if (ctx != NULL) {
             reportLocationStack(ctx, line);
         } else {

--- a/right/src/macros/status_buffer.c
+++ b/right/src/macros/status_buffer.c
@@ -376,7 +376,7 @@ void Macros_ReportWarn(const char* err, const char* arg, const char *argEnd)
     reportError(err, arg, argEnd, NULL);
 }
 
-void Macros_PrintfWithPos(const char* pos, const char *fmt, ...)
+void Macros_PrintfWithPos(parser_context_t* ctx, const char *fmt, ...)
 {
     REENTRANCY_GUARD_BEGIN;
     va_list myargs;
@@ -385,9 +385,10 @@ void Macros_PrintfWithPos(const char* pos, const char *fmt, ...)
     vsprintf(buffer, fmt, myargs);
 
     indicateOut();
-    if (pos != NULL) {
-        reportErrorHeader("Out", findPosition(pos));
-        reportError(buffer, pos, pos, NULL);
+    if (ctx != NULL) {
+        reportErrorHeader("Out", findPositionCtx(ctx));
+        reportError(buffer, NULL, NULL, ctx);
+
     } else {
         Macros_SetStatusString(buffer, NULL);
     }

--- a/right/src/macros/status_buffer.h
+++ b/right/src/macros/status_buffer.h
@@ -37,7 +37,7 @@
     void Macros_ReportErrorNum(const char* err, int32_t num, const char* pos);
     void Macros_ReportErrorFloat(const char* err, float num, const char* pos);
     void Macros_ReportWarn(const char* err, const char* arg, const char *argEnd);
-    void Macros_PrintfWithPos(const char* pos, const char *fmt, ...);
+    void Macros_PrintfWithPos(parser_context_t* ctx, const char *fmt, ...);
     void Macros_SanitizedPut(const char* text, const char *textEnd);
 
     void MacroStatusBuffer_Validate(void);

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -148,7 +148,7 @@ static char consumeExpressionCharOfString(const macro_variable_t* variable, uint
 static char consumeExpressionChar(parser_context_t* ctx, string_type_t stringType, uint16_t* index)
 {
     char c;
-    if (TryExpandMacroTemplateOnce(ctx)) {
+    if (TRY_EXPAND_TEMPLATE(ctx)) {
         // Call tree of this never expands or unexpands this context, so we can safely perform a pop after.
         // (If there is an expansion, it is handled within a new context copy.)
         c = consumeCharOfTemplate(ctx, stringType, index);

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -1058,7 +1058,8 @@ static bool expandArgumentInplace(parser_context_t* ctx, uint8_t argNumber) {
     string_segment_t str = ParseMacroArgument(S->ms.currentMacroArgumentOffset, argNumber);
 
     if (str.start == NULL) {
-        Macros_ReportErrorPrintf(ctx->at, "Failed to retrieve argument %d. Argument not found!", argNumber);
+        // If this kind of substitution is not found, assume it is empty and do *not* throw an error.
+        // Macros_ReportErrorPrintf(ctx->at, "Failed to retrieve argument %d. Argument not found!", argNumber);
         return false;
     }
 

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -50,6 +50,7 @@ typedef enum {
 macro_variable_t macroVariables[MACRO_VARIABLE_COUNT_MAX];
 uint8_t macroVariableCount = 0;
 
+static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx);
 static macro_variable_t consumeParenthessExpression(parser_context_t* ctx);
 static macro_variable_t consumeValue(parser_context_t* ctx);
 static macro_variable_t negate(parser_context_t *ctx, macro_variable_t res);
@@ -377,6 +378,9 @@ static macro_variable_t consumeDollarExpression(parser_context_t* ctx)
             return noneVar();
         }
     }
+    else if (ConsumeToken(ctx, "macroArg")) {
+        return consumeArgumentAsValue(ctx);
+    }
     else if ((res = Macro_TryReadConfigVal(ctx)).type != MacroVariableType_None) {
         return res;
     } else {
@@ -386,7 +390,7 @@ static macro_variable_t consumeDollarExpression(parser_context_t* ctx)
 
 static macro_variable_t consumeValue(parser_context_t* ctx)
 {
-    if (*ctx->at == '$') {
+    if (*ctx->at == '&') {
         TryExpandMacroTemplateOnce(ctx);
         if (Macros_ParserError) {
             return noneVar();
@@ -1017,16 +1021,38 @@ void MacroVariables_RunTests(void) {
 #endif
 }
 
-static bool expandArgument(parser_context_t* ctx, uint8_t argNumber) {
+static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
+    ConsumeUntilDot(ctx);
+    uint8_t argId = Macros_ConsumeInt(ctx);
+
     if (S->ms.currentMacroArgumentOffset == 0) {
-        if (Macros_ValidationInProgress) {
-            // mark this action as failed, but don't report it. It will get validated in keymap run later
-            Macros_ParserError = true;
-            return false;
-        } else {
-            Macros_ReportErrorPrintf(ctx->at, "Failed to retrieve argument %d, because this macro doesn't seem to have arguments assigned!", argNumber);
-            return false;
-        }
+        Macros_ReportErrorPrintf(ctx->at, "Failed to retrieve argument %d, because this macro doesn't seem to have arguments assigned!", argId);
+    }
+
+    string_segment_t str = ParseMacroArgument(S->ms.currentMacroArgumentOffset, argId);
+
+    if (str.start == NULL) {
+        Macros_ReportErrorPrintf(ctx->at, "Failed to retrieve argument %d. Argument not found!", argId);
+        return noneVar();
+    }
+
+    parser_context_t varCtx = (parser_context_t) {
+        .at = str.start,
+        .begin = str.start,
+        .end = str.end,
+        .macroState = ctx->macroState,
+        .nestingLevel = ctx->nestingLevel,
+        .nestingBound = ctx->nestingBound,
+    };
+
+    macro_variable_t res = consumeValue(&varCtx);
+
+    return res;
+}
+
+static bool expandArgumentInplace(parser_context_t* ctx, uint8_t argNumber) {
+    if (S->ms.currentMacroArgumentOffset == 0) {
+        Macros_ReportErrorPrintf(ctx->at, "Failed to retrieve argument %d, because this macro doesn't seem to have arguments assigned!", argNumber);
     }
 
     string_segment_t str = ParseMacroArgument(S->ms.currentMacroArgumentOffset, argNumber);
@@ -1040,7 +1066,7 @@ static bool expandArgument(parser_context_t* ctx, uint8_t argNumber) {
 }
 
 bool TryExpandMacroTemplateOnce(parser_context_t* ctx) {
-    ASSERT(*ctx->at == '$');
+    ASSERT(*ctx->at == '&');
 
     ctx->at++;
 
@@ -1049,25 +1075,10 @@ bool TryExpandMacroTemplateOnce(parser_context_t* ctx) {
     if (ConsumeToken(ctx, "macroArg")) {
         ConsumeUntilDot(ctx);
         uint8_t argId = Macros_ConsumeInt(ctx);
-        expandArgument(ctx, argId);
+        expandArgumentInplace(ctx, argId);
         return true;
     }
-    else if (ConsumeToken(ctx, "macroTemplate")) {
-        ConsumeUntilDot(ctx);
-        if (ConsumeToken(ctx, "test")) {
-            const char* arg = "3";
-            bool success = PushParserContext(ctx, arg, arg, arg + strlen(arg));
-            return success;
-        }
-        else if (ConsumeToken(ctx, "emoji")) {
-            const char* arg = "€";
-            bool success = PushParserContext(ctx, arg, arg, arg + strlen(arg));
-            return success;
-        } else {
-            Macros_ReportErrorTok(ctx, "Expected valid template name!");
-            return true;
-        }
-    }
+
     ctx->at--;
     return false;
 }

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -388,6 +388,9 @@ static macro_variable_t consumeValue(parser_context_t* ctx)
 {
     if (*ctx->at == '$') {
         TryExpandMacroTemplateOnce(ctx);
+        if (Macros_ParserError) {
+            return noneVar();
+        }
     }
 
     switch (*ctx->at) {

--- a/right/src/macros/vars.h
+++ b/right/src/macros/vars.h
@@ -16,6 +16,7 @@
 // Macros:
 
     #define MACRO_VARIABLE_COUNT_MAX 32
+    #define TRY_EXPAND_TEMPLATE(CTX) (*ctx->at == '&' && TryExpandMacroTemplateOnce(CTX))
 
 // Typedefs:
 

--- a/right/src/str_utils.c
+++ b/right/src/str_utils.c
@@ -120,7 +120,7 @@ static void consumeWhite(parser_context_t* ctx)
                 ctx->at++;
             }
         }
-        if (*ctx->at == '$' && TryExpandMacroTemplateOnce(ctx)) {
+        if (TRY_EXPAND_TEMPLATE(ctx)) {
             continue;
         } else {
             return;


### PR DESCRIPTION
Changelog:
- Distinguish `&macroArg.1` and `$macroArg.1` expansions
- Validate all macros in the context of their binding sites.