### PR TITLE
Fix adc_read freezes.

### DIFF
--- a/patches/hal_nordic/0001-nrfx_saadc-avoid-lost-STARTED-event-in-simple-non-bl.patch
+++ b/patches/hal_nordic/0001-nrfx_saadc-avoid-lost-STARTED-event-in-simple-non-bl.patch
@@ -1,0 +1,63 @@
+From 4d7612dfa889d0f1ddf037dec8676d62778a4f78 Mon Sep 17 00:00:00 2001
+From: Karel Tucek <kareltucek@centrum.cz>
+Date: Wed, 10 Jun 2026 12:52:04 +0200
+Subject: [PATCH] nrfx_saadc: avoid lost STARTED event in simple non-blocking
+ mode
+
+In simple non-blocking mode, nrfx_saadc_mode_trigger() enables the SAADC
+and only afterwards advances m_cb.saadc_state to SIMPLE_MODE_SAMPLE.
+Enabling the peripheral (and the subsequent buffer latch) can raise a
+STARTED event before that state update. If the SAADC interrupt is serviced
+in this window, saadc_event_started_handle() falls through its default
+branch and the SAMPLE task is never triggered. No END event is generated,
+the conversion never completes, and a blocking caller (e.g. the Zephyr
+adc_read() driver) waits forever.
+
+Mask the SAADC interrupt at the NVIC while enabling the SAADC, updating the
+state and latching the buffer, then re-enable it. A STARTED raised during
+setup stays pending and is serviced once the state is SIMPLE_MODE_SAMPLE and
+the buffer is programmed, so the SAMPLE task is correctly triggered. The
+mask is applied at the NVIC rather than the peripheral INTEN because the
+enable path can leave INTEN re-asserted within the critical window.
+
+Signed-off-by: Karel Tucek <kareltucek@centrum.cz>
+---
+ nrfx/drivers/src/nrfx_saadc.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/nrfx/drivers/src/nrfx_saadc.c b/nrfx/drivers/src/nrfx_saadc.c
+index f44e5f2..d5942ed 100644
+--- a/nrfx/drivers/src/nrfx_saadc.c
++++ b/nrfx/drivers/src/nrfx_saadc.c
+@@ -679,6 +679,20 @@ int nrfx_saadc_mode_trigger(void)
+     {
+         case NRF_SAADC_STATE_SIMPLE_MODE:
+         {
++            if (m_cb.event_handler)
++            {
++                // Defer servicing of the SAADC interrupt until the sampling state
++                // and the result buffer are both set up below. Enabling the SAADC
++                // (and the buffer latch) can raise STARTED before m_cb.saadc_state
++                // is advanced to SIMPLE_MODE_SAMPLE; if the SAADC ISR runs in that
++                // window, saadc_event_started_handle() takes its default branch and
++                // the SAMPLE task is never triggered, so no END event arrives and
++                // the conversion never completes. Mask at the NVIC (not the
++                // peripheral INTEN, which the enable path can clobber) to hold any
++                // STARTED pending until setup is finished.
++                NRFX_IRQ_DISABLE(nrfx_get_irq_number(NRF_SAADC));
++            }
++
+             nrfy_saadc_enable(NRF_SAADC);
+             // When in simple blocking or non-blocking mode, buffer size is equal to activated channel count.
+             // Single SAMPLE task is enough to obtain one sample on each activated channel.
+@@ -688,6 +702,7 @@ int nrfx_saadc_mode_trigger(void)
+             {
+                 m_cb.saadc_state = NRF_SAADC_STATE_SIMPLE_MODE_SAMPLE;
+                 nrfy_saadc_buffer_set(NRF_SAADC, &m_cb.buffer_primary, true, false);
++                NRFX_IRQ_ENABLE(nrfx_get_irq_number(NRF_SAADC));
+             }
+             else
+             {
+-- 
+2.51.0
+


### PR DESCRIPTION
Changelog:

-  Fix: upstream bug that made battery-included uhk80 freeze every few hours of operation.
