### PR TITLE
Use exponential backoff for USB report retry throttle

### DIFF
--- a/device/src/messenger.c
+++ b/device/src/messenger.c
@@ -242,6 +242,8 @@ static void processSyncablePropertyDongle(device_id_t src, const uint8_t* data, 
 #if DEVICE_IS_UHK_DONGLE
     uint8_t retryCounter = 0;
     while (ShouldResendReport(ret == 0, &retryCounter)) {
+        uint16_t delay = GetResendThrottleDelay(retryCounter);
+        k_sleep(K_MSEC(delay));
         k_sem_take(&dongleUsbSem, K_MSEC(128));
         ret = sendDongleReport(propertyId, message);
     }

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -890,9 +890,14 @@ static bool controlsNeedsResending = false;
 static uint8_t mouseRetries = 0;
 static bool mouseNeedsResending = false;
 
-// Try resending a report for maxDelay ms. Give up if it doesn't succeed by then.
-// Once given up, stay given up until some statusOk is seen, so a full queue doesn't
-// freeze for queueLength * maxDelay on replay.
+// Counts retry attempts and decides whether to keep trying. On success, resets
+// the counter and clears the give-up latch. On failure, increments the counter
+// and gives up once MAX_RETRIES is exceeded. Once given up, stay given up until
+// some statusOk is seen, so a full queue doesn't replay one report at a time.
+//
+// Pair with GetResendThrottleDelay() to compute the wait before the next retry.
+// MAX_RETRIES is sized so that the cumulative wait from GetResendThrottleDelay()
+// is ~1024 ms (1+2+4+8+16+32 + 30*32 = 1023).
 bool ShouldResendReport(bool statusOk, uint8_t* counter) {
     static bool givenUp = false;
 
@@ -906,20 +911,30 @@ bool ShouldResendReport(bool statusOk, uint8_t* counter) {
         return false;
     }
 
-    const uint16_t maxDelay = 1024; //ms
-    const uint8_t granularity = 16; //ms
-    uint8_t minimizedTime = Timer_GetCurrentTime() / granularity;
+    const uint8_t MAX_RETRIES = 36;
 
-    if (*counter == 0) {
-        *counter = minimizedTime;
-        return true;
-    } else if ((uint8_t)(minimizedTime - *counter) < (maxDelay / granularity)) {
-        return true;
-    } else {
+    (*counter)++;
+    if (*counter > MAX_RETRIES) {
         *counter = 0;
         givenUp = true;
         return false;
     }
+    return true;
+}
+
+// Exponential backoff for retry throttling: 1, 2, 4, 8, 16, 32 ms, then
+// capped at 32 ms. Keeps initial retries snappy (mouse keys don't stutter on
+// transient USB-busy) while still backing off on sustained failure.
+uint16_t GetResendThrottleDelay(uint8_t counter) {
+    if (counter == 0) {
+        return 0;
+    }
+    const uint8_t MAX_SHIFT = 5; // 1 << 5 == 32 ms
+    uint8_t shift = counter - 1;
+    if (shift > MAX_SHIFT) {
+        shift = MAX_SHIFT;
+    }
+    return (uint16_t)1 << shift;
 }
 
 static void clearMouseMovement(void) {
@@ -995,7 +1010,7 @@ static void sendActiveReports(bool resending) {
                     //This is *not* asynchronously safe as long as multiple reports of different type can be sent at the same time.
                     //TODO: consider making it atomic, or lowering semaphore reset delay
                     keyboardNeedsResending = true;
-                    retryThrottleTime = Timer_GetCurrentTime() + USB_RESEND_DELAY_MS;
+                    retryThrottleTime = Timer_GetCurrentTime() + GetResendThrottleDelay(keyboardRetries);
                     UsbReportUpdateSemaphore &= ~UsbReportUpdate_Keyboard;
                     EventVector_Set(EventVector_ResendUsbReports);
                 } else {
@@ -1022,7 +1037,7 @@ static void sendActiveReports(bool resending) {
         if (ShouldResendReport(ret == 0, &controlsRetries)) {
             reportRetry(ret);
             controlsNeedsResending = true;
-            retryThrottleTime = Timer_GetCurrentTime() + USB_RESEND_DELAY_MS;
+            retryThrottleTime = Timer_GetCurrentTime() + GetResendThrottleDelay(controlsRetries);
             UsbReportUpdateSemaphore &= ~UsbReportUpdate_Controls;
             EventVector_Set(EventVector_ResendUsbReports);
         } else {
@@ -1048,7 +1063,7 @@ static void sendActiveReports(bool resending) {
         if (ShouldResendReport(ret == 0, &mouseRetries)) {
             reportRetry(ret);
             mouseNeedsResending = true;
-            retryThrottleTime = Timer_GetCurrentTime() + USB_RESEND_DELAY_MS;
+            retryThrottleTime = Timer_GetCurrentTime() + GetResendThrottleDelay(mouseRetries);
             UsbReportUpdateSemaphore &= ~UsbReportUpdate_Mouse;
             EventVector_Set(EventVector_ResendUsbReports);
         } else {

--- a/right/src/usb_report_updater.h
+++ b/right/src/usb_report_updater.h
@@ -70,5 +70,6 @@
 
     hid_keyboard_report_t* GetInactiveKeyboardReport(void);
     bool ShouldResendReport(bool statusOk, uint8_t* counter);
+    uint16_t GetResendThrottleDelay(uint8_t counter);
 
 #endif


### PR DESCRIPTION
The previous fixed 10 ms minimum retry delay caused mouse-key stutter when USB reported "busy" rather than a hard error: every busy reply pushed the next attempt out by a full 10 ms.

Refactor ShouldResendReport into a simple retry counter plus a new GetResendThrottleDelay() that returns the per-attempt delay. The schedule is 1, 2, 4, 8, 16, 32 ms and then capped at 32 ms; MAX_RETRIES is sized so the cumulative wait stays at the original ~1024 ms budget.

Also switches the synchronous dongle resend loop in messenger.c (which already called ShouldResendReport) to the new counter semantics implicitly.

Changelog:
- make usb retries back off exponentially.