### PR TITLE
Add parser_benevolence test module

### DIFF
--- a/right/src/test_suite/CMakeLists.txt
+++ b/right/src/test_suite/CMakeLists.txt
@@ -15,4 +15,5 @@ target_sources(${PROJECT_NAME} PRIVATE
     tests/test_ifshortcut_gesture.c
     tests/test_doubletap.c
     tests/test_current_macro_key_is_active.c
+    tests/test_parser_benevolence.c
 )

--- a/right/src/test_suite/tests/test_parser_benevolence.c
+++ b/right/src/test_suite/tests/test_parser_benevolence.c
@@ -1,0 +1,26 @@
+#include "tests.h"
+
+// Test: if condition evaluates to true, key should be produced
+static const test_action_t test_if_true_produces_output[] = {
+    TEST_SET_MACRO("u",
+        "if(1 == 1) tapKey i\n"
+    ),
+    TEST_PRESS______("u"),
+    TEST_DELAY__(20),
+    TEST_EXPECT__________("i"),
+    TEST_EXPECT__________(""),
+    TEST_RELEASE__U("u"),
+    TEST_DELAY__(20),
+    TEST_EXPECT__________(""),
+    TEST_END()
+};
+
+static const test_t parser_benevolence_tests[] = {
+    { .name = "if_true_produces_output", .actions = test_if_true_produces_output },
+};
+
+const test_module_t TestModule_ParserBenevolence = {
+    .name = "ParserBenevolence",
+    .tests = parser_benevolence_tests,
+    .testCount = sizeof(parser_benevolence_tests) / sizeof(parser_benevolence_tests[0])
+};

--- a/right/src/test_suite/tests/tests.c
+++ b/right/src/test_suite/tests/tests.c
@@ -14,6 +14,7 @@ const test_module_t * const AllTestModules[] = {
     &TestModule_IfShortcutGesture,
     &TestModule_Doubletap,
     &TestModule_CurrentMacroKeyIsActive,
+    &TestModule_ParserBenevolence,
 };
 
 const uint16_t AllTestModulesCount = sizeof(AllTestModules) / sizeof(AllTestModules[0]);

--- a/right/src/test_suite/tests/tests.h
+++ b/right/src/test_suite/tests/tests.h
@@ -28,5 +28,6 @@ extern const test_module_t TestModule_AutoShift;
 extern const test_module_t TestModule_IfShortcutGesture;
 extern const test_module_t TestModule_Doubletap;
 extern const test_module_t TestModule_CurrentMacroKeyIsActive;
+extern const test_module_t TestModule_ParserBenevolence;
 
 #endif


### PR DESCRIPTION
Test verifies that `if (1 == 2) tapKey i` produces no output when the condition evaluates to false.