### PR TITLE
USB log buffer refactoring

### DIFF
--- a/device/src/proxy_log_backend.c
+++ b/device/src/proxy_log_backend.c
@@ -17,6 +17,7 @@
 #include "wormhole.h"
 #include "zephyr/logging/log_core.h"
 #include "config_manager.h"
+#include "usb_log_buffer.h"
 
 typedef struct {
     bool outputToStatusBuffer;
@@ -27,80 +28,10 @@ typedef struct {
 #define PROXY_BACKEND_BUFFER_SIZE 2048
 
 bool ProxyLog_IsInPanicMode = false;
-
-static char buffer[PROXY_BACKEND_BUFFER_SIZE];
-uint16_t bufferPosition = 0;
-uint16_t bufferLength = 0;
-
-bool ProxyLog_HasLog = false;
 bool ProxyLog_IsAttached = false;
-
-#define POS(x) ((bufferPosition + (x) + PROXY_BACKEND_BUFFER_SIZE) % PROXY_BACKEND_BUFFER_SIZE)
-
-static void updateNonemptyFlag() {
-    ProxyLog_HasLog = (bufferLength > 0);
-}
-
-uint16_t ProxyLog_ConsumeLog(uint8_t* outBuf, uint16_t outBufSize) {
-    uint16_t copied = 0;
-    uint16_t remaining = MIN(bufferLength, outBufSize);
-    while (remaining > 0) {
-        char a = buffer[bufferPosition++];
-        outBuf[copied++] = a;
-        if (bufferPosition >= PROXY_BACKEND_BUFFER_SIZE) {
-            bufferPosition = 0;
-        }
-        remaining--;
-        bufferLength--;
-    }
-    if (copied < outBufSize) {
-        outBuf[copied] = 0;
-    }
-    updateNonemptyFlag();
-    return copied;
-}
 
 void ProxyLog_SetAttached(bool attached) {
     ProxyLog_IsAttached = attached;
-}
-
-static void addChar(char c) {
-    if (CHAR_IS_VALID(c)) {
-        if (bufferLength < PROXY_BACKEND_BUFFER_SIZE) {
-            buffer[POS(bufferLength)] = c;
-            bufferLength++;
-        } else {
-            buffer[bufferPosition++] = c;
-            bufferPosition %= PROXY_BACKEND_BUFFER_SIZE;
-        }
-
-    }
-}
-
-void printToOurBuffer(uint8_t *data, size_t length) {
-    for (uint16_t i = 0; i < length; i++) {
-        addChar(data[i]);
-    }
-    updateNonemptyFlag();
-}
-
-void ProxyLog_GetFill(uint16_t* occupied, uint16_t* length) {
-    *occupied = bufferLength;
-    *length = PROXY_BACKEND_BUFFER_SIZE;
-}
-
-void ProxyLog_SnapToStatusBuffer(void) {
-    StateWormhole_Open();
-    StateWormhole.persistStatusBuffer = true;
-
-    uint16_t pos = bufferPosition;
-    uint16_t len = bufferLength;
-
-    for (uint16_t i = 0; i < len; i++) {
-        char c = buffer[pos];
-        Macros_SanitizedPut(&c, &c + 1);
-        pos = (pos + 1) % PROXY_BACKEND_BUFFER_SIZE;
-    }
 }
 
 static void processLog(const struct log_backend *const backend, union log_msg_generic *msg);
@@ -127,7 +58,7 @@ static int outputFunc(uint8_t *data, size_t length, void *ctx)
         Macros_SanitizedPut(data, data + length);
     }
     if (outputs->outputToUsbBuffer) {
-        printToOurBuffer(data, length);
+        UsbLogBuffer_Print(data, length);
     }
     if (outputs->outputToOled) {
         LogO("%.*s", length, data);

--- a/device/src/proxy_log_backend.c
+++ b/device/src/proxy_log_backend.c
@@ -18,6 +18,7 @@
 #include "zephyr/logging/log_core.h"
 #include "config_manager.h"
 #include "usb_log_buffer.h"
+#include "config_manager.h"
 
 typedef struct {
     bool outputToStatusBuffer;
@@ -28,11 +29,6 @@ typedef struct {
 #define PROXY_BACKEND_BUFFER_SIZE 2048
 
 bool ProxyLog_IsInPanicMode = false;
-bool ProxyLog_IsAttached = false;
-
-void ProxyLog_SetAttached(bool attached) {
-    ProxyLog_IsAttached = attached;
-}
 
 static void processLog(const struct log_backend *const backend, union log_msg_generic *msg);
 
@@ -95,7 +91,7 @@ static void processLog(const struct log_backend *const backend, union log_msg_ge
             .outputToOled = false,
     };
 
-    if (ProxyLog_IsAttached) {
+    if (WormCfg->UsbLogEnabled) {
         outputs.outputToUsbBuffer = true;
         outputs.outputToOled = true;
     }
@@ -115,7 +111,6 @@ static void processLog(const struct log_backend *const backend, union log_msg_ge
 
     if (outputs.outputToStatusBuffer || outputs.outputToUsbBuffer || outputs.outputToOled) {
         log_output_ctx_set(&logOutput, &outputs);
-
         uint8_t flags = LOG_OUTPUT_FLAG_CRLF_LFONLY;
         log_output_msg_process(&logOutput, &msg->log, flags);
     }

--- a/device/src/proxy_log_backend.h
+++ b/device/src/proxy_log_backend.h
@@ -12,17 +12,12 @@
 
 // Variables:
 
-
     extern bool ProxyLog_IsAttached;
-    extern bool ProxyLog_HasLog;
     extern bool ProxyLog_IsInPanicMode;
 
 // Functions:
 
     void ProxyLog_SetAttached(bool attached);
     void InitProxyLogBackend(void);
-    uint16_t ProxyLog_ConsumeLog(uint8_t* outBuf, uint16_t outBufSize);
-    void ProxyLog_GetFill(uint16_t* occupied, uint16_t* length);
-    void ProxyLog_SnapToStatusBuffer(void);
 
-#endif /* __MACRO_SET_COMMAND_H__ */
+#endif

--- a/device/src/proxy_log_backend.h
+++ b/device/src/proxy_log_backend.h
@@ -12,12 +12,10 @@
 
 // Variables:
 
-    extern bool ProxyLog_IsAttached;
     extern bool ProxyLog_IsInPanicMode;
 
 // Functions:
 
-    void ProxyLog_SetAttached(bool attached);
     void InitProxyLogBackend(void);
 
 #endif

--- a/device/src/shell.c
+++ b/device/src/shell.c
@@ -368,15 +368,15 @@ static int cmd_uhk_logPriority(const struct shell *shell, size_t argc, char *arg
 static int cmd_uhk_logs(const struct shell *shell, size_t argc, char *argv[])
 {
     if (argc == 1 || argv[1][0] == '1') {
-        ProxyLog_SetAttached(true);
+        WormCfg->UsbLogEnabled = true;
     } else if (argc == 1 || argv[1][0] == '0') {
-        ProxyLog_SetAttached(false);
+        WormCfg->UsbLogEnabled = false;
     }
 
     uint16_t usbBufferFill, usbBufferSize;
     UsbLogBuffer_GetFill(&usbBufferFill, &usbBufferSize);
 
-    printk("Usb logging enabled: %d\n", ProxyLog_IsAttached);
+    printk("Usb logging enabled: %d\n", WormCfg->UsbLogEnabled);
     printk("Has log: %d\n", UsbLogBuffer_HasLog);
     printk("Usb log buffer fill: %d / %d\n", usbBufferFill, usbBufferSize);
     return 0;

--- a/device/src/shell.c
+++ b/device/src/shell.c
@@ -6,6 +6,7 @@
 #include "keyboard/oled/oled.h"
 #include "logger.h"
 #include "proxy_log_backend.h"
+#include "usb_log_buffer.h"
 #include "usb/usb.h"
 #include <zephyr/drivers/adc.h>
 #include <zephyr/drivers/gpio.h>
@@ -373,17 +374,17 @@ static int cmd_uhk_logs(const struct shell *shell, size_t argc, char *argv[])
     }
 
     uint16_t usbBufferFill, usbBufferSize;
-    ProxyLog_GetFill(&usbBufferFill, &usbBufferSize);
+    UsbLogBuffer_GetFill(&usbBufferFill, &usbBufferSize);
 
     printk("Usb logging enabled: %d\n", ProxyLog_IsAttached);
-    printk("Has log: %d\n", ProxyLog_HasLog);
+    printk("Has log: %d\n", UsbLogBuffer_HasLog);
     printk("Usb log buffer fill: %d / %d\n", usbBufferFill, usbBufferSize);
     return 0;
 }
 
 static int cmd_uhk_snaplog(const struct shell *shell, size_t argc, char *argv[])
 {
-    ProxyLog_SnapToStatusBuffer();
+    UsbLogBuffer_SnapToStatusBuffer();
     printk("Log snapped to status buffer.\n");
     return 0;
 }

--- a/right/src/CMakeLists.txt
+++ b/right/src/CMakeLists.txt
@@ -68,6 +68,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     trace.c
     $<$<BOOL:${IS_MCUX_SDK}>:${CMAKE_CURRENT_SOURCE_DIR}/trace_reasons.c>
     $<$<BOOL:${IS_MCUX_SDK}>:${CMAKE_CURRENT_SOURCE_DIR}/usb_composite_device.c>
+    usb_log_buffer.c
     usb_protocol_handler.c
     usb_report_updater.c
     user_logic.c

--- a/right/src/config_manager.c
+++ b/right/src/config_manager.c
@@ -304,6 +304,7 @@ worm_config_t* WormCfg = &StateWormhole.WormCfg;
 
 const worm_config_t DefaultWormCfg = {
     .devMode = false,
+    .UsbLogEnabled = false,
 };
 
 void ConfigManager_ResetWormConfiguration(void) {

--- a/right/src/logger.c
+++ b/right/src/logger.c
@@ -6,6 +6,7 @@
 #include "macros/status_buffer.h"
 #include "macro_events.h"
 #include "debug.h"
+#include "usb_log_buffer.h"
 
 
 #ifdef __ZEPHYR__
@@ -119,6 +120,10 @@ void LogConstantTo(device_id_t deviceId, log_target_t logMask, const char* buffe
 #ifdef __ZEPHYR__
         if ((logMask & LogTarget_Uart) && DEBUG_LOG_UART) {
             Uart_LogConstant(buffer);
+        }
+#else
+        if (logMask & LogTarget_Uart) {
+            UsbLogBuffer_Print((uint8_t*)buffer, strlen(buffer));
         }
 #endif
         if (logMask & LogTarget_ErrorBuffer) {

--- a/right/src/usb_commands/usb_command_get_device_state.c
+++ b/right/src/usb_commands/usb_command_get_device_state.c
@@ -20,6 +20,8 @@
 #include "trace.h"
 #include "config_manager.h"
 
+#include "usb_log_buffer.h"
+
 #ifdef __ZEPHYR__
     #include "flash.h"
     #include "device_state.h"
@@ -27,13 +29,11 @@
     #include "slave_scheduler.h"
     #include "bt_pair.h"
     #include "bt_conn.h"
-    #include "proxy_log_backend.h"
 #else
     #include "usb_report_updater.h"
     #include "slave_scheduler.h"
     #define BtPair_PairingMode PairingMode_Off
     #define Bt_NewPairedDevice 0
-    #define ProxyLog_HasLog 0
 #endif
 
 static void detectFreezes() {
@@ -80,7 +80,7 @@ void UsbCommand_GetKeyboardState(const uint8_t *GenericHidOutBuffer, uint8_t *Ge
         | (MergeSensor_IsMerged() == MergeSensorState_Joined ? GetDeviceStateByte2_HalvesMerged : 0)
         | (BtPair_PairingMode == PairingMode_Oob ? GetDeviceStateByte2_PairingInProgress : 0)
         | (Bt_NewPairedDevice ? GetDeviceStateByte2_NewPairedDevice : 0)
-        | (ProxyLog_HasLog ? GetDeviceStateByte2_ZephyrLog : 0);
+        | (UsbLogBuffer_HasLog ? GetDeviceStateByte2_ZephyrLog : 0);
     SetUsbTxBufferUint8(2, byte2);
     SetUsbTxBufferUint8(3, ModuleConnectionStates[UhkModuleDriverId_LeftKeyboardHalf].moduleId);
     SetUsbTxBufferUint8(4, ModuleConnectionStates[UhkModuleDriverId_LeftModule].moduleId);

--- a/right/src/usb_commands/usb_command_get_variable.c
+++ b/right/src/usb_commands/usb_command_get_variable.c
@@ -7,6 +7,7 @@
 #include "config_manager.h"
 #include "usb_interfaces/usb_interface_generic_hid.h"
 
+#include "usb_log_buffer.h"
 #ifdef __ZEPHYR__
 #include "proxy_log_backend.h"
 #include "state_sync.h"
@@ -47,9 +48,7 @@ void UsbCommand_GetVariable(const uint8_t *GenericHidOutBuffer, uint8_t *Generic
             #endif
             break;
         case UsbVariable_ShellBuffer:
-            #ifdef __ZEPHYR__
-                ProxyLog_ConsumeLog(GenericHidInBuffer + 1, USB_GENERIC_HID_IN_BUFFER_LENGTH - 1);
-            #endif
+            UsbLogBuffer_Consume(GenericHidInBuffer + 1, USB_GENERIC_HID_IN_BUFFER_LENGTH - 1);
             break;
         case UsbVariable_LedAudioRegisters:
 #if defined(__ZEPHYR__) && DEVICE_IS_KEYBOARD

--- a/right/src/usb_commands/usb_command_get_variable.c
+++ b/right/src/usb_commands/usb_command_get_variable.c
@@ -9,7 +9,6 @@
 
 #include "usb_log_buffer.h"
 #ifdef __ZEPHYR__
-#include "proxy_log_backend.h"
 #include "state_sync.h"
 #endif
 
@@ -43,9 +42,7 @@ void UsbCommand_GetVariable(const uint8_t *GenericHidOutBuffer, uint8_t *Generic
             }
             break;
         case UsbVariable_ShellEnabled:
-            #ifdef __ZEPHYR__
-                SetUsbTxBufferUint8(1, ProxyLog_IsAttached);
-            #endif
+            SetUsbTxBufferUint8(1, WormCfg->UsbLogEnabled);
             break;
         case UsbVariable_ShellBuffer:
             UsbLogBuffer_Consume(GenericHidInBuffer + 1, USB_GENERIC_HID_IN_BUFFER_LENGTH - 1);

--- a/right/src/usb_commands/usb_command_set_variable.c
+++ b/right/src/usb_commands/usb_command_set_variable.c
@@ -13,7 +13,6 @@
 #endif
 
 #ifdef __ZEPHYR__
-#include "proxy_log_backend.h"
 #include "state_sync.h"
 #endif
 
@@ -52,9 +51,7 @@ void UsbCommand_SetVariable(const uint8_t *GenericHidOutBuffer, uint8_t *Generic
 #endif
             break;
         case UsbVariable_ShellEnabled:
-            #ifdef __ZEPHYR__
-                ProxyLog_SetAttached(GetUsbRxBufferUint8(2));
-            #endif
+            WormCfg->UsbLogEnabled = GetUsbRxBufferUint8(2);
             break;
         case UsbVariable_FirmwareVersionCheckEnabled:
             #ifdef __ZEPHYR__

--- a/right/src/usb_log_buffer.c
+++ b/right/src/usb_log_buffer.c
@@ -1,0 +1,73 @@
+#include "usb_log_buffer.h"
+#include "str_utils.h"
+#include "wormhole.h"
+#include "macros/status_buffer.h"
+
+static char buffer[USB_LOG_BUFFER_SIZE];
+static uint16_t bufferPosition = 0;
+static uint16_t bufferLength = 0;
+
+bool UsbLogBuffer_HasLog = false;
+
+#define POS(x) ((bufferPosition + (x) + USB_LOG_BUFFER_SIZE) % USB_LOG_BUFFER_SIZE)
+
+static void updateNonemptyFlag() {
+    UsbLogBuffer_HasLog = (bufferLength > 0);
+}
+
+static void addChar(char c) {
+    if (CHAR_IS_VALID(c)) {
+        if (bufferLength < USB_LOG_BUFFER_SIZE) {
+            buffer[POS(bufferLength)] = c;
+            bufferLength++;
+        } else {
+            buffer[bufferPosition++] = c;
+            bufferPosition %= USB_LOG_BUFFER_SIZE;
+        }
+    }
+}
+
+void UsbLogBuffer_Print(uint8_t *data, uint16_t length) {
+    for (uint16_t i = 0; i < length; i++) {
+        addChar(data[i]);
+    }
+    updateNonemptyFlag();
+}
+
+uint16_t UsbLogBuffer_Consume(uint8_t* outBuf, uint16_t outBufSize) {
+    uint16_t copied = 0;
+    uint16_t remaining = (bufferLength < outBufSize) ? bufferLength : outBufSize;
+    while (remaining > 0) {
+        char a = buffer[bufferPosition++];
+        outBuf[copied++] = a;
+        if (bufferPosition >= USB_LOG_BUFFER_SIZE) {
+            bufferPosition = 0;
+        }
+        remaining--;
+        bufferLength--;
+    }
+    if (copied < outBufSize) {
+        outBuf[copied] = 0;
+    }
+    updateNonemptyFlag();
+    return copied;
+}
+
+void UsbLogBuffer_GetFill(uint16_t* occupied, uint16_t* size) {
+    *occupied = bufferLength;
+    *size = USB_LOG_BUFFER_SIZE;
+}
+
+void UsbLogBuffer_SnapToStatusBuffer(void) {
+    StateWormhole_Open();
+    StateWormhole.persistStatusBuffer = true;
+
+    uint16_t pos = bufferPosition;
+    uint16_t len = bufferLength;
+
+    for (uint16_t i = 0; i < len; i++) {
+        char c = buffer[pos];
+        Macros_SanitizedPut(&c, &c + 1);
+        pos = (pos + 1) % USB_LOG_BUFFER_SIZE;
+    }
+}

--- a/right/src/usb_log_buffer.h
+++ b/right/src/usb_log_buffer.h
@@ -1,0 +1,24 @@
+#ifndef __USB_LOG_BUFFER_H__
+#define __USB_LOG_BUFFER_H__
+
+// Includes:
+
+    #include <stdint.h>
+    #include <stdbool.h>
+
+// Macros:
+
+#define USB_LOG_BUFFER_SIZE 2048
+
+// Variables:
+
+    extern bool UsbLogBuffer_HasLog;
+
+// Functions:
+
+    void UsbLogBuffer_Print(uint8_t *data, uint16_t length);
+    uint16_t UsbLogBuffer_Consume(uint8_t* outBuf, uint16_t outBufSize);
+    void UsbLogBuffer_GetFill(uint16_t* occupied, uint16_t* size);
+    void UsbLogBuffer_SnapToStatusBuffer(void);
+
+#endif

--- a/right/src/wormhole.h
+++ b/right/src/wormhole.h
@@ -15,6 +15,7 @@
 
     typedef struct {
         bool devMode;
+        bool UsbLogEnabled;
     } worm_config_t;
 
     typedef struct {


### PR DESCRIPTION
## Summary
- Split USB log buffer from proxy_log_backend into a new shared module (`right/src/usb_log_buffer.c`)
- Enable verbose logging on UHK60 by directing Uart logs to the USB log buffer
- Refactor `ProxyLog_IsAttached` into `WormCfg.UsbLogEnabled` for persistent configuration

## Test plan
- [x] Verify USB logging works on UHK80
- [x] Verify USB logging works on UHK60
- [x] Verify logging state persists across reboots

🤖 Generated with [Claude Code](https://claude.com/claude-code)