### PR TITLE
Validate all macros in general context

### DIFF
--- a/right/src/str_utils.c
+++ b/right/src/str_utils.c
@@ -94,6 +94,30 @@ const char* FindChar(char c, const char* str, const char* strEnd)
     return strEnd;
 }
 
+bool StrContains(const char* str, const char* strEnd, const char* needle)
+{
+    uint8_t needleLen = strlen(needle);
+    uint16_t strLen = strEnd - str;
+
+    if (strLen < needleLen) {
+        return false;
+    }
+
+    for (uint16_t i = 0; i <= strLen - needleLen; i++) {
+        bool match = true;
+        for (uint8_t j = 0; j < needleLen; j++) {
+            if (str[i + j] != needle[j]) {
+                match = false;
+                break;
+            }
+        }
+        if (match) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static bool isEnd(parser_context_t* ctx) {
     if (ctx->at < ctx->end) {
         return false;

--- a/right/src/str_utils.h
+++ b/right/src/str_utils.h
@@ -61,6 +61,7 @@
     bool StrLessOrEqual(const char* a, const char* aEnd, const char* b, const char* bEnd);
     bool StrEqual(const char* a, const char* aEnd, const char* b, const char* bEnd);
     const char* FindChar(char c, const char* str, const char* strEnd);
+    bool StrContains(const char* str, const char* strEnd, const char* needle);
     bool ConsumeToken(parser_context_t* ctx, const char *b);
     void ConsumeAnyToken(parser_context_t* ctx);
     void ConsumeCommentsAsWhite(bool consume);


### PR DESCRIPTION
## Summary
- Macros are now validated in general context (without arguments), not just when bound to keys
- Commands containing `macroArg` are skipped during general context validation since they require binding-specific arguments
- Added `StrContains()` utility function to str_utils for substring search

## Test plan
- [x] Run `validateMacros` command and verify unbound macros are now validated
- [x] Verify macros with `macroArg` don't produce false errors when validated in general context

🤖 Generated with [Claude Code](https://claude.ai/claude-code)