### PR TITLE
Send battery level notifications only if the host is awake.

### DIFF
--- a/device/src/keyboard/charger.c
+++ b/device/src/keyboard/charger.c
@@ -362,7 +362,9 @@ void Charger_UpdateBatteryState() {
         StateSync_UpdateProperty(StateSyncPropertyId_Battery, &batteryState);
 
 #ifdef CONFIG_BT_BAS
-        bt_bas_set_battery_level(batteryState.batteryPercentage);
+        if (CurrentPowerMode <= PowerMode_LastAwake) {
+            bt_bas_set_battery_level(batteryState.batteryPercentage);
+        }
 #endif
         stateChanged = false;
     }


### PR DESCRIPTION
Changelog:

- Don't report battery levels over bluetooth when the keyboard is sleeping. It tends to wake up MacOs hosts.

Closes #1517