### PR TITLE
Fix macro scheduler lockup.

### DIFF
--- a/right/src/macros/core.c
+++ b/right/src/macros/core.c
@@ -978,7 +978,7 @@ static void recalculateSleepingMods()
         }
     }
     EventVector_SetValue(EventVector_MacroEnginePostponing, applicableState.someonePostponing);
-    EventVector_SetValue(EventVector_MacroEngine, applicableState.someoneAwake);
+    EventVector_SetValue(EventVector_MacroEngine, applicableState.someoneAwake || SchedulerPostponing);
     EventVector_SetValue(EventVector_MacroReportsUsed, applicableState.reportsUsed);
     Macros_WakeMeOnOneShot = applicableState.someOneShot;
     SuppressMods = applicableState.modifierSuppressMods;


### PR DESCRIPTION
This would happen when macro end aligns with the macro quota running out.

This is reproducible with this config by flashing
[UserConfiguration_macro_deadlock.json](https://github.com/user-attachments/files/29247669/UserConfiguration_macro_deadlock.json) onto an uhk 80 and then repeatedly tapping backspace. The keyboard freezes in the Init keymap.

Changelog:
- Fix: macro scheduler bug that would make uhk lock up on macros of a certain length.

