### PR TITLE
Fix #1090: don't drop USB reports on transient hub stalls

### DIFF
--- a/device/src/messenger.c
+++ b/device/src/messenger.c
@@ -241,7 +241,7 @@ static void processSyncablePropertyDongle(device_id_t src, const uint8_t* data, 
 
 #if DEVICE_IS_UHK_DONGLE
     uint8_t retryCounter = 0;
-    while (ShouldResendReport(ret == 0, &retryCounter)) {
+    while (IsWithinResendWindow(ret == 0, &retryCounter)) {
         k_sem_take(&dongleUsbSem, K_MSEC(128));
         ret = sendDongleReport(propertyId, message);
     }

--- a/right/src/debug.c
+++ b/right/src/debug.c
@@ -1,8 +1,8 @@
 #include <string.h>
 #include "debug.h"
+#include "logger.h"
 
 #ifdef __ZEPHYR__
-#include "logger.h"
 #include "keyboard/oled/screens/screen_manager.h"
 #include <zephyr/kernel.h>
 #else

--- a/right/src/event_scheduler.c
+++ b/right/src/event_scheduler.c
@@ -246,6 +246,9 @@ static void processEvt(event_scheduler_event_t evt)
             BtConn_KickHid();
 #endif
             break;
+        case EventSchedulerEvent_UsbResend:
+            EventVector_Set(EventVector_ResendUsbReports);
+            break;
         default:
             return;
     }

--- a/right/src/event_scheduler.h
+++ b/right/src/event_scheduler.h
@@ -49,6 +49,7 @@
         EventSchedulerEvent_UnselectHostConnection,
         EventSchedulerEvent_OneShotTimeout,
         EventSchedulerEvent_KickHid,
+        EventSchedulerEvent_UsbResend,
         EventSchedulerEvent_Count
     } event_scheduler_event_t;
 

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -896,8 +896,10 @@ static bool mouseNeedsResending = false;
 // attempts.
 #define USB_RESEND_DELAY_MS 4
 
-// Try resending a report for 512ms. Give up if it doesn't succeed by then.
-bool ShouldResendReport(bool statusOk, uint8_t* counter) {
+// Tracks a 128ms retry window per counter. Returns true while a failed call
+// is still within the window; returns false (and resets the counter) on
+// success or after the window expires.
+bool IsWithinResendWindow(bool statusOk, uint8_t* counter) {
 
     if (statusOk) {
         *counter = 0;
@@ -991,7 +993,7 @@ static void sendActiveReports(bool resending) {
                     // causing the OS to keep auto-repeating until the next key press).
                     // The next merge cycle will rebuild the active buffer from the
                     // latest cached state, and CheckReportReady will retry the send.
-                    if (ShouldResendReport(false, &keyboardRetries)) {
+                    if (IsWithinResendWindow(false, &keyboardRetries)) {
                         reportRetry(ret);
                     } else {
                         handleFail(ret);
@@ -1006,7 +1008,7 @@ static void sendActiveReports(bool resending) {
                     EventScheduler_Schedule(Timer_GetCurrentTime() + USB_RESEND_DELAY_MS,
                                             EventSchedulerEvent_UsbResend, "usb-resend");
                 } else {
-                    ShouldResendReport(true, &keyboardRetries); // reset retry counter
+                    IsWithinResendWindow(true, &keyboardRetries); // reset retry counter
                     keyboardNeedsResending = false;
                     switchActiveKeyboardReport();
                 }
@@ -1023,7 +1025,7 @@ static void sendActiveReports(bool resending) {
         ret = Hid_SendControlsReport(ActiveControlsReport);
         if (ret != 0) {
             // See keyboard send path comment.
-            if (ShouldResendReport(false, &controlsRetries)) {
+            if (IsWithinResendWindow(false, &controlsRetries)) {
                 reportRetry(ret);
             } else {
                 handleFail(ret);
@@ -1033,7 +1035,7 @@ static void sendActiveReports(bool resending) {
             EventScheduler_Schedule(Timer_GetCurrentTime() + USB_RESEND_DELAY_MS,
                                     EventSchedulerEvent_UsbResend, "usb-resend");
         } else {
-            ShouldResendReport(true, &controlsRetries);
+            IsWithinResendWindow(true, &controlsRetries);
             controlsNeedsResending = false;
             switchActiveControlsReport();
         }
@@ -1051,7 +1053,7 @@ static void sendActiveReports(bool resending) {
         ret = Hid_SendMouseReport(ActiveMouseReport);
         if (ret != 0) {
             // See keyboard send path comment.
-            if (ShouldResendReport(false, &mouseRetries)) {
+            if (IsWithinResendWindow(false, &mouseRetries)) {
                 reportRetry(ret);
             } else {
                 handleFail(ret);
@@ -1062,7 +1064,7 @@ static void sendActiveReports(bool resending) {
             EventScheduler_Schedule(Timer_GetCurrentTime() + USB_RESEND_DELAY_MS,
                                     EventSchedulerEvent_UsbResend, "usb-resend");
         } else {
-            ShouldResendReport(true, &mouseRetries);
+            IsWithinResendWindow(true, &mouseRetries);
             mouseNeedsResending = false;
             switchActiveMouseReport();
         }

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -974,17 +974,25 @@ static void sendActiveReports(bool resending) {
                 //The semaphore has to be set before the call. Assume what happens if a bus reset happens asynchronously here. (Deadlock.)
                 UsbReportUpdateSemaphore |= UsbReportUpdate_Keyboard;
                 ret = Hid_SendKeyboardReport(ActiveKeyboardReport);
-                if (ShouldResendReport(ret == 0, &keyboardRetries)) {
-                    reportRetry(ret);
+                if (ret != 0) {
+                    // Send failed (likely a transient USB hub stall or busy endpoint).
+                    // Do NOT switch the buffer: that would lose this report's state and
+                    // make it impossible to recover (e.g. release reports get dropped,
+                    // causing the OS to keep auto-repeating until the next key press).
+                    // The next merge cycle will rebuild the active buffer from the
+                    // latest cached state, and CheckReportReady will retry the send.
+                    if (ShouldResendReport(false, &keyboardRetries)) {
+                        reportRetry(ret);
+                    } else {
+                        handleFail(ret);
+                    }
                     //This is *not* asynchronously safe as long as multiple reports of different type can be sent at the same time.
                     //TODO: consider making it atomic, or lowering semaphore reset delay
                     keyboardNeedsResending = true;
                     UsbReportUpdateSemaphore &= ~UsbReportUpdate_Keyboard;
                     EventVector_Set(EventVector_ResendUsbReports);
                 } else {
-                    if (ret != 0) {
-                        handleFail(ret);
-                    }
+                    ShouldResendReport(true, &keyboardRetries); // reset retry counter
                     keyboardNeedsResending = false;
                     switchActiveKeyboardReport();
                 }
@@ -999,15 +1007,18 @@ static void sendActiveReports(bool resending) {
     if (ControlsReport_HasChanges(controlsReports) && (!resending || controlsNeedsResending)) {
         UsbReportUpdateSemaphore |= UsbReportUpdate_Controls;
         ret = Hid_SendControlsReport(ActiveControlsReport);
-        if (ShouldResendReport(ret == 0, &controlsRetries)) {
-            reportRetry(ret);
+        if (ret != 0) {
+            // See keyboard send path comment.
+            if (ShouldResendReport(false, &controlsRetries)) {
+                reportRetry(ret);
+            } else {
+                handleFail(ret);
+            }
             controlsNeedsResending = true;
             UsbReportUpdateSemaphore &= ~UsbReportUpdate_Controls;
             EventVector_Set(EventVector_ResendUsbReports);
         } else {
-            if (ret != 0) {
-                handleFail(ret);
-            }
+            ShouldResendReport(true, &controlsRetries);
             controlsNeedsResending = false;
             switchActiveControlsReport();
         }
@@ -1023,16 +1034,19 @@ static void sendActiveReports(bool resending) {
 
         UsbReportUpdateSemaphore |= UsbReportUpdate_Mouse;
         ret = Hid_SendMouseReport(ActiveMouseReport);
-        if (ShouldResendReport(ret == 0, &mouseRetries)) {
-            reportRetry(ret);
+        if (ret != 0) {
+            // See keyboard send path comment.
+            if (ShouldResendReport(false, &mouseRetries)) {
+                reportRetry(ret);
+            } else {
+                handleFail(ret);
+                clearMouseMovement(); // Don't make cursor jump if we have connection issues.
+            }
             mouseNeedsResending = true;
             UsbReportUpdateSemaphore &= ~UsbReportUpdate_Mouse;
             EventVector_Set(EventVector_ResendUsbReports);
         } else {
-            if (ret != 0) {
-                handleFail(ret);
-                clearMouseMovement(); // Don't make cursor jump if we have connection issues.
-            }
+            ShouldResendReport(true, &mouseRetries);
             mouseNeedsResending = false;
             switchActiveMouseReport();
         }

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -886,6 +886,16 @@ static bool controlsNeedsResending = false;
 static uint8_t mouseRetries = 0;
 static bool mouseNeedsResending = false;
 
+// Delay between consecutive resend attempts when a Hid_Send*Report() call
+// fails (e.g. because of a transient USB hub stall).  Without this throttle
+// the resend would re-fire on every main-loop iteration (sub-100us cadence),
+// which saturates the hub upstream and disturbs other HID devices on the
+// same hub.  4 ms is short enough to feel responsive (a single key event
+// missing the 1 ms USB SOF four times in a row is still well under the
+// keystroke-perception threshold) and long enough to free the bus between
+// attempts.
+#define USB_RESEND_DELAY_MS 4
+
 // Try resending a report for 512ms. Give up if it doesn't succeed by then.
 bool ShouldResendReport(bool statusOk, uint8_t* counter) {
 
@@ -990,7 +1000,11 @@ static void sendActiveReports(bool resending) {
                     //TODO: consider making it atomic, or lowering semaphore reset delay
                     keyboardNeedsResending = true;
                     UsbReportUpdateSemaphore &= ~UsbReportUpdate_Keyboard;
-                    EventVector_Set(EventVector_ResendUsbReports);
+                    // Throttle the retry: schedule it instead of re-arming the flag
+                    // immediately. Re-arming immediately would call sendActiveReports()
+                    // every main-loop iteration and saturate the hub upstream.
+                    EventScheduler_Schedule(Timer_GetCurrentTime() + USB_RESEND_DELAY_MS,
+                                            EventSchedulerEvent_UsbResend, "usb-resend");
                 } else {
                     ShouldResendReport(true, &keyboardRetries); // reset retry counter
                     keyboardNeedsResending = false;
@@ -1016,7 +1030,8 @@ static void sendActiveReports(bool resending) {
             }
             controlsNeedsResending = true;
             UsbReportUpdateSemaphore &= ~UsbReportUpdate_Controls;
-            EventVector_Set(EventVector_ResendUsbReports);
+            EventScheduler_Schedule(Timer_GetCurrentTime() + USB_RESEND_DELAY_MS,
+                                    EventSchedulerEvent_UsbResend, "usb-resend");
         } else {
             ShouldResendReport(true, &controlsRetries);
             controlsNeedsResending = false;
@@ -1044,7 +1059,8 @@ static void sendActiveReports(bool resending) {
             }
             mouseNeedsResending = true;
             UsbReportUpdateSemaphore &= ~UsbReportUpdate_Mouse;
-            EventVector_Set(EventVector_ResendUsbReports);
+            EventScheduler_Schedule(Timer_GetCurrentTime() + USB_RESEND_DELAY_MS,
+                                    EventSchedulerEvent_UsbResend, "usb-resend");
         } else {
             ShouldResendReport(true, &mouseRetries);
             mouseNeedsResending = false;

--- a/right/src/usb_report_updater.h
+++ b/right/src/usb_report_updater.h
@@ -69,6 +69,6 @@
     void RecordKeyTiming_ReportKeystroke(key_state_t *keyState, bool active, uint32_t pressTime, uint32_t activationTime);
 
     hid_keyboard_report_t* GetInactiveKeyboardReport(void);
-    bool ShouldResendReport(bool statusOk, uint8_t* counter);
+    bool IsWithinResendWindow(bool statusOk, uint8_t* counter);
 
 #endif


### PR DESCRIPTION
## Summary

Fixes #1090. Under transient USB hub stalls, the previous `Hid_Send*Report()` failure path silently committed unsent reports as the "previously sent" buffer in the double-buffer scheme, breaking the host's view of key state. User-visible symptoms:

- **Stuck-key auto-repeat** — a dropped release report leaves the key in the host's pressed set until the next press happens to differ.
- **Dropped short presses** — same mechanism, with a press dropped before its release lands.
- **Swapped consecutive bigrams** (e.g. typing `se` produced `es`) — both keys merged into a single multi-key report whose slot order matches matrix order, not press order.
- **Disturbance to other HID devices on the same hub** during sustained UHK input, because the unrate-limited retry path saturated the upstream IN-token queue.

## Changes

Three commits for the fix plus one independent UHK60 build prerequisite:

1. `9616cb4` **Preserve report state on USB send failure** — branch on `ret != 0`; never call `switchActive*Report()` when the send fails. The next merge cycle rebuilds the active buffer from the latest cached state and `CheckReportReady` retries once the link recovers.
2. `a8aa0d4` **Throttle USB resend retries via EventScheduler** — replace the synchronous `EventVector_Set(EventVector_ResendUsbReports)` with `EventScheduler_Schedule(now + 4 ms, EventSchedulerEvent_UsbResend, ...)`. Keyboard / controls / mouse retry wakeups collapse into a single ~250 Hz upper bound across all three paths, freeing the hub upstream queue between attempts.
3. `373cf4f` **Rename `ShouldResendReport` → `IsWithinResendWindow`** — the helper now only manages the per-counter retry window (consumed for log routing in `usb_report_updater.c` and as the resend-loop predicate in `device/src/messenger.c`); the new name reflects that role.
4. `8b36cd3` **Move `logger.h` include in `debug.c`** — independent of #1090 but bundled as a prerequisite UHK60 build fix: `Debug_RecordBleSendResult()` references `LogU()` in a dead-code branch and GCC 15 promotes implicit-declaration warnings to errors.

Applied identically to the keyboard, controls, and mouse send paths. New `EventSchedulerEvent_UsbResend` added to `right/src/event_scheduler.{h,c}`.

## Detailed design notes

Full root-cause analysis, per-symptom mechanism walkthrough, and pre/post-fix mermaid sequence diagrams are kept on a separate docs branch to keep this PR focused on code:

- https://github.com/semnil/firmware/blob/docs/issue-1090-usb-resend-state/doc-dev/other/issue-1090-usb-resend-state.md
