### PR TITLE
Fix sticky holdkey

### DIFF
--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -464,6 +464,7 @@ uint8_t initMacro(
     S->ms.currentMacroArgumentOffset = argumentOffset;
     S->ms.parentMacroSlot = parentMacroSlot;
     S->ms.isDoubletap = keyState != NULL && KeyHistory_WasLastDoubletap();
+    S->ms.isFirstCommand = true;
 
     // If inline text is provided, set up the action before resetToAddressZero
     if (inlineText != NULL) {
@@ -639,6 +640,11 @@ macro_result_t continueMacro(void)
     if (S->ms.postponeNextNCommands > 0) {
         S->ls->as.modifierPostpone = true;
         //PostponerCore_PostponeNCycles(1);
+    }
+
+    if (S->ms.isFirstCommand) {
+        S->ms.isFirstCommand = false;
+        StickyMods_ResetLater(NULL);
     }
 
     macro_result_t res = MacroResult_YieldFlag;

--- a/right/src/macros/core.h
+++ b/right/src/macros/core.h
@@ -166,6 +166,7 @@
             bool autoRepeatInitialDelayPassed: 1;
             macro_autorepeat_state_t autoRepeatPhase: 1;
             bool isDoubletap: 1;
+            bool isFirstCommand : 1;
             secondary_role_state_t secondaryRoleState: 2;
             // ---- 4-aligned ----
 

--- a/right/src/test_suite/CLAUDE.md
+++ b/right/src/test_suite/CLAUDE.md
@@ -1,72 +1,102 @@
 # Test Suite Development Guidelines
 
+## Adding a new test
+
+1. Create `tests/test_<name>.c` defining one or more `test_action_t[]` arrays and a `test_module_t TestModule_<Name>`. Use an existing file (e.g. `test_basic.c`, `test_oneshot.c`) as a template.
+2. Add `extern const test_module_t TestModule_<Name>;` to `tests/tests.h`.
+3. Add `&TestModule_<Name>,` to the `AllTestModules[]` array in `tests/tests.c`.
+4. Add `tests/test_<name>.c` to `CMakeLists.txt`.
+
+## Test actions reference
+
+All actions are defined as macros in `test_actions.h`. The struct backing them is `test_action_t`. Designated-initializer macros zero unset fields, so `layerId` defaults to `LayerId_Base` (0) when not specified.
+
+### Input actions
+- `TEST_PRESS______(key_id)` — simulate key press
+- `TEST_RELEASE__U(key_id)` — simulate key release
+- `TEST_DELAY__(ms)` — wait (use ≥ 50ms after press/release for debounce; see Key Timing)
+
+### Configuration actions (which layer they target)
+| Macro | Layer |
+| --- | --- |
+| `TEST_SET_ACTION(key_id, shortcut)` | Base only |
+| `TEST_SET_MACRO(key_id, macro_text)` | Base only |
+| `TEST_SET_LAYER_MACRO(layer_id, key_id, macro_text)` | Specified layer |
+| `TEST_SET_LAYER_HOLD(key_id, layer_id)` | Sets a layer-hold action on Base **and** on the target layer (so the layer remains held while the key is held) |
+| `TEST_SET_LAYER_DOUBLETAP_TOGGLE(key_id, layer_id)` | Same dual-write as `TEST_SET_LAYER_HOLD`, mode = HoldAndDoubleTapToggle |
+| `TEST_SET_LAYER_ACTION(layer_id, key_id, shortcut)` | Specified layer (shortcut, **not** a macro) |
+| `TEST_SET_SECONDARY_ROLE(key_id, primary_scancode, role)` | Base only |
+| `TEST_SET_GENERIC_ACTION(key_id, action)` | Base only |
+| `TEST_SET_EMPTY(key_id)` | Base only |
+| `TEST_SET_CONFIG(config_text)` | Runs a `set` command (no key mapping) |
+
+`shortcut` strings go through `MacroShortcutParser_Parse` — same syntax as in macros (e.g. `"LS-i"`, `"sLA-tab"`, `"tab"`).
+
+`macro_text` is the inline-macro body — same syntax you'd type in the user-facing config (multi-line, separate commands with `\n`).
+
+### Validation actions
+- `TEST_EXPECT__________(shortcuts)` — assert the next USB report change matches; takes space-separated shortcuts (e.g. `"LS"`, `"LS-i"`, `"LA-tab"`, `""` for empty)
+- `TEST_EXPECT___________MAYBE(shortcuts)` — optional report (consumed if it appears, skipped otherwise); only use for genuinely timing-dependent intermediate states
+- `TEST_CHECK_NOW(shortcuts)` — validate the current report immediately (no waiting)
+- `TEST_END()` — marks end of action array
+
+## Layer fall-through note
+
+`LayerId_Mod` and the keystroke-modifier layers (`LayerId_Shift`/`Ctrl`/`Alt`/`Gui`) have a non-zero `modifierLayerMask`, so a key with no action on that layer falls through to its **base-layer** action. `LayerId_Fn`/`Mouse`/etc. do **not** fall through.
+
+This matters when you want a base-layer macro to run while a layer is held (e.g. for sticky-modifier `Stick_Smart` behavior, which checks `ActiveLayerHeld`): on Mod, you can leave the macro on base; on Fn, you must use `TEST_SET_LAYER_MACRO`.
+
 ## Key Timing
 
-- **Debouncing**: Takes 50ms on press and another 50ms on release
-- Always use `TEST_DELAY__(50)` or more after press/release actions to account for debouncing
-- For sequences requiring key to be fully registered, use at least 50ms delays
+- **Debouncing**: 50ms on press and another 50ms on release.
+- Always `TEST_DELAY__(50)` (or more) after a press/release to let the key register.
 
 ## Key Selection
 
-- **Always use right-half keys** for all tests (j, k, l, ;, p, o, i, u, m, n, h, y, 7, 8, 9, 0, etc.)
-- Never use left-half keys (a, s, d, f, q, w, e, r, etc.)
+- **Always use right-half keys**: j, k, l, ;, p, o, i, u, m, n, h, y, 7, 8, 9, 0, etc.
+- Never use left-half keys (a, s, d, f, q, w, e, r, etc.) — the test rig only drives the right half.
 
 ## Macro Formatting
 
-For `TEST_SET_MACRO`, always use multiline macro formatting with `\n`:
+For `TEST_SET_MACRO` / `TEST_SET_LAYER_MACRO`, use multiline format with `\n`:
 
 ```c
-// CORRECT - multiline format
+// CORRECT
 TEST_SET_MACRO("j", "ifShortcut k final tapKey n\n"
                     "holdKey j")
 
-// WRONG - single line
+// WRONG
 TEST_SET_MACRO("j", "ifShortcut k final tapKey n\n holdKey j")
 ```
 
 ## Expected Report Sequences
 
-- Be explicit about all intermediate USB report states
-- `tapKey` produces two reports: key down, then key up (empty)
-- Modifier keystrokes produce: modifier alone, then modifier+key, then modifier alone, then empty
-- Only use `TEST_EXPECT___________MAYBE` for genuinely optional timing-dependent states
-
-## Logging Behavior
-
-- `TestSuite_Verbose` controls logging
-- `LOG_VERBOSE(fmt, ...)` macro for conditional logging
-- `TEST_EXPECT___________MAYBE` only logs in verbose mode (single test run or failed test rerun)
-- Failure details are always logged immediately
-- Failed tests are automatically rerun with verbose logging
-- Default: non-verbose, rerun failed tests with verbose
-- Important: Reset `TestSuite_Verbose = false` after verbose rerun completes
-
-## File Structure
-
-- `test_suite.c` - Main orchestration, verbose/rerun logic
-- `test_input_machine.c` - Processes test actions (key presses, config changes)
-- `test_output_machine.c` - Validates USB reports against expectations
-- `tests/*.c` - Individual test modules
-
-## Test Actions
-
-Defined in `test_actions.h`:
-- `TEST_PRESS______(key_id)` / `TEST_RELEASE__U(key_id)` - Simulate key events
-- `TEST_DELAY__(ms)` - Wait for processing
-- `TEST_EXPECT__________(shortcuts)` - Validate USB report (OutputMachine)
-- `TEST_EXPECT___________MAYBE(shortcuts)` - Optional expectation
-- `TEST_CHECK_NOW(shortcuts)` - Immediate validation (InputMachine)
-- `TEST_SET_ACTION(key_id, shortcut)` - Configure key action
-- `TEST_SET_MACRO(key_id, macro_text)` - Configure inline macro
-- `TEST_SET_CONFIG(config_text)` - Run set command
-- `TEST_SET_LAYER_HOLD(key_id, layer_id)` - Configure layer hold
-- `TEST_SET_LAYER_ACTION(layer_id, key_id, shortcut)` - Configure layer action
-- `TEST_SET_SECONDARY_ROLE(key_id, scancode, role)` - Configure secondary role
+- Be explicit about all intermediate USB report states.
+- A keystroke with modifiers produces: modifier alone, then modifier+key, then modifier alone (on release), then empty.
+- `tapKey` produces: key down, then key up (empty).
+- `holdKey sLA-x` produces: `LA` (mods first), then `LA-x`, then on key release `LA` (sticky stays if `Stick_Smart` + layer held), then `""` once layer is released.
+- Reserve `TEST_EXPECT___________MAYBE` for genuinely timing-dependent reports.
 
 ## Adding New Test Actions
 
-1. Add macro in `test_actions.h`
-2. Add enum value in `test_action_type_t`
-3. Add any needed fields to `test_action_t` struct
-4. Handle in `test_input_machine.c` switch statement
-5. Add to skip list in `test_output_machine.c` if it's an input-only action
+1. Add the macro in `test_actions.h`.
+2. Add an enum value in `test_action_type_t`.
+3. If new fields are needed, add them to `test_action_t`.
+4. Handle the new case in `test_input_machine.c`'s switch.
+5. Add it to the skip list in `test_output_machine.c` if it is an input-only action.
+6. Document it in the table above.
+
+## File Layout
+
+- `test_suite.c` — orchestration, verbose/rerun logic
+- `test_input_machine.c` — applies test actions (presses, config changes)
+- `test_output_machine.c` — validates USB reports against expectations
+- `tests/*.c` — individual test modules
+
+## Logging
+
+- `TestSuite_Verbose` controls logging.
+- `LOG_VERBOSE(fmt, ...)` is conditional.
+- `TEST_EXPECT___________MAYBE` only logs in verbose mode.
+- Failures are always logged immediately; failed tests are auto-rerun with verbose enabled.
+- Reset `TestSuite_Verbose = false` after a verbose rerun.

--- a/right/src/test_suite/CMakeLists.txt
+++ b/right/src/test_suite/CMakeLists.txt
@@ -16,4 +16,5 @@ target_sources(${PROJECT_NAME} PRIVATE
     tests/test_doubletap.c
     tests/test_current_macro_key_is_active.c
     tests/test_parser_benevolence.c
+    tests/test_sticky.c
 )

--- a/right/src/test_suite/test_actions.h
+++ b/right/src/test_suite/test_actions.h
@@ -33,9 +33,13 @@
 #define TEST_SET_ACTION(key_id, shortcut) \
     { .type = TestAction_SetAction, .keyId = (key_id), .shortcutStr = (shortcut) }
 
-// SetMacro: assign an inline macro to a key
+// SetMacro: assign an inline macro to a key on the base layer
 #define TEST_SET_MACRO(key_id, macro_text) \
     { .type = TestAction_SetMacro, .keyId = (key_id), .macroText = (macro_text) }
+
+// SetLayerMacro: assign an inline macro to a key on a specific layer
+#define TEST_SET_LAYER_MACRO(layer_id, key_id, macro_text) \
+    { .type = TestAction_SetMacro, .keyId = (key_id), .layerId = (layer_id), .macroText = (macro_text) }
 
 // SetLayerHold: assign a layer hold action to a key
 // SwitchLayerMode_Hold = 2

--- a/right/src/test_suite/test_input_machine.c
+++ b/right/src/test_suite/test_input_machine.c
@@ -229,8 +229,8 @@ void InputMachine_Tick(void) {
                     }
                 };
 
-                CurrentKeymap[LayerId_Base][slotId][keyId].action = keyAction;
-                LOG_VERBOSE("[TEST] > SetMacro [%s] = '%s'\n", action->keyId, action->macroText);
+                CurrentKeymap[action->layerId][slotId][keyId].action = keyAction;
+                LOG_VERBOSE("[TEST] > SetMacro layer %d [%s] = '%s'\n", action->layerId, action->keyId, action->macroText);
                 InputMachine_ActionIndex++;
                 break;
             }

--- a/right/src/test_suite/tests/test_sticky.c
+++ b/right/src/test_suite/tests/test_sticky.c
@@ -1,0 +1,87 @@
+#include "tests.h"
+#include "layer.h"
+
+// Same scenario but with a plain `LA-tab` keystroke binding instead of a macro.
+// Under Stick_Smart, the Alt modifier is sticky for Alt+Tab when a layer is held.
+static const test_action_t test_sticky_alt_tab_two_taps[] = {
+    TEST_SET_LAYER_HOLD("n", LayerId_Mod),
+    TEST_SET_LAYER_ACTION(LayerId_Mod, "i", "LA-tab"),
+
+    // Hold the mod layer
+    TEST_PRESS______("n"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    // First tap: Alt down, then Alt+Tab, then Tab releases but Alt sticks
+    TEST_PRESS______("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("LA"),
+    TEST_EXPECT__________("LA-tab"),
+    TEST_RELEASE__U("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("LA"),
+
+    // Second tap: Alt must NOT have released — go straight back to Alt+Tab.
+    TEST_PRESS______("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("LA-tab"),
+    TEST_RELEASE__U("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("LA"),
+
+    // Release layer key: sticky Alt clears on layer change
+    TEST_RELEASE__U("n"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    TEST_END()
+};
+
+// Tap a layer-mapped `holdKey sLA-tab` macro twice while the layer is held.
+// Alt must remain held between the two Tabs (sticky behavior under Stick_Smart
+// keeps the modifier active as long as the layer is held).
+static const test_action_t test_sticky_holdkey_two_taps[] = {
+    TEST_SET_LAYER_HOLD("n", LayerId_Mod),
+    TEST_SET_LAYER_MACRO(LayerId_Mod, "i", "holdKey sLA-tab\n"),
+
+    // Hold the mod layer
+    TEST_PRESS______("n"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    // First tap of the macro: Alt down, then Alt+Tab, then Tab releases but Alt sticks
+    TEST_PRESS______("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("LA"),
+    TEST_EXPECT__________("LA-tab"),
+    TEST_RELEASE__U("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("LA"),
+
+    // Second tap: Alt must NOT have released — go straight back to Alt+Tab.
+    // No empty report between the two taps.
+    TEST_PRESS______("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("LA-tab"),
+    TEST_RELEASE__U("i"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________("LA"),
+
+    // Release layer key: sticky Alt clears on layer change
+    TEST_RELEASE__U("n"),
+    TEST_DELAY__(50),
+    TEST_EXPECT__________(""),
+
+    TEST_END()
+};
+
+static const test_t sticky_tests[] = {
+    { .name = "sticky_alt_tab_two_taps", .actions = test_sticky_alt_tab_two_taps },
+    { .name = "sticky_holdkey_two_taps", .actions = test_sticky_holdkey_two_taps },
+};
+
+const test_module_t TestModule_Sticky = {
+    .name = "Sticky",
+    .tests = sticky_tests,
+    .testCount = sizeof(sticky_tests) / sizeof(sticky_tests[0])
+};

--- a/right/src/test_suite/tests/tests.c
+++ b/right/src/test_suite/tests/tests.c
@@ -15,6 +15,7 @@ const test_module_t * const AllTestModules[] = {
     &TestModule_Doubletap,
     &TestModule_CurrentMacroKeyIsActive,
     &TestModule_ParserBenevolence,
+    &TestModule_Sticky,
 };
 
 const uint16_t AllTestModulesCount = sizeof(AllTestModules) / sizeof(AllTestModules[0]);

--- a/right/src/test_suite/tests/tests.h
+++ b/right/src/test_suite/tests/tests.h
@@ -29,5 +29,6 @@ extern const test_module_t TestModule_IfShortcutGesture;
 extern const test_module_t TestModule_Doubletap;
 extern const test_module_t TestModule_CurrentMacroKeyIsActive;
 extern const test_module_t TestModule_ParserBenevolence;
+extern const test_module_t TestModule_Sticky;
 
 #endif

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -268,6 +268,20 @@ static void resetStickyMods(key_action_cached_t *cachedAction)
     EventVector_Set(EventVector_SendUsbReports);
 }
 
+void StickyMods_ResetLater(key_action_cached_t *cachedAction)
+{
+    static uint8_t negativeMods;
+
+    if (cachedAction != NULL) {
+        negativeMods = cachedAction->modifierLayerMask;
+    } else {
+        StickyModifiers = 0;
+        StickyModifiersNegative = negativeMods;
+        EventVector_Set(EventVector_SendUsbReports);
+    }
+}
+
+
 static void activateStickyMods(key_state_t *keyState, key_action_cached_t *action)
 {
     StickyModifiersNegative = action->modifierLayerMask;
@@ -510,13 +524,13 @@ void ApplyKeyAction(key_state_t *keyState, key_action_cached_t *cachedAction, ke
             break;
         case KeyActionType_PlayMacro:
             if (KeyState_ActivatedNow(keyState)) {
-                resetStickyMods(cachedAction);
+                StickyMods_ResetLater(cachedAction);
                 Macros_StartMacro(action->playMacro.macroId, keyState, action->playMacro.offset, keyState->activationId, 255, true, NULL);
             }
             break;
         case KeyActionType_InlineMacro:
             if (KeyState_ActivatedNow(keyState)) {
-                resetStickyMods(cachedAction);
+                StickyMods_ResetLater(cachedAction);
                 Macros_StartInlineMacro(action->inlineMacro.text, keyState, keyState->activationId);
             }
             break;

--- a/right/src/usb_report_updater.h
+++ b/right/src/usb_report_updater.h
@@ -62,6 +62,7 @@
     void ActivateKey(key_state_t *keyState, bool debounce);
     void ActivateStickyMods(key_state_t *keyState, uint8_t mods);
     void ApplyKeyAction(key_state_t *keyState, key_action_cached_t *cachedAction, key_action_t *actionBase, usb_keyboard_reports_t* reports);
+    void StickyMods_ResetLater(key_action_cached_t *cachedAction);
 
     void UsbReportUpdater_ResetKeyboardReports(usb_keyboard_reports_t* reports);
     void RecordKeyTiming_ReportKeystroke(key_state_t *keyState, bool active, uint32_t pressTime, uint32_t activationTime);


### PR DESCRIPTION
Reported in https://forum.uhk.io/t/alt-tab-on-mod-layer-does-kill-other-mod-keys/2892/10

Steps to reproduce:
- map `holdKey sLA-tab` macro into some layer.
- (optionally) `set keystrokeDelay 200` and open keyboardchecker
- tap it twice
- Actual: alt is released between the two tab taps
- Expected: alt is not released.

Changelog:
- Fix sticky key integration with macros - macros would break sticky key sequences by a brief release before first macro command is executed.