### PR TITLE
Fix mappings changed stuck

### DIFF
--- a/right/src/layer_switcher.c
+++ b/right/src/layer_switcher.c
@@ -164,7 +164,7 @@ void LayerSwitcher_UnToggleLayerOnly(layer_id_t layer) {
 
 static bool heldLayers[LayerId_Count];
 
-static bool mappingsChanged = false;
+static uint8_t mappingsChangedCounter = 0;
 
 // Called by pressed hold-layer keys during every cycle
 void LayerSwitcher_HoldLayer(layer_id_t layer, bool forceSwap) {
@@ -223,10 +223,12 @@ void LayerSwitcher_UpdateHeldLayer() {
         updateActiveLayer();
     }
 
-    if (mappingsChanged) {
-        // this runs before a native action update, so update native actions, and in next cycle, update layer holds again
+    if (mappingsChangedCounter > 0) {
+        // Keep re-running native actions + layer holds for a couple of cycles so that
+        // the refreshed cached actions get a chance to repopulate heldLayers and
+        // then have the hold-layer update reflect that fresh state.
+        mappingsChangedCounter--;
         EventVector_Set(EventVector_NativeActions | EventVector_LayerHolds);
-        mappingsChanged = false;
     }
 }
 
@@ -237,8 +239,8 @@ void LayerSwitcher_ResetHolds() {
 }
 
 void LayerSwitcher_MarkMappingsChanged() {
-    EventVector_Unset(EventVector_LayerHolds);
-    mappingsChanged = true;
+    mappingsChangedCounter = 2;
+    EventVector_Set(EventVector_NativeActions | EventVector_LayerHolds);
 }
 
 /**

--- a/right/src/test_suite/tests/test_layers.c
+++ b/right/src/test_suite/tests/test_layers.c
@@ -42,9 +42,34 @@ static const test_action_t test_layer_hold_with_modifier[] = {
     TEST_END()
 };
 
+// Regression: tapping a macro that runs `holdLayer mod` followed by
+// `replaceLayer mod current mod` must not leave the mod layer stuck active.
+// The witness is "i": on the base layer it produces "i", on the mod layer "j".
+// After the tap, subsequent "i" presses must produce the base-layer action.
+static const test_action_t test_layer_hold_replace_layer[] = {
+    TEST_SET_ACTION("i", "i"),
+    TEST_SET_LAYER_ACTION(LayerId_Mod, "i", "j"),
+    TEST_SET_MACRO("u",
+        "holdLayer mod\n"
+        "replaceLayer mod current mod\n"
+    ),
+    TEST_PRESS______("u"),
+    TEST_DELAY__(50),
+    TEST_RELEASE__U("u"),
+    TEST_DELAY__(50),
+    TEST_PRESS______("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("i"),
+    TEST_RELEASE__U("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+    TEST_END()
+};
+
 static const test_t layer_tests[] = {
     { .name = "layer_hold", .actions = test_layer_hold },
     { .name = "layer_hold_with_modifier", .actions = test_layer_hold_with_modifier },
+    { .name = "layer_hold_replace_layer", .actions = test_layer_hold_replace_layer },
 };
 
 const test_module_t TestModule_Layers = {


### PR DESCRIPTION
Changelog:
- fix stuck layer hold when replaceLayer is triggered from macro after layer release.

Discovered due to https://forum.uhk.io/t/alt-tab-on-mod-layer-does-kill-other-mod-keys/2892/3