### PR TITLE
Key History and Macros

### DIFF
--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -202,7 +202,7 @@ CONDITION = {ifShortcut | ifNotShortcut} [IFSHORTCUT_OPTIONS]* [KEYID]+
 CONDITION = {ifGesture | ifNotGesture} [IFSHORTCUT_OPTIONS]* [KEYID]+
 CONDITION = {ifPrimary | ifSecondary} [ simpleStrategy | advancedStrategy | ignoreTriggersFromSameHalf | acceptTriggersFromSameHalf ]
 CONDITION = {ifHold | ifTap}
-CONDITION = {ifDoubletap | ifNotDoubletap}
+CONDITION = {ifDoubletap | ifNotDoubletap} [taps <number of taps (INT)>]
 CONDITION = {ifInterrupted | ifNotInterrupted}
 CONDITION = {ifReleased | ifNotReleased}
 CONDITION = {ifKeyActive | ifNotKeyActive} KEYID
@@ -541,7 +541,7 @@ Conditions are checked before processing the rest of the command. If the conditi
 
 - `if BOOL` allows switching based on a custom expression. E.g., `if ($keystrokeDelay > 10) ...`
 - `else` condition is true if the previous command ended due to a failed condition.
-- `ifDoubletap/ifNotDoubletap` is true if the macro was started at most 300ms after the start of another instance of the same macro.
+- `ifDoubletap/ifNotDoubletap` is true if the macro was started at most 300ms after the start of another instance of the same macro.  If `taps` is provided, test for that number of rapid taps in a row, for example `ifDoubletap taps 3` will test for a tripletap.
 - `ifInterrupted/ifNotInterrupted` is true if a keystroke action or mouse action was triggered during macro runtime. Allows fake implementation of secondary roles. Also allows interruption of cycles.
 - `ifReleased/ifNotReleased` is true if the key which activated current macro has been released. If the key has been physically released but the release has been postponed by another key, the conditien yields false. If the key has been physically released and the postponing mode was initiated by this macro (e.g., `postponeKeys ifReleased goTo ($currentAddress+2)`), it returns non-postponed release state (i.e., true if there's a matching release event in the postponing queue).
 - `ifPending/ifNotPending <n>` is true if there is at least `n` postponed keys in the postponing queue. In context of postponing mechanism, this condition acts similar in place of ifInterrupted.
@@ -620,7 +620,7 @@ Key actions can be parametrized with macro arguments. These arguments can be exp
   This allows the user to trigger chorded shortcuts in an arbitrary order (all at the "same" time). E.g., if `A+Ctrl` is pressed instead of `Ctrl+A`, the keyboard will still send `Ctrl+A` if the two key presses follow within the specified time.
 - `set autoShiftDelay 0 | <time in ms (INT)>` If nonzero, the autoshift feature is turned on. This adds shift to a scancode when the key is held for at least `autoShiftDelay` ms. (E.g., tapping 'a' results in 'a', pressing 'a' for a little bit longer results in 'A'.)
 - `set debounceDelay <time in ms, at most 250>` prevents key state from changing for some time after every state change. This is needed because contacts of mechanical switches can bounce after contact and therefore change state multiple times in span of a few milliseconds. Official firmware debounce time is 50 ms for both press and release. Recommended value is 10-50, default is 50.
-- `set doubletapTimeout <time in ms, at most 65535>` controls doubletap timeouts for both layer switchers and for the `ifDoubletap` condition.
+- `set doubletapTimeout <time in ms, at most 65535>` controls doubletap interval limit for layer switchers, secondary role doubletap to primary, and for the `ifDoubletap` condition.
 - `set keystrokeDelay <time in ms, at most 65535>` allows slowing down keyboard output. This is handy for lousily written RDP clients and other software which just scans keys once a while and processes them in wrong order if multiple keys have been pressed inbetween. In more detail, this setting adds a delay whenever a basic usb report is sent. During this delay, key matrix is still scanned and keys are debounced, but instead of activating, the keys are added into a queue to be replayed later. Recommended value is 10 if you have issues with RDP missing modifier keys, 0 otherwise.
 - `set autoRepeatDelay <time in ms, at most 65535>` and `set autoRepeatRate <time in ms, at most 65535>` allows you to set the initial delay (default: 500 ms) and the repeat delay (default: 50 ms) when using `autoRepeat`. When you run the command `autoRepeat <command>`, the `<command>` is first run without delay. Then, it will waits `autoRepeatDelay` amount of time before running `<command>` again. Then and thereafter, it will waits `autoRepeatRate` amount of time before repeating `<command>` again. This is consistent with typical OS keyrepeat feature.
 - `set oneShotTimeout <time in ms, at most 65535>` sets the timeout for `oneShot` modifier. Zero means infinite.

--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -782,6 +782,8 @@ Key actions can be parametrized with macro arguments. These arguments can be exp
     - `$currentTime` returns current time in milliseconds in 31 bit range.
     - `$queuedKeyId.<index (NUMBER)>` which stands for a zero-indexed position in the postponer queue.
     - `$uhk.name` returns a reference to the uhk name string.
+    - `$previousKeyId` returns the id of the last key that was pressed previously to the one which started the macro
+    - `$previousKeyPressTime` returns the time activation time of the last key pressed previously to the one which started the macro
 - `KEYMAPID` - is assumed to be 3 characters long abbreviation of a keymap.
 - `MACROID` - macro slot identifier is either a number or a single ascii character (interpreted as a one-byte value). `$thisKeyId` can be used so that the same macro refers to different slots when assigned to different keys.
 - `custom text` is an arbitrary text starting on the next non-space character and ending at the end of the text action. (Yes, this should be refactored in the future.)

--- a/right/src/key_history.c
+++ b/right/src/key_history.c
@@ -9,7 +9,7 @@
 typedef struct {
     const key_state_t *keyState;
     uint32_t timestamp;
-    uint8_t multiTapCount;
+    uint8_t multiTapCount : 6;
     uint8_t keyActivationId : 4;
     bool multiTapBreaker : 1;
 } key_press_event_t;

--- a/right/src/key_history.c
+++ b/right/src/key_history.c
@@ -2,6 +2,10 @@
 #include "key_history.h"
 #include "postponer.h"
 
+#define HISTORY_SIZE 2
+#define LAST (position % HISTORY_SIZE)
+#define POS(p) ((position - p) % HISTORY_SIZE)
+
 typedef enum {
     DoubletapState_Blocked,
     DoubletapState_First,
@@ -14,20 +18,23 @@ typedef struct {
     uint8_t keyActivationId;
     uint32_t timestamp;
     doubletap_state_t doubletapState;
-} previous_key_event_type_t;
+} key_press_event_t;
 
-static previous_key_event_type_t lastPress;
+static key_press_event_t history[HISTORY_SIZE];
+static uint8_t position = 0;
 
 void KeyHistory_RecordPress(const key_state_t *keyState)
 {
+    const key_press_event_t * const lastPress = &history[LAST];
     const bool isMultitap = 
-        keyState == lastPress.keyState
-        && lastPress.doubletapState != DoubletapState_Blocked
-        && CurrentPostponedTime < lastPress.timestamp + Cfg.DoubletapTimeout;
+        keyState == lastPress->keyState
+        && lastPress->doubletapState != DoubletapState_Blocked
+        && CurrentPostponedTime < lastPress->timestamp + Cfg.DoubletapTimeout;
     const bool isDoubletap = isMultitap &&
-        (lastPress.doubletapState == DoubletapState_First || lastPress.doubletapState == DoubletapState_Multitap);
+        (lastPress->doubletapState == DoubletapState_First || lastPress->doubletapState == DoubletapState_Multitap);
 
-    lastPress = (previous_key_event_type_t){
+    ++position;
+    history[LAST] = (key_press_event_t) {
         .keyState = keyState,
         .keyActivationId = keyState->activationId,
         .timestamp = CurrentPostponedTime,
@@ -39,17 +46,29 @@ void KeyHistory_RecordPress(const key_state_t *keyState)
 
 void KeyHistory_RecordRelease(const key_state_t *keyState)
 {
-    if (keyState != lastPress.keyState) {
-        lastPress.doubletapState = DoubletapState_Blocked;
+    if (keyState != history[LAST].keyState) {
+        history[LAST].doubletapState = DoubletapState_Blocked;
     }
 }
 
-bool KeyHistory_WasLastDoubletap()
+bool KeyHistory_WasDoubletap(const key_state_t *keyState, uint8_t activationId)
 {
-    return lastPress.doubletapState == DoubletapState_Doubletap;
+    for (uint8_t i = 0; i < HISTORY_SIZE; ++i) {
+        const key_press_event_t * const event = &history[POS(i)];
+        if (event->keyState == keyState && event->keyActivationId == activationId) {
+            return event->doubletapState == DoubletapState_Doubletap;
+        }
+    }
+    return false;
 }
 
-bool KeyHistory_WasLastMultitap()
+bool KeyHistory_WasMultitap(const key_state_t *keyState, uint8_t activationId)
 {
-    return lastPress.doubletapState >= DoubletapState_Multitap;
+    for (uint8_t i = 0; i < HISTORY_SIZE; ++i) {
+        const key_press_event_t * const event = &history[POS(i)];
+        if (event->keyState == keyState && event->keyActivationId == activationId) {
+            return event->doubletapState >= DoubletapState_Multitap;
+        }
+    }
+    return false;
 }

--- a/right/src/key_history.c
+++ b/right/src/key_history.c
@@ -6,18 +6,12 @@
 #define LAST (position % HISTORY_SIZE)
 #define POS(p) ((position - p) % HISTORY_SIZE)
 
-typedef enum {
-    DoubletapState_Blocked,
-    DoubletapState_First,
-    DoubletapState_Multitap,
-    DoubletapState_Doubletap,
-} doubletap_state_t;
-
 typedef struct {
     const key_state_t *keyState;
-    uint8_t keyActivationId;
     uint32_t timestamp;
-    doubletap_state_t doubletapState;
+    uint8_t multiTapCount;
+    uint8_t keyActivationId : 4;
+    bool multiTapBreaker : 1;
 } key_press_event_t;
 
 static key_press_event_t history[HISTORY_SIZE];
@@ -28,47 +22,31 @@ void KeyHistory_RecordPress(const key_state_t *keyState)
     const key_press_event_t * const lastPress = &history[LAST];
     const bool isMultitap = 
         keyState == lastPress->keyState
-        && lastPress->doubletapState != DoubletapState_Blocked
+        && !lastPress->multiTapBreaker
         && CurrentPostponedTime < lastPress->timestamp + Cfg.DoubletapTimeout;
-    const bool isDoubletap = isMultitap &&
-        (lastPress->doubletapState == DoubletapState_First || lastPress->doubletapState == DoubletapState_Multitap);
 
     ++position;
     history[LAST] = (key_press_event_t) {
         .keyState = keyState,
         .keyActivationId = keyState->activationId,
         .timestamp = CurrentPostponedTime,
-        .doubletapState = isDoubletap ? DoubletapState_Doubletap :
-            isMultitap ? DoubletapState_Multitap :
-            DoubletapState_First,
+        .multiTapCount = 1 + (isMultitap ? lastPress->multiTapCount : 0),
+        .multiTapBreaker = false,
     };
 }
 
 void KeyHistory_RecordRelease(const key_state_t *keyState)
 {
     if (keyState != history[LAST].keyState) {
-        history[LAST].doubletapState = DoubletapState_Blocked;
+        history[LAST].multiTapBreaker = true;
     }
 }
 
-bool KeyHistory_WasDoubletap(const key_state_t *keyState, uint8_t activationId)
-{
-    for (uint8_t i = 0; i < HISTORY_SIZE; ++i) {
-        const key_press_event_t * const event = &history[POS(i)];
-        if (event->keyState == keyState && event->keyActivationId == activationId) {
-            return event->doubletapState == DoubletapState_Doubletap;
+uint8_t KeyHistory_GetMultitapCount(const key_state_t *keyState, uint8_t activationId) {
+    for (uint8_t i = 0; i < HISTORY_SIZE - 1; ++i) {
+        if(history[POS(i)].keyState == keyState && history[POS(i)].keyActivationId == activationId) {
+            return history[POS(i)].multiTapCount;
         }
     }
-    return false;
-}
-
-bool KeyHistory_WasMultitap(const key_state_t *keyState, uint8_t activationId)
-{
-    for (uint8_t i = 0; i < HISTORY_SIZE; ++i) {
-        const key_press_event_t * const event = &history[POS(i)];
-        if (event->keyState == keyState && event->keyActivationId == activationId) {
-            return event->doubletapState >= DoubletapState_Multitap;
-        }
-    }
-    return false;
+    return 0;
 }

--- a/right/src/key_history.c
+++ b/right/src/key_history.c
@@ -4,15 +4,7 @@
 
 #define HISTORY_SIZE 2
 #define LAST (position % HISTORY_SIZE)
-#define POS(p) ((position - p) % HISTORY_SIZE)
-
-typedef struct {
-    const key_state_t *keyState;
-    uint32_t timestamp;
-    uint8_t multiTapCount : 6;
-    uint8_t keyActivationId : 4;
-    bool multiTapBreaker : 1;
-} key_press_event_t;
+#define POS(p) ((position - p) % HISTORY_SIZE) // Proceeding backwards in time
 
 static key_press_event_t history[HISTORY_SIZE];
 static uint8_t position = 0;
@@ -40,6 +32,19 @@ void KeyHistory_RecordRelease(const key_state_t *keyState)
     if (keyState != history[LAST].keyState) {
         history[LAST].multiTapBreaker = true;
     }
+}
+
+const key_press_event_t * KeyHistory_GetPreceedingPress(const key_state_t *keyState, uint8_t activationId)
+{
+    for (uint8_t i = 0; i < HISTORY_SIZE - 1; ++i) {
+        if(history[POS(i)].keyState == keyState && history[POS(i)].keyActivationId == activationId) {
+            if (history[POS(++i)].keyState != NULL) {
+                return &history[POS(i)];
+            }
+            return NULL;
+        }
+    }
+    return NULL;
 }
 
 uint8_t KeyHistory_GetMultitapCount(const key_state_t *keyState, uint8_t activationId) {

--- a/right/src/key_history.c
+++ b/right/src/key_history.c
@@ -4,7 +4,7 @@
 
 #define HISTORY_SIZE 2
 #define LAST (position % HISTORY_SIZE)
-#define POS(p) ((position - p) % HISTORY_SIZE) // Proceeding backwards in time
+#define POS(p) ((position + HISTORY_SIZE - p) % HISTORY_SIZE) // Proceeding backwards in time
 
 static key_press_event_t history[HISTORY_SIZE];
 static uint8_t position = 0;
@@ -17,7 +17,8 @@ void KeyHistory_RecordPress(const key_state_t *keyState)
         && !lastPress->multiTapBreaker
         && CurrentPostponedTime < lastPress->timestamp + Cfg.DoubletapTimeout;
 
-    ++position;
+    position = (position + 1) % HISTORY_SIZE;
+    
     history[LAST] = (key_press_event_t) {
         .keyState = keyState,
         .keyActivationId = keyState->activationId,

--- a/right/src/key_history.h
+++ b/right/src/key_history.h
@@ -15,8 +15,8 @@
 
 void KeyHistory_RecordPress(const key_state_t *keyState);
 void KeyHistory_RecordRelease(const key_state_t *keyState);
-bool KeyHistory_WasLastDoubletap();
-bool KeyHistory_WasLastMultitap();
+bool KeyHistory_WasDoubletap(const key_state_t *keyState, uint8_t activationId);
+bool KeyHistory_WasMultitap(const key_state_t *keyState, uint8_t activationId);
 
 
 #endif

--- a/right/src/key_history.h
+++ b/right/src/key_history.h
@@ -15,8 +15,7 @@
 
 void KeyHistory_RecordPress(const key_state_t *keyState);
 void KeyHistory_RecordRelease(const key_state_t *keyState);
-bool KeyHistory_WasDoubletap(const key_state_t *keyState, uint8_t activationId);
-bool KeyHistory_WasMultitap(const key_state_t *keyState, uint8_t activationId);
 
+uint8_t KeyHistory_GetMultitapCount(const key_state_t *keyState, uint8_t activationId);
 
 #endif

--- a/right/src/key_history.h
+++ b/right/src/key_history.h
@@ -9,13 +9,26 @@
 
 // Typedefs:
 
+typedef struct {
+    const key_state_t *keyState;
+    uint32_t timestamp;
+    uint8_t multiTapCount : 6;
+    uint8_t keyActivationId : 4;
+    bool multiTapBreaker : 1;
+} key_press_event_t;
+
 // Variables:
 
 // Functions:
 
+// Recording events
 void KeyHistory_RecordPress(const key_state_t *keyState);
 void KeyHistory_RecordRelease(const key_state_t *keyState);
 
+// Querying whole events
+const key_press_event_t * KeyHistory_GetPreceedingPress(const key_state_t *keyState, uint8_t activationId);
+
+// Querying specific info
 uint8_t KeyHistory_GetMultitapCount(const key_state_t *keyState, uint8_t activationId);
 
 #endif

--- a/right/src/key_states.h
+++ b/right/src/key_states.h
@@ -43,7 +43,7 @@
         bool debouncing : 1;
         secondary_role_state_t secondaryState : 2;
         bool padding : 1; // This allows the KEY_INACTIVE() macro to not trigger false because of sequence
-        uint8_t activationId: 4;
+        uint8_t activationId : 4;
     } key_state_t;
 
 // Variables:

--- a/right/src/layer_switcher.c
+++ b/right/src/layer_switcher.c
@@ -117,7 +117,7 @@ void LayerSwitcher_DoubleTapToggle(layer_id_t layer, key_state_t *keyState) {
 
     if(KeyState_ActivatedNow(keyState)) {
         LayerStack_LegacyPop(layer);
-        if (KeyHistory_WasDoubletap(keyState, keyState->activationId)) {
+        if (KeyHistory_GetMultitapCount(keyState, keyState->activationId) % 2 == 0) {
             LayerStack_LegacyPush(layer);
             doubleTapSwitchLayerKey = keyState;
             doubleTapSwitchLayerTriggerTime = Timer_GetCurrentTime();

--- a/right/src/layer_switcher.c
+++ b/right/src/layer_switcher.c
@@ -117,7 +117,7 @@ void LayerSwitcher_DoubleTapToggle(layer_id_t layer, key_state_t *keyState) {
 
     if(KeyState_ActivatedNow(keyState)) {
         LayerStack_LegacyPop(layer);
-        if (KeyHistory_WasLastDoubletap()) {
+        if (KeyHistory_WasDoubletap(keyState, keyState->activationId)) {
             LayerStack_LegacyPush(layer);
             doubleTapSwitchLayerKey = keyState;
             doubleTapSwitchLayerTriggerTime = Timer_GetCurrentTime();

--- a/right/src/macro_events.c
+++ b/right/src/macro_events.c
@@ -54,7 +54,7 @@ void MacroEvent_OnInit()
     const char* name = "$onInit";
     uint8_t idx = FindMacroIndexByName(name, name + strlen(name), false);
     if (idx != 255) {
-        previousEventMacroSlot = Macros_StartMacro(idx, NULL, 0, 255, 255, false, NULL);
+        previousEventMacroSlot = Macros_StartMacro(idx, NULL, 0, 255, false, NULL);
     }
 
     registerJoinSplitEvents();
@@ -67,7 +67,7 @@ static void startMacroInSlot(macro_index_t macroIndex, uint8_t* slotId) {
         if (*slotId != 255 && MacroState[*slotId].ms.macroPlaying) {
             *slotId = Macros_QueueMacro(macroIndex, NULL, 255, *slotId);
         } else {
-            *slotId = Macros_StartMacro(macroIndex, NULL, 0, 255, 255, false, NULL);
+            *slotId = Macros_StartMacro(macroIndex, NULL, 0, 255, false, NULL);
         }
     }
 }

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -136,22 +136,18 @@ static bool isCurrentMacroPostponing()
  */
 bool Macros_CurrentMacroKeyIsActive()
 {
-    if (S->ms.oneShot == 1) {
-        return true;
-    }
     if (S->ms.currentMacroKey == NULL) {
-        return false;
-    }
-    if (S->ms.currentMacroKey->activationId != S->ms.keyActivationId) {
-        return false;
-    }
-    if (!KeyState_Active(S->ms.currentMacroKey)) {
-        return false;
+        return S->ms.oneShot == 1;
     }
     if (isCurrentMacroPostponing()) {
-        return !PostponerQuery_IsKeyReleased(S->ms.currentMacroKey);
+        bool isSameActivation = (S->ms.currentMacroKey->activationId == S->ms.keyActivationId);
+        bool keyIsActive = (KeyState_Active(S->ms.currentMacroKey) && !PostponerQuery_IsKeyReleased(S->ms.currentMacroKey));
+        return  (isSameActivation && keyIsActive) || S->ms.oneShot == 1;
+    } else {
+        bool isSameActivation = (S->ms.currentMacroKey->activationId == S->ms.keyActivationId);
+        bool keyIsActive = KeyState_Active(S->ms.currentMacroKey);
+        return (isSameActivation && keyIsActive) || S->ms.oneShot == 1;
     }
-    return true;
 }
 
 static macro_result_t writeNum(uint32_t a)

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -554,12 +554,22 @@ static macro_result_t processRecordMacroDelayCommand()
     return MacroResult_Finished;
 }
 
-static bool processIfDoubletapCommand(bool negate)
+static bool processIfDoubletapCommand(parser_context_t *ctx, bool negate)
 {
+    uint8_t n = 2;
+    if (ConsumeToken(ctx, "taps")) {
+        n = Macros_ConsumeInt(ctx);
+    }
+
     if (Macros_DryRun) {
         return true;
     }
-    return S->ms.isDoubletap != negate;
+
+    if (S->ms.currentMacroKey == NULL) {
+        return false;
+    }
+
+    return (S->ms.multitapCount % n == 0) != negate;
 }
 
 static bool processIfModifierCommand(bool negate, uint8_t modmask)
@@ -2097,9 +2107,9 @@ static macro_result_t processCommand(parser_context_t* ctx)
         case CommandId_if:
             PROCESS_CONDITION(processIfCommand(ctx))
         case CommandId_ifDoubletap:
-            PROCESS_CONDITION(processIfDoubletapCommand(false))
+            PROCESS_CONDITION(processIfDoubletapCommand(ctx, false))
         case CommandId_ifNotDoubletap:
-            PROCESS_CONDITION(processIfDoubletapCommand(true))
+            PROCESS_CONDITION(processIfDoubletapCommand(ctx, true))
         case CommandId_ifInterrupted:
             PROCESS_CONDITION(processIfInterruptedCommand(false))
         case CommandId_ifNotInterrupted:

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -136,18 +136,22 @@ static bool isCurrentMacroPostponing()
  */
 bool Macros_CurrentMacroKeyIsActive()
 {
+    if (S->ms.oneShot == 1) {
+        return true;
+    }
     if (S->ms.currentMacroKey == NULL) {
-        return S->ms.oneShot == 1;
+        return false;
+    }
+    if (S->ms.currentMacroKey->activationId != S->ms.keyActivationId) {
+        return false;
+    }
+    if (!KeyState_Active(S->ms.currentMacroKey)) {
+        return false;
     }
     if (isCurrentMacroPostponing()) {
-        bool isSameActivation = (S->ms.currentMacroKey->activationId == S->ms.keyActivationId);
-        bool keyIsActive = (KeyState_Active(S->ms.currentMacroKey) && !PostponerQuery_IsKeyReleased(S->ms.currentMacroKey));
-        return  (isSameActivation && keyIsActive) || S->ms.oneShot == 1;
-    } else {
-        bool isSameActivation = (S->ms.currentMacroKey->activationId == S->ms.keyActivationId);
-        bool keyIsActive = KeyState_Active(S->ms.currentMacroKey);
-        return (isSameActivation && keyIsActive) || S->ms.oneShot == 1;
+        return !PostponerQuery_IsKeyReleased(S->ms.currentMacroKey);
     }
+    return true;
 }
 
 static macro_result_t writeNum(uint32_t a)

--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -402,6 +402,55 @@ static bool macroIsValid(uint8_t index)
     return exists && isNonEmpty;
 }
 
+macro_result_t Macros_ExecMacro(uint8_t macroIndex)
+{
+    if (!macroIsValid(macroIndex))  {
+       S->ms.macroBroken = true;
+       return MacroResult_Finished;
+    }
+
+    //reset to address zero and load first address
+    resetToAddressZero(macroIndex);
+
+    if (Cfg.Macros_Scheduler == Scheduler_Preemptive) {
+        continueMacro();
+    }
+
+    return MacroResult_JumpedForward;
+}
+
+uint8_t startMacro(
+    uint8_t index,
+    key_state_t *keyState,
+    uint16_t argumentOffset,
+    uint8_t keyActivationId,
+    uint8_t parentMacroSlot,
+    bool runFirstAction,
+    const char *inlineText,
+    const macro_state_t *parentMacroState
+);
+
+macro_result_t Macros_CallMacro(uint8_t macroIndex)
+{
+    uint32_t parentSlotIndex = S - MacroState;
+    uint8_t childSlotIndex = startMacro(macroIndex, S->ms.currentMacroKey, 0, S->ms.keyActivationId, parentSlotIndex, true, NULL, S);
+
+    if (childSlotIndex != 255) {
+        unscheduleCurrentSlot();
+        S->ms.macroSleeping = true;
+        S->ms.wakeMeOnKeystateChange = false;
+        S->ms.wakeMeOnTime = false;
+    }
+
+    return MacroResult_Finished | MacroResult_YieldFlag;
+}
+
+macro_result_t Macros_ForkMacro(uint8_t macroIndex)
+{
+    startMacro(macroIndex, S->ms.currentMacroKey, 0, S->ms.keyActivationId, 255, true, NULL, S);
+    return MacroResult_Finished;
+}
+
 uint8_t initMacro(
     uint8_t index,
     key_state_t *keyState,
@@ -470,6 +519,7 @@ uint8_t initMacro(
 }
 
 
+//partentMacroSlot == 255 means no parent
 uint8_t startMacro(
     uint8_t index,
     key_state_t *keyState,
@@ -506,7 +556,6 @@ uint8_t startMacro(
     return slotIndex;
 }
 
-//partentMacroSlot == 255 means no parent
 uint8_t Macros_StartMacro(
     uint8_t index,
     key_state_t *keyState,
@@ -516,44 +565,6 @@ uint8_t Macros_StartMacro(
     const char *inlineText
 ) {
     return startMacro(index, keyState, argumentOffset, keyActivationId, MacroIndex_None, runFirstAction, inlineText, NULL);
-}
-
-macro_result_t Macros_ExecMacro(uint8_t macroIndex)
-{
-    if (!macroIsValid(macroIndex))  {
-       S->ms.macroBroken = true;
-       return MacroResult_Finished;
-    }
-
-    //reset to address zero and load first address
-    resetToAddressZero(macroIndex);
-
-    if (Cfg.Macros_Scheduler == Scheduler_Preemptive) {
-        continueMacro();
-    }
-
-    return MacroResult_JumpedForward;
-}
-
-macro_result_t Macros_CallMacro(uint8_t macroIndex)
-{
-    uint32_t parentSlotIndex = S - MacroState;
-    uint8_t childSlotIndex = startMacro(macroIndex, S->ms.currentMacroKey, 0, S->ms.keyActivationId, parentSlotIndex, true, NULL, S);
-
-    if (childSlotIndex != 255) {
-        unscheduleCurrentSlot();
-        S->ms.macroSleeping = true;
-        S->ms.wakeMeOnKeystateChange = false;
-        S->ms.wakeMeOnTime = false;
-    }
-
-    return MacroResult_Finished | MacroResult_YieldFlag;
-}
-
-macro_result_t Macros_ForkMacro(uint8_t macroIndex)
-{
-    startMacro(macroIndex, S->ms.currentMacroKey, 0, S->ms.keyActivationId, MacroIndex_None, true, NULL, S);
-    return MacroResult_Finished;
 }
 
 uint8_t Macros_StartInlineMacro(const char *text, key_state_t *keyState, uint8_t keyActivationId)

--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -463,7 +463,18 @@ uint8_t initMacro(
     S->ms.currentMacroStartTime = CurrentPostponedTime;
     S->ms.currentMacroArgumentOffset = argumentOffset;
     S->ms.parentMacroSlot = parentMacroSlot;
-    S->ms.multitapCount = keyState == NULL ? 0 : KeyHistory_GetMultitapCount(keyState, keyActivationId);
+
+    S->ms.multitapCount = 0;
+    S->ms.previousKeyPressTime = 0;
+    S->ms.previousKeyId = 255;
+    if (keyState != NULL) {
+        S->ms.multitapCount = KeyHistory_GetMultitapCount(keyState, keyActivationId);
+        const key_press_event_t * const prevEvt = KeyHistory_GetPreceedingPress(keyState, keyActivationId);
+        if (prevEvt != NULL) {
+            S->ms.previousKeyId = Utils_KeyStateToKeyId(prevEvt->keyState);
+            S->ms.previousKeyPressTime = prevEvt->timestamp;
+        }
+    }
 
     // If inline text is provided, set up the action before resetToAddressZero
     if (inlineText != NULL) {

--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -463,7 +463,7 @@ uint8_t initMacro(
     S->ms.currentMacroStartTime = CurrentPostponedTime;
     S->ms.currentMacroArgumentOffset = argumentOffset;
     S->ms.parentMacroSlot = parentMacroSlot;
-    S->ms.isDoubletap = keyState != NULL && KeyHistory_GetMultitapCount(keyState, keyActivationId) % 2 == 0;
+    S->ms.multitapCount = keyState == NULL ? 0 : KeyHistory_GetMultitapCount(keyState, keyActivationId);
 
     // If inline text is provided, set up the action before resetToAddressZero
     if (inlineText != NULL) {

--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -402,51 +402,14 @@ static bool macroIsValid(uint8_t index)
     return exists && isNonEmpty;
 }
 
-macro_result_t Macros_ExecMacro(uint8_t macroIndex)
-{
-    if (!macroIsValid(macroIndex))  {
-       S->ms.macroBroken = true;
-       return MacroResult_Finished;
-    }
-
-    //reset to address zero and load first address
-    resetToAddressZero(macroIndex);
-
-    if (Cfg.Macros_Scheduler == Scheduler_Preemptive) {
-        continueMacro();
-    }
-
-    return MacroResult_JumpedForward;
-}
-
-macro_result_t Macros_CallMacro(uint8_t macroIndex)
-{
-    uint32_t parentSlotIndex = S - MacroState;
-    uint8_t childSlotIndex = Macros_StartMacro(macroIndex, S->ms.currentMacroKey, 0, S->ms.keyActivationId, parentSlotIndex, true, NULL);
-
-    if (childSlotIndex != 255) {
-        unscheduleCurrentSlot();
-        S->ms.macroSleeping = true;
-        S->ms.wakeMeOnKeystateChange = false;
-        S->ms.wakeMeOnTime = false;
-    }
-
-    return MacroResult_Finished | MacroResult_YieldFlag;
-}
-
-macro_result_t Macros_ForkMacro(uint8_t macroIndex)
-{
-    Macros_StartMacro(macroIndex, S->ms.currentMacroKey, 0, S->ms.keyActivationId, 255, true, NULL);
-    return MacroResult_Finished;
-}
-
 uint8_t initMacro(
     uint8_t index,
     key_state_t *keyState,
     uint16_t argumentOffset,
     uint8_t keyActivationId,
     uint8_t parentMacroSlot,
-    const char *inlineText
+    const char *inlineText,
+    const macro_state_t *parentMacroState
 ) {
     if (!macroIsValid(index) || !findFreeStateSlot() || !findFreeScopeStateSlot())  {
        return 255;
@@ -460,19 +423,28 @@ uint8_t initMacro(
     S->ms.currentMacroIndex = index;
     S->ms.currentMacroKey = keyState;
     S->ms.keyActivationId = keyActivationId;
-    S->ms.currentMacroStartTime = CurrentPostponedTime;
     S->ms.currentMacroArgumentOffset = argumentOffset;
     S->ms.parentMacroSlot = parentMacroSlot;
 
-    S->ms.multitapCount = 0;
-    S->ms.previousKeyPressTime = 0;
-    S->ms.previousKeyId = 255;
-    if (keyState != NULL) {
-        S->ms.multitapCount = KeyHistory_GetMultitapCount(keyState, keyActivationId);
-        const key_press_event_t * const prevEvt = KeyHistory_GetPreceedingPress(keyState, keyActivationId);
-        if (prevEvt != NULL) {
-            S->ms.previousKeyId = Utils_KeyStateToKeyId(prevEvt->keyState);
-            S->ms.previousKeyPressTime = prevEvt->timestamp;
+    if(parentMacroState != NULL) {
+        S->ms.currentMacroStartTime = parentMacroState->ms.currentMacroStartTime;
+        S->ms.multitapCount = parentMacroState->ms.multitapCount;
+        S->ms.previousKeyPressTime = parentMacroState->ms.previousKeyPressTime;
+        S->ms.previousKeyId = parentMacroState->ms.previousKeyId;
+        S->ms.secondaryRoleState = parentMacroState->ms.secondaryRoleState;
+    }
+    else {
+        S->ms.currentMacroStartTime = CurrentPostponedTime;
+        S->ms.multitapCount = 0;
+        S->ms.previousKeyPressTime = 0;
+        S->ms.previousKeyId = 255;
+        if (keyState != NULL) {
+            S->ms.multitapCount = KeyHistory_GetMultitapCount(keyState, keyActivationId);
+            const key_press_event_t * const prevEvt = KeyHistory_GetPreceedingPress(keyState, keyActivationId);
+            if (prevEvt != NULL) {
+                S->ms.previousKeyId = Utils_KeyStateToKeyId(prevEvt->keyState);
+                S->ms.previousKeyPressTime = prevEvt->timestamp;
+            }
         }
     }
 
@@ -498,19 +470,19 @@ uint8_t initMacro(
 }
 
 
-//partentMacroSlot == 255 means no parent
-uint8_t Macros_StartMacro(
+uint8_t startMacro(
     uint8_t index,
     key_state_t *keyState,
     uint16_t argumentOffset,
     uint8_t keyActivationId,
     uint8_t parentMacroSlot,
     bool runFirstAction,
-    const char *inlineText
+    const char *inlineText,
+    const macro_state_t *parentMacroState
 ) {
     macro_state_t* oldState = S;
 
-    uint8_t slotIndex = initMacro(index, keyState, argumentOffset, keyActivationId, parentMacroSlot, inlineText);
+    uint8_t slotIndex = initMacro(index, keyState, argumentOffset, keyActivationId, parentMacroSlot, inlineText, parentMacroState);
 
     if (slotIndex == 255) {
         S = oldState;
@@ -534,14 +506,64 @@ uint8_t Macros_StartMacro(
     return slotIndex;
 }
 
+//partentMacroSlot == 255 means no parent
+uint8_t Macros_StartMacro(
+    uint8_t index,
+    key_state_t *keyState,
+    uint16_t argumentOffset,
+    uint8_t keyActivationId,
+    bool runFirstAction,
+    const char *inlineText
+) {
+    return startMacro(index, keyState, argumentOffset, keyActivationId, MacroIndex_None, runFirstAction, inlineText, NULL);
+}
+
+macro_result_t Macros_ExecMacro(uint8_t macroIndex)
+{
+    if (!macroIsValid(macroIndex))  {
+       S->ms.macroBroken = true;
+       return MacroResult_Finished;
+    }
+
+    //reset to address zero and load first address
+    resetToAddressZero(macroIndex);
+
+    if (Cfg.Macros_Scheduler == Scheduler_Preemptive) {
+        continueMacro();
+    }
+
+    return MacroResult_JumpedForward;
+}
+
+macro_result_t Macros_CallMacro(uint8_t macroIndex)
+{
+    uint32_t parentSlotIndex = S - MacroState;
+    uint8_t childSlotIndex = startMacro(macroIndex, S->ms.currentMacroKey, 0, S->ms.keyActivationId, parentSlotIndex, true, NULL, S);
+
+    if (childSlotIndex != 255) {
+        unscheduleCurrentSlot();
+        S->ms.macroSleeping = true;
+        S->ms.wakeMeOnKeystateChange = false;
+        S->ms.wakeMeOnTime = false;
+    }
+
+    return MacroResult_Finished | MacroResult_YieldFlag;
+}
+
+macro_result_t Macros_ForkMacro(uint8_t macroIndex)
+{
+    startMacro(macroIndex, S->ms.currentMacroKey, 0, S->ms.keyActivationId, MacroIndex_None, true, NULL, S);
+    return MacroResult_Finished;
+}
+
 uint8_t Macros_StartInlineMacro(const char *text, key_state_t *keyState, uint8_t keyActivationId)
 {
-    return Macros_StartMacro(MacroIndex_InlineMacro, keyState, 0, keyActivationId, 255, true, text);
+    return startMacro(MacroIndex_InlineMacro, keyState, 0, keyActivationId, MacroIndex_None, true, text, NULL);
 }
 
 void Macros_ValidateMacro(uint8_t macroIndex, uint16_t argumentOffset, uint8_t moduleId, uint8_t keyIdx, uint8_t keymapIdx, uint8_t layerIdx) {
     bool wasValid = true;
-    uint8_t slotIndex = initMacro(macroIndex, NULL, argumentOffset, 255, 255, NULL);
+    uint8_t slotIndex = initMacro(macroIndex, NULL, argumentOffset, 255, MacroIndex_None, NULL, NULL);
 
     if (slotIndex == 255) {
         S = NULL;
@@ -622,7 +644,7 @@ uint8_t Macros_QueueMacro(uint8_t index, key_state_t *keyState, uint8_t keyActiv
 {
     macro_state_t* oldState = S;
 
-    uint8_t slotIndex = initMacro(index, keyState, 0, keyActivationId, 255, NULL);
+    uint8_t slotIndex = initMacro(index, keyState, 0, keyActivationId, MacroIndex_None, NULL, NULL);
 
     if (slotIndex == 255) {
         return slotIndex;

--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -463,7 +463,7 @@ uint8_t initMacro(
     S->ms.currentMacroStartTime = CurrentPostponedTime;
     S->ms.currentMacroArgumentOffset = argumentOffset;
     S->ms.parentMacroSlot = parentMacroSlot;
-    S->ms.isDoubletap = keyState != NULL && KeyHistory_WasDoubletap(keyState, keyActivationId);
+    S->ms.isDoubletap = keyState != NULL && KeyHistory_GetMultitapCount(keyState, keyActivationId) % 2 == 0;
 
     // If inline text is provided, set up the action before resetToAddressZero
     if (inlineText != NULL) {

--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -463,7 +463,7 @@ uint8_t initMacro(
     S->ms.currentMacroStartTime = CurrentPostponedTime;
     S->ms.currentMacroArgumentOffset = argumentOffset;
     S->ms.parentMacroSlot = parentMacroSlot;
-    S->ms.isDoubletap = keyState != NULL && KeyHistory_WasLastDoubletap();
+    S->ms.isDoubletap = keyState != NULL && KeyHistory_WasDoubletap(keyState, keyActivationId);
 
     // If inline text is provided, set up the action before resetToAddressZero
     if (inlineText != NULL) {

--- a/right/src/macros/core.h
+++ b/right/src/macros/core.h
@@ -281,7 +281,7 @@
     macro_result_t Macros_SleepTillTime(uint32_t time, const char* reason);
     uint8_t Macros_ConsumeLayerId(parser_context_t* ctx);
     uint8_t Macros_QueueMacro(uint8_t index, key_state_t *keyState, uint8_t keyActivationId, uint8_t queueAfterSlot);
-    uint8_t Macros_StartMacro(uint8_t index, key_state_t *keyState, uint16_t argumentOffset, uint8_t keyActivationId, uint8_t parentMacroSlot, bool runFirstAction, const char *inlineText);
+    uint8_t Macros_StartMacro(uint8_t index, key_state_t *keyState, uint16_t argumentOffset, uint8_t keyActivationId, bool runFirstAction, const char *inlineText);
     uint8_t Macros_StartInlineMacro(const char *text, key_state_t *keyState, uint8_t keyActivationId);
     uint8_t Macros_TryConsumeKeyId(parser_context_t* ctx);
     void Macros_ContinueMacro(void);

--- a/right/src/macros/core.h
+++ b/right/src/macros/core.h
@@ -155,9 +155,10 @@
             uint8_t nextSlot;
             uint8_t oneShot : 2;
             bool macroInterrupted : 1;
-            uint8_t keyActivationId: 4;
             // TODO: refactor macroSleeping, macroBroken and macroPlaying into a single state?
             bool macroSleeping : 1;
+            uint8_t keyActivationId: 4;
+
             bool macroBroken : 1;
             bool macroPlaying : 1;
             bool macroScheduled : 1;
@@ -166,7 +167,8 @@
             bool wakeMeOnKeystateChange: 1;
             bool autoRepeatInitialDelayPassed: 1;
             macro_autorepeat_state_t autoRepeatPhase: 1;
-            bool isDoubletap: 1;
+
+            uint8_t multitapCount : 6;
             secondary_role_state_t secondaryRoleState: 2;
             // ---- 4-aligned ----
 

--- a/right/src/macros/core.h
+++ b/right/src/macros/core.h
@@ -145,6 +145,8 @@
             macro_action_t currentMacroAction;
             key_state_t *currentMacroKey;
             uint32_t currentMacroStartTime;
+            uint8_t previousKeyId;
+            uint32_t previousKeyPressTime;
             uint16_t currentMacroActionIndex;
             uint16_t currentMacroArgumentOffset;
             uint16_t bufferOffset;

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -342,6 +342,12 @@ static macro_variable_t consumeDollarExpression(parser_context_t* ctx)
     else if (ConsumeToken(ctx, "thisKeyId")) {
         return intVar(Utils_KeyStateToKeyId(ctx->macroState->ms.currentMacroKey));
     }
+    else if (ConsumeToken(ctx, "previousKeyId")) {
+        return intVar(ctx->macroState->ms.previousKeyId);
+    }
+    else if (ConsumeToken(ctx, "previousKeyPressTime")) {
+        return intVar(ctx->macroState->ms.previousKeyPressTime);
+    }
     else if (ConsumeToken(ctx, "currentAddress")) {
         return intVar(ctx->macroState->ls->ms.commandAddress);
     }

--- a/right/src/postponer.c
+++ b/right/src/postponer.c
@@ -33,7 +33,7 @@ uint8_t Postponer_LastKeyMods = 0;
 //static uint8_t cyclesUntilActivation = 0;
 static uint32_t lastPressTime;
 
-#define POS(idx) ((bufferPosition + POSTPONER_BUFFER_SIZE + (idx)) % POSTPONER_BUFFER_SIZE)
+#define POS(idx) ((bufferPosition + (idx)) % POSTPONER_BUFFER_SIZE)
 
 uint32_t CurrentPostponedTime = 0;
 

--- a/right/src/postponer.c
+++ b/right/src/postponer.c
@@ -33,7 +33,7 @@ uint8_t Postponer_LastKeyMods = 0;
 //static uint8_t cyclesUntilActivation = 0;
 static uint32_t lastPressTime;
 
-#define POS(idx) ((bufferPosition + (idx)) % POSTPONER_BUFFER_SIZE)
+#define POS(idx) ((bufferPosition + POSTPONER_BUFFER_SIZE + (idx)) % POSTPONER_BUFFER_SIZE)
 
 uint32_t CurrentPostponedTime = 0;
 

--- a/right/src/secondary_role_driver.c
+++ b/right/src/secondary_role_driver.c
@@ -250,7 +250,7 @@ static void startResolution(
 {
     // store current state
     currentlyResolving = true;
-    isDoubletap = KeyHistory_WasLastMultitap();
+    isDoubletap = KeyHistory_WasMultitap(keyState, keyState->activationId);
     resolutionKey = keyState;
     resolutionStartTime = CurrentPostponedTime;
     resolutionCallerIsMacroEngine = isMacroResolution;

--- a/right/src/secondary_role_driver.c
+++ b/right/src/secondary_role_driver.c
@@ -250,7 +250,7 @@ static void startResolution(
 {
     // store current state
     currentlyResolving = true;
-    isDoubletap = KeyHistory_WasMultitap(keyState, keyState->activationId);
+    isDoubletap = KeyHistory_GetMultitapCount(keyState, keyState->activationId) > 1;
     resolutionKey = keyState;
     resolutionStartTime = CurrentPostponedTime;
     resolutionCallerIsMacroEngine = isMacroResolution;

--- a/right/src/usb_commands/usb_command_exec_macro_command.c
+++ b/right/src/usb_commands/usb_command_exec_macro_command.c
@@ -42,7 +42,7 @@ static bool canExecute()
 
 void UsbMacroCommand_ExecuteSynchronously()
 {
-    Macros_StartMacro(MacroIndex_InlineMacro, &dummyState, 0, 255, MacroIndex_None, false, UsbMacroCommand);
+    Macros_StartMacro(MacroIndex_InlineMacro, &dummyState, 0, 255, false, UsbMacroCommand);
     EventVector_Unset(EventVector_UsbMacroCommandWaitingForExecution);
 }
 

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -469,7 +469,7 @@ void ApplyKeyAction(key_state_t *keyState, key_action_cached_t *cachedAction, ke
         case KeyActionType_PlayMacro:
             if (KeyState_ActivatedNow(keyState)) {
                 resetStickyMods(cachedAction);
-                Macros_StartMacro(action->playMacro.macroId, keyState, action->playMacro.offset, keyState->activationId, 255, true, NULL);
+                Macros_StartMacro(action->playMacro.macroId, keyState, action->playMacro.offset, keyState->activationId, true, NULL);
             }
             break;
         case KeyActionType_InlineMacro:

--- a/right/src/utils.c
+++ b/right/src/utils.c
@@ -26,24 +26,15 @@
 #if !DEVICE_IS_UHK_DONGLE
 //this is noop at the moment, prepared for time when MAX_KEY_COUNT_PER_MODULE changes
 //the purpose is to preserve current keyids
-static uint16_t recodeId(uint16_t newFormat, uint16_t fromBase, uint16_t toBase)
-{
-    return toBase * (newFormat / fromBase) + (newFormat % fromBase);
-}
+#define RECODE_ID(id, oldBase, newBase) (newBase * (id / oldBase) + id % oldBase)
 #endif
 
-uint16_t Utils_KeyStateToKeyId(key_state_t* key)
-{
+uint16_t Utils_KeyStateToKeyId(const key_state_t *key) {
 #if DEVICE_IS_UHK_DONGLE
     return 0;
 #else
-    if (key == NULL) {
-        return 0;
-    }
-    uint32_t ptr1 = (uint32_t)(key_state_t*)key;
-    uint32_t ptr2 = (uint32_t)(key_state_t*)&(KeyStates[0][0]);
-    uint32_t res = (ptr1 - ptr2) / sizeof(key_state_t);
-    return recodeId(res, MAX_KEY_COUNT_PER_MODULE, 64);
+    uint16_t arrayPos = (uint16_t)(key - (key_state_t*)KeyStates);
+    return RECODE_ID(arrayPos, MAX_KEY_COUNT_PER_MODULE, 64);
 #endif
 }
 
@@ -52,7 +43,7 @@ key_state_t* Utils_KeyIdToKeyState(uint16_t keyid)
 #if DEVICE_IS_UHK_DONGLE
     return NULL;
 #else
-    return &(((key_state_t*)KeyStates)[recodeId(keyid, 64, MAX_KEY_COUNT_PER_MODULE)]);
+    return &(((key_state_t*)KeyStates)[RECODE_ID(keyid, 64, MAX_KEY_COUNT_PER_MODULE)]);
 #endif
 }
 

--- a/right/src/utils.c
+++ b/right/src/utils.c
@@ -33,6 +33,9 @@ uint16_t Utils_KeyStateToKeyId(const key_state_t *key) {
 #if DEVICE_IS_UHK_DONGLE
     return 0;
 #else
+    if (key == NULL) {
+        return 255;
+    }
     uint16_t arrayPos = (uint16_t)(key - (key_state_t*)KeyStates);
     return RECODE_ID(arrayPos, MAX_KEY_COUNT_PER_MODULE, 64);
 #endif

--- a/right/src/utils.h
+++ b/right/src/utils.h
@@ -35,7 +35,7 @@ if (reentrancyGuard_active) {                    \
 
     uint8_t Utils_SafeStrCopy(char* target, const char* src, uint8_t max);
     key_state_t* Utils_KeyIdToKeyState(uint16_t keyid);
-    uint16_t Utils_KeyStateToKeyId(key_state_t* key);
+    uint16_t Utils_KeyStateToKeyId(const key_state_t* key);
     const char* Utils_KeyStateToKeyAbbreviation(key_state_t* key);
     void Utils_DecodeId(uint16_t keyid, uint8_t* outSlotId, uint8_t* outSlotIdx);
     const char* Utils_GetUsbReportString(const usb_basic_keyboard_report_t* report);


### PR DESCRIPTION
Did some more key history work and exposed it in macros:
`ifDoubletap` has support for detecting a series of taps any number long, within reason, such as triple and so on.
Added `$previousKeyId` which can be used to create a repeat key, which I have seen requested.
Added `$previousKeyPressTime` which can be used to detect idle time before the key was pressed.  I know that has also been requested.

Also did a couple of small refactors where I ran across code which I thought could be optimized.

I want to do one more small refactor in macros:  Macros started using `call`, `fork` and `exec` should inherit more variables from their parents than `currentMacroKey` and `keyActivationId`.

I am okay with any part of this being rejected, I mostly did this for fun.