### PR TITLE
fix: enable I2C glitch filter (Width=15) to reject EMI above 2 MHz

### DIFF
--- a/right/src/init_peripherals.c
+++ b/right/src/init_peripherals.c
@@ -123,6 +123,11 @@ static void initI2cBus(i2c_bus_t *i2cBus)
     i2c_master_config_t masterConfig;
     I2C_MasterGetDefaultConfig(&masterConfig);
     masterConfig.baudRate_Bps = i2cBus == &i2cMainBus ? I2cMainBusRequestedBaudRateBps : I2C_EEPROM_BUS_BAUD_RATE;
+    // Glitch filter is only enabled on the main bus, where the inter-half cable
+    // is exposed to external EMI. The EEPROM bus runs at 1 MHz on short on-PCB
+    // traces, so the filter is left disabled there to keep the SCL high time
+    // within Fast-mode Plus margins.
+    masterConfig.glitchFilterWidth = i2cBus == &i2cMainBus ? 15U : 0U;
     uint32_t sourceClock = CLOCK_GetFreq(i2cBus->clockSrc);
     uint32_t baudrate = I2C_MasterInit(i2cBus->baseAddr, &masterConfig, sourceClock);
 


### PR DESCRIPTION
Set the K22 glitch filter to its maximum value on the main I2C bus only,
which runs to the left half over an external cable and is exposed to
external EMI sources. At the 60 MHz bus clock, FLT=15 absorbs glitches
up to 15 / 60 MHz = 250 ns, i.e. continuous EMI at frequencies of
1 / (2 * 250 ns) = 2 MHz or higher.

The EEPROM bus (I2C1) keeps the filter disabled. It runs at 1 MHz
(Fast-mode Plus) on short on-PCB traces only, where there is no EMI
exposure and 250 ns of timing margin cannot be spared from t_HIGH.