### PR TITLE
ci: archive builds to Backblaze B2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,16 +90,17 @@ jobs:
           retention-days: 90
 
       - name: Run build-archiver
-        uses: UltimateHackingKeyboard/build-archiver@v0.0.5
-        if: github.repository == 'UltimateHackingKeyboard/firmware' && github.event.pull_request.head.repo.fork == false
+        uses: UltimateHackingKeyboard/build-archiver@v0.0.9
+        if: github.repository == 'UltimateHackingKeyboard/firmware' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
         with:
           FILE_PATTERN: "firmware/scripts/uhk-firmware-*.tar.gz"
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          S3_ACCESS_KEY: ${{ secrets.UHK_BUILD_ARCHIVER_AWS_ACCESS_SECRET }}
-          S3_ACCESS_KEY_ID: ${{ secrets.UHK_BUILD_ARCHIVER_AWS_ACCESS_KEY }}
+          S3_ACCESS_KEY: ${{ secrets.UHK_BUILD_ARCHIVER_B2_ACCESS_SECRET }}
+          S3_ACCESS_KEY_ID: ${{ secrets.UHK_BUILD_ARCHIVER_B2_ACCESS_KEY }}
           S3_BUCKET: "uhk-build-archives"
+          S3_ENDPOINT: https://s3.us-east-005.backblazeb2.com
           S3_KEY_PREFIX: "firmware/"
-          S3_REGION: "eu-central-1"
+          S3_REGION: "us-east-005"
 
       - name: Check whether tag is a version
         id: version_check


### PR DESCRIPTION
## Summary
- Switch \`build-archiver\` to Backblaze B2 (\`@v0.0.9\`) with dedicated B2 secrets
- Fix archiver condition so push/tag runs are included (not only PRs)
- Keep AWS secrets unused for easy rollback

## Test plan
- [ ] Staging/master CI uploads under \`firmware/sha/<sha>/\` on B2
- [ ] \`firmware/index.json\` on B2 updates
- [ ] builds.uhk.io shows new Firmware builds


Made with [Cursor](https://cursor.com)