### PR TITLE
Add doubletap test suite

### DIFF
--- a/right/src/test_suite/CMakeLists.txt
+++ b/right/src/test_suite/CMakeLists.txt
@@ -13,4 +13,5 @@ target_sources(${PROJECT_NAME} PRIVATE
     tests/test_chording.c
     tests/test_autoshift.c
     tests/test_ifshortcut_gesture.c
+    tests/test_doubletap.c
 )

--- a/right/src/test_suite/test_actions.h
+++ b/right/src/test_suite/test_actions.h
@@ -37,8 +37,14 @@
     { .type = TestAction_SetMacro, .keyId = (key_id), .macroText = (macro_text) }
 
 // SetLayerHold: assign a layer hold action to a key
+// SwitchLayerMode_Hold = 2
 #define TEST_SET_LAYER_HOLD(key_id, layer_id) \
-    { .type = TestAction_SetLayerHold, .keyId = (key_id), .layerId = (layer_id) }
+    { .type = TestAction_SetLayerHold, .keyId = (key_id), .layerId = (layer_id), .switchLayerMode = 2 }
+
+// SetLayerDoubleTapToggle: assign a hold-and-doubletap-toggle layer action to a key
+// SwitchLayerMode_HoldAndDoubleTapToggle = 0
+#define TEST_SET_LAYER_DOUBLETAP_TOGGLE(key_id, layer_id) \
+    { .type = TestAction_SetLayerHold, .keyId = (key_id), .layerId = (layer_id), .switchLayerMode = 0 }
 
 // SetLayerAction: assign a key action on a specific layer
 #define TEST_SET_LAYER_ACTION(layer_id, key_id, shortcut) \
@@ -78,6 +84,7 @@ typedef struct {
     test_action_type_t type;
     const char *keyId;
     uint8_t layerId;              // For SetLayerHold, SetLayerAction
+    uint8_t switchLayerMode;      // For SetLayerHold (0 = Hold, see SwitchLayerMode enum)
     uint8_t primaryScancode;      // For SetSecondaryRole
     uint8_t secondaryRoleId;      // For SetSecondaryRole
     union {

--- a/right/src/test_suite/test_input_machine.c
+++ b/right/src/test_suite/test_input_machine.c
@@ -247,12 +247,12 @@ void InputMachine_Tick(void) {
                     .type = KeyActionType_SwitchLayer,
                     .switchLayer = {
                         .layer = action->layerId,
-                        .mode = SwitchLayerMode_Hold
+                        .mode = action->switchLayerMode
                     }
                 };
 
                 CurrentKeymap[LayerId_Base][slotId][keyId] = keyAction;
-                LOG_VERBOSE("[TEST] > SetLayerHold [%s] = layer %d\n", action->keyId, action->layerId);
+                LOG_VERBOSE("[TEST] > SetLayerHold [%s] = layer %d, mode %d\n", action->keyId, action->layerId, action->switchLayerMode);
                 InputMachine_ActionIndex++;
                 break;
             }

--- a/right/src/test_suite/tests/test_doubletap.c
+++ b/right/src/test_suite/tests/test_doubletap.c
@@ -1,0 +1,193 @@
+#include "tests.h"
+#include "layer.h"
+
+// Test: layer doubletap toggle - tap-tap toggles layer on
+// Setup: key "u" is HoldAndDoubleTapToggle for Mod layer, key "i" has different action on Mod layer
+// Action: tap "u", release, tap "u" again quickly (within doubletap timeout)
+// Expected: layer toggles on after second tap, "i" produces Mod layer action
+static const test_action_t test_layer_doubletap_toggle[] = {
+    TEST_SET_CONFIG("doubletapTimeout 400"),
+    TEST_SET_LAYER_DOUBLETAP_TOGGLE("u", LayerId_Mod),
+    TEST_SET_ACTION("i", "i"),
+    TEST_SET_LAYER_ACTION(LayerId_Mod, "i", "n"),
+
+    // First tap - just hold layer temporarily
+    TEST_PRESS______("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+    TEST_RELEASE__U("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    // Second tap quickly - should toggle layer on
+    TEST_PRESS______("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+    TEST_RELEASE__U("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    // Now press "i" - should produce Mod layer action (n) because layer is toggled
+    TEST_PRESS______("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("n"),
+    TEST_RELEASE__U("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    // Wait for doubletap window to expire before toggling off
+    TEST_DELAY__(500),
+
+    // Tap layer key again to toggle off (outside doubletap window)
+    TEST_PRESS______("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+    TEST_RELEASE__U("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    // Now "i" should produce base layer action (i)
+    TEST_PRESS______("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("i"),
+    TEST_RELEASE__U("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    TEST_END()
+};
+
+// Test: layer doubletap interrupt - pressing another key between taps prevents toggle
+// Setup: key "u" is HoldAndDoubleTapToggle for Mod layer
+// Action: tap "u", press another key "i", tap "u" again
+// Expected: layer does NOT toggle (interrupted by "i")
+static const test_action_t test_layer_doubletap_interrupt[] = {
+    TEST_SET_CONFIG("doubletapTimeout 400"),
+    TEST_SET_LAYER_DOUBLETAP_TOGGLE("u", LayerId_Mod),
+    TEST_SET_ACTION("i", "i"),
+    TEST_SET_LAYER_ACTION(LayerId_Mod, "i", "n"),
+
+    // First tap
+    TEST_PRESS______("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+    TEST_RELEASE__U("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    // Interrupt with another key
+    TEST_PRESS______("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("i"),
+    TEST_RELEASE__U("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    // Second tap - should NOT toggle because interrupted
+    TEST_PRESS______("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+    TEST_RELEASE__U("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    // Now "i" should produce base layer action (i), not Mod layer (n)
+    TEST_PRESS______("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("i"),
+    TEST_RELEASE__U("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    TEST_END()
+};
+
+// Test: ifDoubletap macro command - doubletap triggers conditional
+// Setup: macro with ifDoubletap that types different keys based on doubletap
+// Action: single tap, then doubletap
+// Expected: single tap produces one output, doubletap produces different output
+static const test_action_t test_macro_if_doubletap[] = {
+    TEST_SET_CONFIG("doubletapTimeout 400"),
+    TEST_SET_MACRO("u",
+        "ifDoubletap tapKey n\n"
+        "tapKey u\n"
+    ),
+
+    // First tap - should produce "u" (not doubletap)
+    TEST_PRESS______("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("u"),
+    TEST_EXPECT__________(""),
+    TEST_RELEASE__U("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    // Wait for doubletap window to pass
+    TEST_DELAY__(500),
+
+    // Single tap again - should produce "u" (not doubletap)
+    TEST_PRESS______("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("u"),
+    TEST_EXPECT__________(""),
+    TEST_RELEASE__U("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    // Now doubletap quickly - should produce "n" then "u"
+    TEST_PRESS______("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("n"),
+    TEST_EXPECT__________(""),
+    TEST_EXPECT__________("u"),
+    TEST_EXPECT__________(""),
+    TEST_RELEASE__U("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    TEST_END()
+};
+
+// Test: ifNotDoubletap macro command - inverse of ifDoubletap
+static const test_action_t test_macro_if_not_doubletap[] = {
+    TEST_SET_CONFIG("doubletapTimeout 400"),
+    TEST_SET_MACRO("u",
+        "ifNotDoubletap tapKey u\n"
+        "tapKey n\n"
+    ),
+
+    // First tap - should produce "u" then "n" (not doubletap, so ifNotDoubletap fires)
+    TEST_PRESS______("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("u"),
+    TEST_EXPECT__________(""),
+    TEST_EXPECT__________("n"),
+    TEST_EXPECT__________(""),
+    TEST_RELEASE__U("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    // Doubletap quickly - should only produce "n" (doubletap, so ifNotDoubletap skipped)
+    TEST_PRESS______("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("n"),
+    TEST_EXPECT__________(""),
+    TEST_RELEASE__U("u"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    TEST_END()
+};
+
+static const test_t doubletap_tests[] = {
+    { .name = "layer_doubletap_toggle", .actions = test_layer_doubletap_toggle },
+    { .name = "layer_doubletap_interrupt", .actions = test_layer_doubletap_interrupt },
+    { .name = "macro_if_doubletap", .actions = test_macro_if_doubletap },
+    { .name = "macro_if_not_doubletap", .actions = test_macro_if_not_doubletap },
+};
+
+const test_module_t TestModule_Doubletap = {
+    .name = "Doubletap",
+    .tests = doubletap_tests,
+    .testCount = sizeof(doubletap_tests) / sizeof(doubletap_tests[0])
+};

--- a/right/src/test_suite/tests/tests.c
+++ b/right/src/test_suite/tests/tests.c
@@ -12,6 +12,7 @@ const test_module_t * const AllTestModules[] = {
     &TestModule_Chording,
     &TestModule_AutoShift,
     &TestModule_IfShortcutGesture,
+    &TestModule_Doubletap,
 };
 
 const uint16_t AllTestModulesCount = sizeof(AllTestModules) / sizeof(AllTestModules[0]);

--- a/right/src/test_suite/tests/tests.h
+++ b/right/src/test_suite/tests/tests.h
@@ -26,5 +26,6 @@ extern const test_module_t TestModule_Autorepeat;
 extern const test_module_t TestModule_Chording;
 extern const test_module_t TestModule_AutoShift;
 extern const test_module_t TestModule_IfShortcutGesture;
+extern const test_module_t TestModule_Doubletap;
 
 #endif


### PR DESCRIPTION
## Summary
- Add test infrastructure for layer doubletap toggle mode (`SwitchLayerMode_HoldAndDoubleTapToggle`)
- Add `switchLayerMode` field to `test_action_t` and `TEST_SET_LAYER_DOUBLETAP_TOGGLE` macro
- Add 4 doubletap tests:
  - `layer_doubletap_toggle` - verifies tap-tap toggles layer ON
  - `layer_doubletap_interrupt` - verifies another key between taps prevents toggle
  - `macro_if_doubletap` - verifies `ifDoubletap` macro command
  - `macro_if_not_doubletap` - verifies `ifNotDoubletap` macro command

## Test plan
- [ ] Build firmware and flash to device
- [ ] Run test suite and verify all doubletap tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)